### PR TITLE
feat: add floating action bar for AI Rewrite text selection

### DIFF
--- a/web/src/components/floating-action-bar.tsx
+++ b/web/src/components/floating-action-bar.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { TextSelectionState } from "@/hooks/use-text-selection";
+
+interface FloatingActionBarProps {
+  /** Current text selection state from useTextSelection hook */
+  selection: TextSelectionState;
+  /** Callback when the AI Rewrite button is clicked */
+  onRewrite?: (selectedText: string) => void;
+}
+
+/**
+ * FloatingActionBar - Appears near text selection with an "AI Rewrite" button.
+ *
+ * Per PRD US-016:
+ * - Floating bar appears ~200ms after native menu (delay handled by useTextSelection)
+ * - Positioned on opposite side of selection from native iPadOS menu
+ *   (native menu appears above selection, this bar appears below)
+ * - Minimum touch target: 48x48pt for AI Rewrite button
+ * - Maximum selection: 2,000 words with warning message
+ * - Does NOT interfere with native copy/paste menu
+ * - Tracks selection bounds when user adjusts handles
+ */
+export function FloatingActionBar({ selection, onRewrite }: FloatingActionBarProps) {
+  if (!selection.hasSelection || !selection.floatingBarPosition) {
+    return null;
+  }
+
+  const { top, left } = selection.floatingBarPosition;
+
+  const handleRewriteClick = (e: React.MouseEvent | React.TouchEvent) => {
+    // Prevent the click from propagating to the editor and clearing selection
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (selection.exceedsLimit) return;
+    onRewrite?.(selection.selectedText);
+  };
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="AI text actions"
+      className="absolute z-50 flex items-center gap-2 bg-white border border-gray-200
+                 rounded-xl shadow-lg px-2 py-1 select-none
+                 transform -translate-x-1/2"
+      style={{
+        top: `${top}px`,
+        left: `${left}px`,
+      }}
+      // Prevent mousedown from stealing focus from the editor
+      onMouseDown={(e) => e.preventDefault()}
+      onTouchStart={(e) => e.stopPropagation()}
+    >
+      {selection.exceedsLimit ? (
+        <span className="text-sm text-amber-700 px-3 py-2 whitespace-nowrap" role="alert">
+          Select up to 2,000 words
+        </span>
+      ) : (
+        <button
+          onClick={handleRewriteClick}
+          className="flex items-center gap-2 px-4 py-2 min-w-[48px] min-h-[48px]
+                     text-sm font-medium text-white bg-blue-600 rounded-lg
+                     hover:bg-blue-700 active:bg-blue-800
+                     transition-colors whitespace-nowrap
+                     touch-manipulation"
+          aria-label="AI Rewrite selected text"
+        >
+          {/* Sparkle/AI icon */}
+          <svg
+            className="w-4 h-4 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.455 2.456L21.75 6l-1.036.259a3.375 3.375 0 00-2.455 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z"
+            />
+          </svg>
+          AI Rewrite
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default FloatingActionBar;

--- a/web/src/hooks/use-text-selection.ts
+++ b/web/src/hooks/use-text-selection.ts
@@ -1,0 +1,249 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import type { Editor } from "@tiptap/react";
+
+export interface FloatingBarPosition {
+  /** Top position relative to the container element */
+  top: number;
+  /** Left position relative to the container element (centered) */
+  left: number;
+}
+
+export interface TextSelectionState {
+  /** Whether text is currently selected within the editor */
+  hasSelection: boolean;
+  /** The selected plain text */
+  selectedText: string;
+  /** Word count of the selected text */
+  wordCount: number;
+  /** Whether the selection exceeds the maximum word limit */
+  exceedsLimit: boolean;
+  /** Computed position for the floating bar, relative to the container */
+  floatingBarPosition: FloatingBarPosition | null;
+}
+
+const MAX_WORDS = 2000;
+
+/**
+ * Counts words in a plain text string.
+ */
+function countWords(text: string): number {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return trimmed.split(/\s+/).length;
+}
+
+/**
+ * Gets the bounding rectangle of the current DOM selection,
+ * merging all client rects into a single envelope.
+ */
+function getSelectionBounds(
+  selection: Selection,
+): { top: number; bottom: number; left: number; right: number; centerX: number } | null {
+  if (selection.rangeCount === 0) return null;
+
+  const range = selection.getRangeAt(0);
+  const rects = range.getClientRects();
+
+  if (rects.length === 0) {
+    const rect = range.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) return null;
+    return {
+      top: rect.top,
+      bottom: rect.bottom,
+      left: rect.left,
+      right: rect.right,
+      centerX: rect.left + rect.width / 2,
+    };
+  }
+
+  let top = Infinity;
+  let bottom = -Infinity;
+  let left = Infinity;
+  let right = -Infinity;
+
+  for (let i = 0; i < rects.length; i++) {
+    const rect = rects[i];
+    if (rect.width === 0 && rect.height === 0) continue;
+    top = Math.min(top, rect.top);
+    bottom = Math.max(bottom, rect.bottom);
+    left = Math.min(left, rect.left);
+    right = Math.max(right, rect.right);
+  }
+
+  if (top === Infinity) return null;
+
+  return {
+    top,
+    bottom,
+    left,
+    right,
+    centerX: left + (right - left) / 2,
+  };
+}
+
+/**
+ * Computes the floating bar position relative to a container element.
+ * Positions below the selection (opposite side from native iPadOS menu).
+ */
+function computeFloatingBarPosition(
+  selectionBounds: { top: number; bottom: number; centerX: number },
+  container: HTMLElement,
+): FloatingBarPosition {
+  const containerRect = container.getBoundingClientRect();
+  const barHeight = 48;
+  const gap = 8;
+
+  // Position below the selection (opposite side from native iPadOS menu which appears above)
+  let top = selectionBounds.bottom + gap - containerRect.top + container.scrollTop;
+  const left = selectionBounds.centerX - containerRect.left;
+
+  // Clamp horizontal position to stay within the container
+  const barWidthEstimate = 160;
+  const halfBar = barWidthEstimate / 2;
+  const minLeft = halfBar + 8;
+  const maxLeft = containerRect.width - halfBar - 8;
+  const clampedLeft = Math.max(minLeft, Math.min(maxLeft, left));
+
+  // If the bar would go below the visible area, show it above the selection instead
+  const visibleBottom = container.scrollTop + containerRect.height;
+  if (top + barHeight > visibleBottom) {
+    top = selectionBounds.top - barHeight - gap - containerRect.top + container.scrollTop;
+  }
+
+  return { top, left: clampedLeft };
+}
+
+/**
+ * Hook that tracks text selection within a Tiptap editor.
+ *
+ * Returns the current selection state including selected text,
+ * word count, limit enforcement, and a pre-computed floating bar position.
+ *
+ * The selection state is updated with a configurable delay (default 200ms)
+ * after the native iPadOS text menu appears, to avoid interference.
+ *
+ * @param editor - The Tiptap editor instance
+ * @param containerRef - Ref to the container element used for position calculations
+ * @param delay - Delay in ms before updating state (default: 200)
+ */
+export function useTextSelection(
+  editor: Editor | null,
+  containerRef: React.RefObject<HTMLElement | null>,
+  delay = 200,
+): TextSelectionState {
+  const [state, setState] = useState<TextSelectionState>({
+    hasSelection: false,
+    selectedText: "",
+    wordCount: 0,
+    exceedsLimit: false,
+    floatingBarPosition: null,
+  });
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const updateSelection = useCallback(() => {
+    if (!editor) {
+      setState({
+        hasSelection: false,
+        selectedText: "",
+        wordCount: 0,
+        exceedsLimit: false,
+        floatingBarPosition: null,
+      });
+      return;
+    }
+
+    const { from, to, empty } = editor.state.selection;
+
+    if (empty || from === to) {
+      setState({
+        hasSelection: false,
+        selectedText: "",
+        wordCount: 0,
+        exceedsLimit: false,
+        floatingBarPosition: null,
+      });
+      return;
+    }
+
+    // Get the selected text from the editor document
+    const selectedText = editor.state.doc.textBetween(from, to, " ");
+    const words = countWords(selectedText);
+
+    // Get DOM selection bounds and compute floating bar position
+    const domSelection = window.getSelection();
+    const bounds = domSelection ? getSelectionBounds(domSelection) : null;
+    const container = containerRef.current;
+
+    let floatingBarPosition: FloatingBarPosition | null = null;
+    if (bounds && container) {
+      floatingBarPosition = computeFloatingBarPosition(bounds, container);
+    }
+
+    setState({
+      hasSelection: true,
+      selectedText,
+      wordCount: words,
+      exceedsLimit: words > MAX_WORDS,
+      floatingBarPosition,
+    });
+  }, [editor, containerRef]);
+
+  useEffect(() => {
+    if (!editor) return;
+
+    // Listen to Tiptap's selection update event
+    const handleSelectionUpdate = () => {
+      clearTimer();
+      timerRef.current = setTimeout(updateSelection, delay);
+    };
+
+    // Listen to Tiptap's blur event to clear selection state
+    const handleBlur = () => {
+      clearTimer();
+      // Small delay to allow for click-on-floating-bar to register
+      timerRef.current = setTimeout(() => {
+        setState({
+          hasSelection: false,
+          selectedText: "",
+          wordCount: 0,
+          exceedsLimit: false,
+          floatingBarPosition: null,
+        });
+      }, 150);
+    };
+
+    editor.on("selectionUpdate", handleSelectionUpdate);
+    editor.on("blur", handleBlur);
+
+    // Also listen to native selectionchange for handle-drag tracking
+    const handleNativeSelectionChange = () => {
+      if (!editor.isFocused) return;
+      const { empty } = editor.state.selection;
+      if (!empty) {
+        clearTimer();
+        timerRef.current = setTimeout(updateSelection, delay);
+      }
+    };
+
+    document.addEventListener("selectionchange", handleNativeSelectionChange);
+
+    return () => {
+      clearTimer();
+      editor.off("selectionUpdate", handleSelectionUpdate);
+      editor.off("blur", handleBlur);
+      document.removeEventListener("selectionchange", handleNativeSelectionChange);
+    };
+  }, [editor, delay, updateSelection, clearTimer]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- Add `useTextSelection` hook that tracks editor text selection with 200ms debounced delay, computes floating bar position relative to the editor container, and enforces 2,000-word selection limit
- Add `FloatingActionBar` component that renders below the selection (opposite side from native iPadOS menu) with a 48x48pt minimum touch target "AI Rewrite" button
- Integrate floating bar into `ChapterEditor` with new `onRewrite` callback prop, using `position: relative` container for correct absolute positioning

## Test Plan
- [ ] Select text in editor, verify floating bar appears ~200ms after selection
- [ ] Verify bar does not interfere with native copy/paste menu (positioned below selection, native menu appears above)
- [ ] Verify 48x48pt minimum touch target on AI Rewrite button
- [ ] Select >2,000 words, verify warning message "Select up to 2,000 words" appears instead of button
- [ ] Adjust selection handles, verify bar tracks selection bounds via selectionchange events
- [ ] Click AI Rewrite button, verify it does not steal focus from editor
- [ ] Blur editor, verify floating bar disappears after short delay

Closes #30

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>