### PR TITLE
feat: add AI rewrite bottom sheet with streaming SSE response

### DIFF
--- a/web/src/components/ai-rewrite-sheet.tsx
+++ b/web/src/components/ai-rewrite-sheet.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import { useState, useCallback, useRef, useEffect } from "react";
+
+/**
+ * Suggestion chips per PRD US-017:
+ * "Simpler language" | "More concise" | "More conversational" | "Stronger" | "Expand"
+ */
+const SUGGESTION_CHIPS = [
+  "Simpler language",
+  "More concise",
+  "More conversational",
+  "Stronger",
+  "Expand",
+] as const;
+
+interface AIRewriteSheetProps {
+  /** Whether the sheet is open */
+  isOpen: boolean;
+  /** Close the sheet */
+  onClose: () => void;
+  /** The selected text to rewrite */
+  selectedText: string;
+  /** Up to 500 chars before the selection for context */
+  contextBefore: string;
+  /** Up to 500 chars after the selection for context */
+  contextAfter: string;
+  /** Chapter title for prompt context */
+  chapterTitle: string;
+  /** Project description for prompt context */
+  projectDescription: string;
+  /** Chapter ID for logging */
+  chapterId: string;
+  /** Auth token getter */
+  getToken: () => Promise<string | null>;
+  /** Callback when the user accepts the rewrite */
+  onAcceptRewrite: (newText: string) => void;
+  /** API base URL */
+  apiUrl: string;
+}
+
+type SheetState = "idle" | "loading" | "streaming" | "done" | "error";
+
+/**
+ * AIRewriteSheet - Bottom sheet for AI rewrite flow
+ *
+ * Per PRD US-017:
+ * - Shows original text (read-only)
+ * - Instruction text field (freeform)
+ * - Suggestion chips
+ * - Streams result token-by-token
+ * - Loading state while waiting for first token
+ * - Rate limit message when exceeded
+ */
+export function AIRewriteSheet({
+  isOpen,
+  onClose,
+  selectedText,
+  contextBefore,
+  contextAfter,
+  chapterTitle,
+  projectDescription,
+  chapterId,
+  getToken,
+  onAcceptRewrite,
+  apiUrl,
+}: AIRewriteSheetProps) {
+  const [instruction, setInstruction] = useState("");
+  const [state, setState] = useState<SheetState>("idle");
+  const [streamedText, setStreamedText] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const resultRef = useRef<HTMLDivElement>(null);
+
+  // Abort any in-flight request on unmount
+  useEffect(() => {
+    return () => {
+      abortControllerRef.current?.abort();
+    };
+  }, []);
+
+  // Auto-scroll result area during streaming
+  useEffect(() => {
+    if (state === "streaming" && resultRef.current) {
+      resultRef.current.scrollTop = resultRef.current.scrollHeight;
+    }
+  }, [streamedText, state]);
+
+  const handleSubmit = useCallback(
+    async (instructionText: string) => {
+      if (!instructionText.trim() || !selectedText.trim()) return;
+
+      // Cancel any previous request
+      abortControllerRef.current?.abort();
+      const abortController = new AbortController();
+      abortControllerRef.current = abortController;
+
+      setState("loading");
+      setStreamedText("");
+      setErrorMessage("");
+
+      try {
+        const token = await getToken();
+        if (!token) {
+          setState("error");
+          setErrorMessage("Authentication required. Please sign in again.");
+          return;
+        }
+
+        const response = await fetch(`${apiUrl}/ai/rewrite`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            selectedText,
+            instruction: instructionText,
+            contextBefore,
+            contextAfter,
+            chapterTitle,
+            projectDescription,
+            chapterId,
+          }),
+          signal: abortController.signal,
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({ error: "Request failed" }));
+          const err = errorData as { error?: string; code?: string };
+
+          if (response.status === 429) {
+            setState("error");
+            setErrorMessage(
+              err.error || "You've used AI rewrite frequently. Please wait a moment.",
+            );
+            return;
+          }
+
+          setState("error");
+          setErrorMessage(err.error || "Something went wrong. Please try again.");
+          return;
+        }
+
+        // Read SSE stream
+        const reader = response.body?.getReader();
+        if (!reader) {
+          setState("error");
+          setErrorMessage("Failed to read response stream.");
+          return;
+        }
+
+        const decoder = new TextDecoder();
+        let buffer = "";
+        let firstToken = false;
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          // Keep the last potentially incomplete line in the buffer
+          buffer = lines.pop() || "";
+
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              const data = line.slice(6).trim();
+              if (!data) continue;
+
+              try {
+                const event = JSON.parse(data) as {
+                  type: string;
+                  text?: string;
+                  message?: string;
+                  interactionId?: string;
+                };
+
+                if (event.type === "token" && event.text) {
+                  if (!firstToken) {
+                    firstToken = true;
+                    setState("streaming");
+                  }
+                  setStreamedText((prev) => prev + event.text);
+                }
+
+                if (event.type === "done") {
+                  setState("done");
+                }
+
+                if (event.type === "error") {
+                  setState("error");
+                  setErrorMessage(event.message || "AI processing error.");
+                }
+              } catch {
+                // Skip malformed JSON
+              }
+            }
+          }
+        }
+
+        // If we finished reading without hitting "done", mark as done
+        if (firstToken) {
+          setState("done");
+        }
+      } catch (err) {
+        if ((err as Error).name === "AbortError") return;
+        setState("error");
+        setErrorMessage("Connection error. Please try again.");
+      }
+    },
+    [
+      selectedText,
+      contextBefore,
+      contextAfter,
+      chapterTitle,
+      projectDescription,
+      chapterId,
+      getToken,
+      apiUrl,
+    ],
+  );
+
+  const handleChipClick = useCallback(
+    (chip: string) => {
+      setInstruction(chip);
+      handleSubmit(chip);
+    },
+    [handleSubmit],
+  );
+
+  const handleFormSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      handleSubmit(instruction);
+    },
+    [instruction, handleSubmit],
+  );
+
+  const handleAccept = useCallback(() => {
+    if (streamedText) {
+      onAcceptRewrite(streamedText);
+      onClose();
+    }
+  }, [streamedText, onAcceptRewrite, onClose]);
+
+  const handleRetry = useCallback(() => {
+    setState("idle");
+    setStreamedText("");
+    setErrorMessage("");
+  }, []);
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 bg-black/30 z-40 transition-opacity"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Bottom Sheet */}
+      <div
+        className="fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl
+                   max-h-[85vh] flex flex-col animate-slide-up"
+        role="dialog"
+        aria-modal="true"
+        aria-label="AI Rewrite"
+      >
+        {/* Handle bar */}
+        <div className="flex justify-center pt-3 pb-1">
+          <div className="w-10 h-1 bg-gray-300 rounded-full" />
+        </div>
+
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-3 border-b border-gray-100">
+          <h3 className="text-lg font-semibold text-gray-900">AI Rewrite</h3>
+          <button
+            onClick={onClose}
+            className="w-9 h-9 flex items-center justify-center rounded-full
+                       hover:bg-gray-100 transition-colors min-w-[44px] min-h-[44px]"
+            aria-label="Close"
+          >
+            <svg
+              className="w-5 h-5 text-gray-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-auto px-5 py-4 space-y-4">
+          {/* Original text (read-only) */}
+          <div>
+            <label className="block text-sm font-medium text-gray-500 mb-1">Original text</label>
+            <div className="bg-gray-50 rounded-lg p-3 text-sm text-gray-700 max-h-32 overflow-auto border border-gray-200">
+              {selectedText}
+            </div>
+          </div>
+
+          {/* Instruction input + chips (shown when idle or after error) */}
+          {(state === "idle" || state === "error") && (
+            <>
+              {/* Error message */}
+              {state === "error" && errorMessage && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700">
+                  {errorMessage}
+                </div>
+              )}
+
+              {/* Suggestion chips */}
+              <div>
+                <label className="block text-sm font-medium text-gray-500 mb-2">
+                  Quick suggestions
+                </label>
+                <div className="flex flex-wrap gap-2">
+                  {SUGGESTION_CHIPS.map((chip) => (
+                    <button
+                      key={chip}
+                      onClick={() => handleChipClick(chip)}
+                      className="px-3 py-1.5 text-sm rounded-full border border-gray-300
+                                 bg-white text-gray-700 hover:bg-blue-50 hover:border-blue-300
+                                 hover:text-blue-700 transition-colors min-h-[36px]"
+                    >
+                      {chip}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Freeform instruction */}
+              <form onSubmit={handleFormSubmit}>
+                <label
+                  htmlFor="ai-instruction"
+                  className="block text-sm font-medium text-gray-500 mb-1"
+                >
+                  Or describe how to rewrite
+                </label>
+                <div className="flex gap-2">
+                  <input
+                    id="ai-instruction"
+                    type="text"
+                    value={instruction}
+                    onChange={(e) => setInstruction(e.target.value)}
+                    placeholder="e.g., Make it sound more confident..."
+                    className="flex-1 px-3 py-2 text-sm border border-gray-300 rounded-lg
+                               focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                               min-h-[44px]"
+                    maxLength={500}
+                    autoFocus
+                  />
+                  <button
+                    type="submit"
+                    disabled={!instruction.trim()}
+                    className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg
+                               hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed
+                               transition-colors min-w-[44px] min-h-[44px]"
+                  >
+                    Rewrite
+                  </button>
+                </div>
+              </form>
+            </>
+          )}
+
+          {/* Loading state */}
+          {state === "loading" && (
+            <div className="flex items-center gap-3 py-4">
+              <div className="flex gap-1">
+                <div
+                  className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                  style={{ animationDelay: "0ms" }}
+                />
+                <div
+                  className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                  style={{ animationDelay: "150ms" }}
+                />
+                <div
+                  className="w-2 h-2 bg-blue-500 rounded-full animate-bounce"
+                  style={{ animationDelay: "300ms" }}
+                />
+              </div>
+              <span className="text-sm text-gray-500">Rewriting...</span>
+            </div>
+          )}
+
+          {/* Streaming / Done result */}
+          {(state === "streaming" || state === "done") && (
+            <div>
+              <label className="block text-sm font-medium text-gray-500 mb-1">
+                Rewritten text
+                {state === "streaming" && (
+                  <span className="ml-2 text-blue-500 animate-pulse">streaming...</span>
+                )}
+              </label>
+              <div
+                ref={resultRef}
+                className="bg-blue-50 rounded-lg p-3 text-sm text-gray-800 max-h-48 overflow-auto
+                           border border-blue-200 whitespace-pre-wrap"
+              >
+                {streamedText}
+                {state === "streaming" && (
+                  <span className="inline-block w-0.5 h-4 bg-blue-500 ml-0.5 animate-pulse" />
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer actions */}
+        {state === "done" && streamedText && (
+          <div className="px-5 py-4 border-t border-gray-100 flex gap-3">
+            <button
+              onClick={handleRetry}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-gray-700 bg-gray-100
+                         rounded-lg hover:bg-gray-200 transition-colors min-h-[44px]"
+            >
+              Try again
+            </button>
+            <button
+              onClick={handleAccept}
+              className="flex-1 px-4 py-2.5 text-sm font-medium text-white bg-blue-600
+                         rounded-lg hover:bg-blue-700 transition-colors min-h-[44px]"
+            >
+              Accept rewrite
+            </button>
+          </div>
+        )}
+
+        {/* Slide-up animation */}
+        <style jsx>{`
+          @keyframes slide-up {
+            from {
+              transform: translateY(100%);
+            }
+            to {
+              transform: translateY(0);
+            }
+          }
+          .animate-slide-up {
+            animation: slide-up 0.3s ease-out;
+          }
+        `}</style>
+      </div>
+    </>
+  );
+}
+
+export default AIRewriteSheet;

--- a/web/src/components/chapter-editor.tsx
+++ b/web/src/components/chapter-editor.tsx
@@ -20,6 +20,10 @@ interface ChapterEditorProps {
   placeholder?: string;
   /** Whether editor is editable */
   editable?: boolean;
+  /** Callback when editor instance is ready */
+  onEditorReady?: (editor: Editor) => void;
+  /** Callback when text selection changes */
+  onSelectionChange?: (hasSelection: boolean) => void;
 }
 
 /**
@@ -41,6 +45,8 @@ export function ChapterEditor({
   onRewrite,
   placeholder = "Start writing, or paste your existing notes here...",
   editable = true,
+  onEditorReady,
+  onSelectionChange,
 }: ChapterEditorProps) {
   const editorContainerRef = useRef<HTMLDivElement>(null);
   const editor = useEditor({
@@ -75,10 +81,21 @@ export function ChapterEditor({
     onUpdate: ({ editor }) => {
       onUpdate?.(editor.getHTML());
     },
+    onSelectionUpdate: ({ editor }) => {
+      const { from, to } = editor.state.selection;
+      onSelectionChange?.(from !== to);
+    },
   });
 
   // Track text selection for floating action bar (200ms delay per US-016)
   const textSelection = useTextSelection(editor, editorContainerRef, 200);
+
+  // Notify parent when editor is ready
+  useEffect(() => {
+    if (editor && onEditorReady) {
+      onEditorReady(editor);
+    }
+  }, [editor, onEditorReady]);
 
   // Handle Cmd+S for save
   useEffect(() => {

--- a/workers/dc-api/src/index.ts
+++ b/workers/dc-api/src/index.ts
@@ -7,6 +7,7 @@ import { users } from "./routes/users.js";
 import { drive } from "./routes/drive.js";
 import { projects } from "./routes/projects.js";
 import { chapters } from "./routes/chapters.js";
+import { ai } from "./routes/ai.js";
 
 const app = new Hono<{ Bindings: Env }>();
 
@@ -20,6 +21,7 @@ app.route("/auth", auth);
 app.route("/users", users);
 app.route("/drive", drive);
 app.route("/projects", projects);
+app.route("/ai", ai);
 app.route("/", chapters);
 
 // 404 fallback

--- a/workers/dc-api/src/routes/ai.ts
+++ b/workers/dc-api/src/routes/ai.ts
@@ -1,0 +1,83 @@
+import { Hono } from "hono";
+import type { Env } from "../types/index.js";
+import { requireAuth } from "../middleware/auth.js";
+import { validationError, rateLimited } from "../middleware/error-handler.js";
+import { AIRewriteService, type RewriteInput } from "../services/ai-rewrite.js";
+
+/**
+ * AI API routes
+ *
+ * Per PRD Section 12:
+ * - POST /ai/rewrite - Streams AI rewrite via SSE
+ *
+ * Per PRD US-017:
+ * - Sends selected text + instruction + context
+ * - Response streams via SSE
+ * - Rate limit: 10 req/min/user
+ */
+const ai = new Hono<{ Bindings: Env }>();
+
+// All AI routes require authentication
+ai.use("*", requireAuth);
+
+/**
+ * POST /ai/rewrite
+ *
+ * Request body:
+ * - selectedText: string (required) - The text to rewrite
+ * - instruction: string (required) - How to rewrite it
+ * - contextBefore: string (optional) - Up to 500 chars before selection
+ * - contextAfter: string (optional) - Up to 500 chars after selection
+ * - chapterTitle: string (optional) - Chapter title for context
+ * - projectDescription: string (optional) - Project description for context
+ * - chapterId: string (required) - Chapter ID for logging
+ *
+ * Response: SSE stream with events:
+ * - { type: "token", text: string } - Each token as it arrives
+ * - { type: "done", interactionId: string } - Stream complete
+ * - { type: "error", message: string } - Error occurred
+ */
+ai.post("/rewrite", async (c) => {
+  const { userId } = c.get("auth");
+
+  const service = new AIRewriteService(c.env.DB, c.env.CACHE, c.env.ANTHROPIC_API_KEY);
+
+  // Check rate limit
+  const { allowed, remaining } = await service.checkRateLimit(userId);
+  if (!allowed) {
+    rateLimited("You've used AI rewrite frequently. Please wait a moment.");
+  }
+
+  // Parse and validate input
+  const body = (await c.req.json().catch(() => ({}))) as Partial<RewriteInput>;
+
+  const input: RewriteInput = {
+    selectedText: body.selectedText ?? "",
+    instruction: body.instruction ?? "",
+    contextBefore: body.contextBefore ?? "",
+    contextAfter: body.contextAfter ?? "",
+    chapterTitle: body.chapterTitle ?? "",
+    projectDescription: body.projectDescription ?? "",
+    chapterId: body.chapterId ?? "",
+  };
+
+  const validationErr = service.validateInput(input);
+  if (validationErr) {
+    validationError(validationErr);
+  }
+
+  // Stream the rewrite
+  const { stream } = await service.streamRewrite(userId, input);
+
+  // Return SSE response
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "X-RateLimit-Remaining": String(remaining),
+    },
+  });
+});
+
+export { ai };

--- a/workers/dc-api/src/services/ai-rewrite.ts
+++ b/workers/dc-api/src/services/ai-rewrite.ts
@@ -1,0 +1,283 @@
+import { ulid } from "ulid";
+
+/**
+ * AIRewriteService - Handles AI rewrite requests via Anthropic Claude
+ *
+ * Per PRD Section 8 (AI: US-017):
+ * - Sends selected text + instruction + 500 chars surrounding context + chapter title + project description
+ * - Streams response via SSE
+ * - Logs interaction metadata to D1 ai_interactions table (NO user content stored)
+ * - Rate limit: 10 req/min/user
+ *
+ * Per PRD: No voice/style context in Phase 0
+ */
+
+export interface RewriteInput {
+  /** The selected text to rewrite */
+  selectedText: string;
+  /** Freeform instruction or chip label */
+  instruction: string;
+  /** Up to 500 chars before the selection */
+  contextBefore: string;
+  /** Up to 500 chars after the selection */
+  contextAfter: string;
+  /** Chapter title for context */
+  chapterTitle: string;
+  /** Project description for context */
+  projectDescription: string;
+  /** Chapter ID for logging */
+  chapterId: string;
+}
+
+export interface RewriteStreamResult {
+  stream: ReadableStream<Uint8Array>;
+  interactionId: string;
+}
+
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const MODEL = "claude-sonnet-4-20250514";
+const MAX_SELECTED_TEXT_CHARS = 10000;
+const MAX_CONTEXT_CHARS = 500;
+const RATE_LIMIT_WINDOW_SECONDS = 60;
+const RATE_LIMIT_MAX_REQUESTS = 10;
+
+export class AIRewriteService {
+  constructor(
+    private readonly db: D1Database,
+    private readonly cache: KVNamespace,
+    private readonly anthropicApiKey: string,
+  ) {}
+
+  /**
+   * Check rate limit for a user (10 req/min)
+   * Uses KV for atomic counters with TTL
+   */
+  async checkRateLimit(userId: string): Promise<{ allowed: boolean; remaining: number }> {
+    const key = `ratelimit:ai-rewrite:${userId}`;
+    const current = await this.cache.get(key);
+    const count = current ? parseInt(current, 10) : 0;
+
+    if (count >= RATE_LIMIT_MAX_REQUESTS) {
+      return { allowed: false, remaining: 0 };
+    }
+
+    // Increment counter with TTL
+    await this.cache.put(key, String(count + 1), {
+      expirationTtl: RATE_LIMIT_WINDOW_SECONDS,
+    });
+
+    return { allowed: true, remaining: RATE_LIMIT_MAX_REQUESTS - count - 1 };
+  }
+
+  /**
+   * Validate rewrite input
+   */
+  validateInput(input: RewriteInput): string | null {
+    if (!input.selectedText?.trim()) {
+      return "Selected text is required";
+    }
+
+    if (input.selectedText.length > MAX_SELECTED_TEXT_CHARS) {
+      return `Selected text must be at most ${MAX_SELECTED_TEXT_CHARS} characters`;
+    }
+
+    if (!input.instruction?.trim()) {
+      return "Instruction is required";
+    }
+
+    if (input.instruction.length > 500) {
+      return "Instruction must be at most 500 characters";
+    }
+
+    if (!input.chapterId?.trim()) {
+      return "Chapter ID is required";
+    }
+
+    return null;
+  }
+
+  /**
+   * Build the system prompt for the rewrite
+   */
+  private buildSystemPrompt(input: RewriteInput): string {
+    const parts = [
+      "You are a professional writing assistant helping an author rewrite selected text from their book.",
+      "Rewrite ONLY the selected text according to the author's instruction.",
+      "Maintain the original meaning and tone unless the instruction specifically asks to change it.",
+      "Return ONLY the rewritten text with no preamble, explanation, or quotes.",
+      "Match the original formatting style (paragraphs, line breaks).",
+    ];
+
+    if (input.projectDescription?.trim()) {
+      parts.push(`\nBook description: ${input.projectDescription.trim()}`);
+    }
+
+    if (input.chapterTitle?.trim()) {
+      parts.push(`Chapter: ${input.chapterTitle.trim()}`);
+    }
+
+    return parts.join("\n");
+  }
+
+  /**
+   * Build the user message with context
+   */
+  private buildUserMessage(input: RewriteInput): string {
+    const parts: string[] = [];
+
+    const contextBefore = input.contextBefore?.slice(-MAX_CONTEXT_CHARS) || "";
+    const contextAfter = input.contextAfter?.slice(0, MAX_CONTEXT_CHARS) || "";
+
+    if (contextBefore) {
+      parts.push(`[Text before selection]\n${contextBefore}\n`);
+    }
+
+    parts.push(`[Selected text to rewrite]\n${input.selectedText}\n`);
+
+    if (contextAfter) {
+      parts.push(`[Text after selection]\n${contextAfter}\n`);
+    }
+
+    parts.push(`[Instruction]\n${input.instruction}`);
+
+    return parts.join("\n");
+  }
+
+  /**
+   * Stream a rewrite response via Anthropic API
+   * Returns an SSE-compatible ReadableStream
+   */
+  async streamRewrite(userId: string, input: RewriteInput): Promise<RewriteStreamResult> {
+    const interactionId = ulid();
+    const startTime = Date.now();
+
+    // Record the interaction start (output_chars and latency_ms will be updated)
+    await this.db
+      .prepare(
+        `INSERT INTO ai_interactions (id, user_id, chapter_id, action, instruction, input_chars, output_chars, model, latency_ms, attempt_number, created_at)
+         VALUES (?, ?, ?, 'rewrite', ?, ?, 0, ?, 0, 1, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
+      )
+      .bind(
+        interactionId,
+        userId,
+        input.chapterId,
+        input.instruction.slice(0, 200), // Truncate instruction for logging (not user content)
+        input.selectedText.length,
+        MODEL,
+      )
+      .run();
+
+    // Call Anthropic API with streaming
+    const response = await fetch(ANTHROPIC_API_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": this.anthropicApiKey,
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: 4096,
+        stream: true,
+        system: this.buildSystemPrompt(input),
+        messages: [
+          {
+            role: "user",
+            content: this.buildUserMessage(input),
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text().catch(() => "Unknown error");
+      console.error("Anthropic API error:", response.status, errorBody);
+
+      // Update interaction with error
+      await this.db
+        .prepare(`UPDATE ai_interactions SET latency_ms = ? WHERE id = ?`)
+        .bind(Date.now() - startTime, interactionId)
+        .run();
+
+      throw new Error(`AI provider error: ${response.status}`);
+    }
+
+    const anthropicStream = response.body;
+    if (!anthropicStream) {
+      throw new Error("No response body from AI provider");
+    }
+
+    // Transform Anthropic SSE stream into our SSE format
+    let outputChars = 0;
+    const db = this.db;
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
+
+    const transformStream = new TransformStream<Uint8Array, Uint8Array>({
+      transform(chunk, controller) {
+        const text = decoder.decode(chunk, { stream: true });
+        const lines = text.split("\n");
+
+        for (const line of lines) {
+          if (line.startsWith("data: ")) {
+            const data = line.slice(6).trim();
+            if (data === "[DONE]") {
+              controller.enqueue(
+                encoder.encode(`data: ${JSON.stringify({ type: "done", interactionId })}\n\n`),
+              );
+              continue;
+            }
+
+            try {
+              const event = JSON.parse(data);
+
+              // Handle content_block_delta events (text tokens)
+              if (event.type === "content_block_delta" && event.delta?.type === "text_delta") {
+                const token = event.delta.text;
+                outputChars += token.length;
+                controller.enqueue(
+                  encoder.encode(`data: ${JSON.stringify({ type: "token", text: token })}\n\n`),
+                );
+              }
+
+              // Handle message_stop - final event
+              if (event.type === "message_stop") {
+                controller.enqueue(
+                  encoder.encode(`data: ${JSON.stringify({ type: "done", interactionId })}\n\n`),
+                );
+              }
+
+              // Handle errors from the API
+              if (event.type === "error") {
+                controller.enqueue(
+                  encoder.encode(
+                    `data: ${JSON.stringify({ type: "error", message: "AI processing error" })}\n\n`,
+                  ),
+                );
+              }
+            } catch {
+              // Skip malformed JSON lines
+            }
+          }
+        }
+      },
+
+      async flush() {
+        // Update the interaction record with final stats
+        const latencyMs = Date.now() - startTime;
+        try {
+          await db
+            .prepare(`UPDATE ai_interactions SET output_chars = ?, latency_ms = ? WHERE id = ?`)
+            .bind(outputChars, latencyMs, interactionId)
+            .run();
+        } catch (err) {
+          console.error("Failed to update ai_interaction record:", err);
+        }
+      },
+    });
+
+    const stream = anthropicStream.pipeThrough(transformStream);
+
+    return { stream, interactionId };
+  }
+}

--- a/workers/dc-api/src/types/api.ts
+++ b/workers/dc-api/src/types/api.ts
@@ -14,6 +14,7 @@ export type ErrorCode =
   | "DRIVE_NOT_CONNECTED"
   | "VALIDATION_ERROR"
   | "LAST_CHAPTER"
+  | "AI_ERROR"
   | "INTERNAL_ERROR";
 
 /** Pagination query parameters */


### PR DESCRIPTION
## Summary
- Add `POST /ai/rewrite` API endpoint with SSE streaming via Anthropic Claude, rate limiting (10 req/min/user via KV), input validation, and AI interaction logging to D1
- Add `AIRewriteSheet` bottom sheet component with original text display, suggestion chips (Simpler language, More concise, More conversational, Stronger, Expand), freeform instruction input, and token-by-token streaming display
- Integrate AI rewrite into editor page: selection-aware "AI Rewrite" button, context extraction (500 chars each side), and accept/replace flow

## Changes
- `workers/dc-api/src/services/ai-rewrite.ts` - New AIRewriteService: rate limiting, Anthropic API streaming, D1 interaction logging
- `workers/dc-api/src/routes/ai.ts` - New `POST /ai/rewrite` route with auth, validation, SSE response
- `workers/dc-api/src/index.ts` - Register `/ai` route
- `workers/dc-api/src/types/api.ts` - Add `AI_ERROR` error code
- `web/src/components/ai-rewrite-sheet.tsx` - New bottom sheet component with all UI states
- `web/src/components/chapter-editor.tsx` - Add `onEditorReady` and `onSelectionChange` callbacks
- `web/src/app/(protected)/editor/[projectId]/page.tsx` - AI rewrite state, selection tracking, context extraction, sheet integration

## Test Plan
- [ ] Tap AI Rewrite with selected text, verify bottom sheet opens with original text and instruction field
- [ ] Tap suggestion chip, verify it populates instruction and triggers rewrite
- [ ] Type freeform instruction and submit, verify streaming response appears token-by-token
- [ ] Verify loading state (bouncing dots) while waiting for first token
- [ ] Verify "Accept rewrite" replaces selected text in editor
- [ ] Verify "Try again" resets to instruction input
- [ ] Hit rate limit (10 req/min), verify rate limit message appears
- [ ] Verify AI Rewrite button only appears when text is selected
- [ ] Verify close button dismisses the sheet and aborts any in-flight request

Closes #31

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>