### PR TITLE
feat: add accept, reject, and retry actions for AI rewrite

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -24,3 +24,44 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* AI Rewrite Bottom Sheet - slide up animation */
+@keyframes slide-up {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.animate-slide-up {
+  animation: slide-up 0.3s ease-out;
+}
+
+/* AI Rewrite - highlight flash on accepted text replacement */
+@keyframes highlight-flash {
+  0% {
+    background-color: rgba(59, 130, 246, 0.3);
+  }
+  100% {
+    background-color: transparent;
+  }
+}
+
+.ai-rewrite-highlight {
+  animation: highlight-flash 1.5s ease-out;
+}
+
+/* Respect prefers-reduced-motion */
+@media (prefers-reduced-motion: reduce) {
+  .animate-slide-up {
+    animation: none;
+  }
+
+  .ai-rewrite-highlight {
+    animation: none;
+  }
+}

--- a/web/src/hooks/use-ai-rewrite.ts
+++ b/web/src/hooks/use-ai-rewrite.ts
@@ -1,0 +1,135 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import type { AIRewriteResult } from "@/components/ai-rewrite-sheet";
+
+interface UseAIRewriteOptions {
+  /** Function to get the auth token */
+  getToken: () => Promise<string | null>;
+  /** API base URL */
+  apiUrl: string;
+}
+
+interface UseAIRewriteReturn {
+  /** Whether the bottom sheet is open */
+  isSheetOpen: boolean;
+  /** The current AI rewrite result being reviewed */
+  currentResult: AIRewriteResult | null;
+  /** Whether a retry request is in progress */
+  isRetrying: boolean;
+  /** Open the sheet with a new AI rewrite result */
+  showResult: (result: AIRewriteResult) => void;
+  /** Handle "Use This" action — logs acceptance, returns the result */
+  handleAccept: (result: AIRewriteResult) => Promise<AIRewriteResult>;
+  /** Handle "Try Again" action — logs rejection, triggers new request */
+  handleRetry: (
+    result: AIRewriteResult,
+    instruction: string,
+  ) => Promise<void>;
+  /** Handle "Discard" action — logs rejection, closes sheet */
+  handleDiscard: (result: AIRewriteResult) => Promise<void>;
+  /** Close the sheet without logging (for internal use) */
+  closeSheet: () => void;
+}
+
+/**
+ * useAIRewrite - Hook for managing AI rewrite accept/reject/retry flow
+ *
+ * Per PRD US-018:
+ * - Each acceptance/rejection logged via API
+ * - Unlimited iterations (try again)
+ * - No silent rewrites — user must explicitly tap "Use This"
+ */
+export function useAIRewrite({ getToken, apiUrl }: UseAIRewriteOptions): UseAIRewriteReturn {
+  const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [currentResult, setCurrentResult] = useState<AIRewriteResult | null>(null);
+  const [isRetrying, setIsRetrying] = useState(false);
+
+  const showResult = useCallback((result: AIRewriteResult) => {
+    setCurrentResult(result);
+    setIsSheetOpen(true);
+  }, []);
+
+  const closeSheet = useCallback(() => {
+    setIsSheetOpen(false);
+    setCurrentResult(null);
+    setIsRetrying(false);
+  }, []);
+
+  /**
+   * Log interaction acceptance/rejection to the API.
+   * Fire-and-forget: we don't block the UI on logging success.
+   */
+  const logInteraction = useCallback(
+    async (interactionId: string, action: "accept" | "reject") => {
+      try {
+        const token = await getToken();
+        if (!token) return;
+
+        await fetch(`${apiUrl}/ai/interactions/${interactionId}/${action}`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+            "Content-Type": "application/json",
+          },
+        });
+      } catch (err) {
+        // Log but don't block the user flow on logging failures
+        console.error(`Failed to log AI interaction ${action}:`, err);
+      }
+    },
+    [getToken, apiUrl],
+  );
+
+  const handleAccept = useCallback(
+    async (result: AIRewriteResult): Promise<AIRewriteResult> => {
+      // Log acceptance (fire-and-forget)
+      logInteraction(result.interactionId, "accept");
+
+      // Close the sheet
+      setIsSheetOpen(false);
+      setCurrentResult(null);
+
+      return result;
+    },
+    [logInteraction],
+  );
+
+  const handleRetry = useCallback(
+    async (result: AIRewriteResult, ...[]: [instruction: string]) => {
+      setIsRetrying(true);
+
+      // Log rejection for the current attempt
+      logInteraction(result.interactionId, "reject");
+
+      // The actual retry request is handled by the parent component
+      // (US-017 rewrite flow). The parent should call showResult() with the
+      // new result when the AI responds, which will reset isRetrying.
+      // The instruction parameter is passed through to the parent's onRetry
+      // callback so it can send the updated instruction to the AI.
+    },
+    [logInteraction],
+  );
+
+  const handleDiscard = useCallback(
+    async (result: AIRewriteResult) => {
+      // Log rejection
+      logInteraction(result.interactionId, "reject");
+
+      // Close the sheet
+      closeSheet();
+    },
+    [logInteraction, closeSheet],
+  );
+
+  return {
+    isSheetOpen,
+    currentResult,
+    isRetrying,
+    showResult,
+    handleAccept,
+    handleRetry,
+    handleDiscard,
+    closeSheet,
+  };
+}

--- a/workers/dc-api/src/services/ai-interaction.ts
+++ b/workers/dc-api/src/services/ai-interaction.ts
@@ -1,0 +1,119 @@
+import { notFound } from "../middleware/error-handler.js";
+
+/**
+ * AIInteractionService - Business logic for AI interaction logging
+ *
+ * Per PRD Section 8 (US-018):
+ * - Logs acceptance/rejection of AI rewrite results
+ * - Stores metadata only (no content): accepted, attempt_number
+ * - Each acceptance/rejection: POST /ai/interactions/:id/accept or /reject
+ */
+
+export interface AIInteraction {
+  id: string;
+  userId: string;
+  chapterId: string;
+  action: string;
+  instruction: string;
+  inputChars: number;
+  outputChars: number;
+  model: string;
+  latencyMs: number;
+  accepted: boolean | null;
+  attemptNumber: number;
+  createdAt: string;
+}
+
+interface AIInteractionRow {
+  id: string;
+  user_id: string;
+  chapter_id: string;
+  action: string;
+  instruction: string;
+  input_chars: number;
+  output_chars: number;
+  model: string;
+  latency_ms: number;
+  accepted: number | null;
+  attempt_number: number;
+  created_at: string;
+}
+
+export class AIInteractionService {
+  constructor(private readonly db: D1Database) {}
+
+  /**
+   * Record acceptance of an AI rewrite result.
+   * Sets accepted = 1 on the interaction row.
+   */
+  async acceptInteraction(userId: string, interactionId: string): Promise<AIInteraction> {
+    // Verify ownership
+    const interaction = await this.db
+      .prepare(
+        `SELECT id, user_id, chapter_id, action, instruction, input_chars, output_chars,
+                model, latency_ms, accepted, attempt_number, created_at
+         FROM ai_interactions
+         WHERE id = ? AND user_id = ?`,
+      )
+      .bind(interactionId, userId)
+      .first<AIInteractionRow>();
+
+    if (!interaction) {
+      notFound("AI interaction not found");
+    }
+
+    // Update accepted status
+    await this.db
+      .prepare(`UPDATE ai_interactions SET accepted = 1 WHERE id = ? AND user_id = ?`)
+      .bind(interactionId, userId)
+      .run();
+
+    return this.mapRow({ ...interaction, accepted: 1 });
+  }
+
+  /**
+   * Record rejection of an AI rewrite result.
+   * Sets accepted = 0 on the interaction row.
+   */
+  async rejectInteraction(userId: string, interactionId: string): Promise<AIInteraction> {
+    // Verify ownership
+    const interaction = await this.db
+      .prepare(
+        `SELECT id, user_id, chapter_id, action, instruction, input_chars, output_chars,
+                model, latency_ms, accepted, attempt_number, created_at
+         FROM ai_interactions
+         WHERE id = ? AND user_id = ?`,
+      )
+      .bind(interactionId, userId)
+      .first<AIInteractionRow>();
+
+    if (!interaction) {
+      notFound("AI interaction not found");
+    }
+
+    // Update accepted status
+    await this.db
+      .prepare(`UPDATE ai_interactions SET accepted = 0 WHERE id = ? AND user_id = ?`)
+      .bind(interactionId, userId)
+      .run();
+
+    return this.mapRow({ ...interaction, accepted: 0 });
+  }
+
+  private mapRow(row: AIInteractionRow): AIInteraction {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      chapterId: row.chapter_id,
+      action: row.action,
+      instruction: row.instruction,
+      inputChars: row.input_chars,
+      outputChars: row.output_chars,
+      model: row.model,
+      latencyMs: row.latency_ms,
+      accepted: row.accepted === null ? null : row.accepted === 1,
+      attemptNumber: row.attempt_number,
+      createdAt: row.created_at,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Implements the accept/reject/retry flow for AI rewrite results per US-018:

- Add `AIRewriteSheet` bottom sheet component with "Use This", "Try Again", and "Discard" actions
- "Use This" replaces selected text via Tiptap transactions (Cmd+Z undoable) with highlight flash animation
- "Try Again" preserves original text with editable instruction field for unlimited iterations
- "Discard" and backdrop click close the sheet with no changes applied
- Add `useAIRewrite` hook for managing sheet state and fire-and-forget interaction logging
- Add API routes `POST /ai/interactions/:id/accept` and `POST /ai/interactions/:id/reject` for logging metadata
- Focus trap within bottom sheet for accessibility; animations respect `prefers-reduced-motion`

## Changes
- `web/src/components/ai-rewrite-sheet.tsx` — New bottom sheet component with three actions, focus trap, original/rewrite display
- `web/src/hooks/use-ai-rewrite.ts` — New hook for accept/reject/retry state management and API interaction logging
- `web/src/components/chapter-editor.tsx` — Converted to forwardRef, exposed `ChapterEditorHandle` with `replaceText` method for undoable text replacement
- `web/src/app/(protected)/editor/[projectId]/page.tsx` — Integrated AIRewriteSheet and editor ref
- `web/src/app/globals.css` — Added slide-up animation and highlight flash with prefers-reduced-motion support
- `workers/dc-api/src/routes/ai.ts` — New route file for AI interaction accept/reject endpoints
- `workers/dc-api/src/services/ai-interaction.ts` — New service for AI interaction acceptance/rejection logging
- `workers/dc-api/src/index.ts` — Registered AI routes

## Test Plan
- [ ] Complete AI rewrite, verify three action buttons appear ("Use This", "Try Again", "Discard")
- [ ] Tap "Use This", verify text replaced with highlight flash animation
- [ ] Undo with Cmd+Z, verify original text restored
- [ ] Tap "Try Again", verify instruction field editable and new request sent
- [ ] Tap "Discard" or outside sheet, verify no changes applied
- [ ] Verify focus trap within bottom sheet for accessibility (Tab/Shift+Tab cycles, Escape closes)
- [ ] Verify highlight flash animation is suppressed with prefers-reduced-motion
- [ ] Verify API logs acceptance via POST /ai/interactions/:id/accept
- [ ] Verify API logs rejection via POST /ai/interactions/:id/reject

Closes #32

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>