### PR TITLE
fix: AI rewrite attempt tracking, 429 handling, dead code cleanup

### DIFF
--- a/web/src/hooks/use-ai-rewrite.ts
+++ b/web/src/hooks/use-ai-rewrite.ts
@@ -93,17 +93,9 @@ export function useAIRewrite({ getToken, apiUrl }: UseAIRewriteOptions): UseAIRe
   );
 
   const handleRetry = useCallback(
-    async (result: AIRewriteResult, ...[]: [instruction: string]) => {
+    async (result: AIRewriteResult, _instruction: string) => {
       setIsRetrying(true);
-
-      // Log rejection for the current attempt
       logInteraction(result.interactionId, "reject");
-
-      // The actual retry request is handled by the parent component
-      // (US-017 rewrite flow). The parent should call showResult() with the
-      // new result when the AI responds, which will reset isRetrying.
-      // The instruction parameter is passed through to the parent's onRetry
-      // callback so it can send the updated instruction to the AI.
     },
     [logInteraction],
   );

--- a/workers/dc-api/migrations/0007_add_parent_interaction_id.sql
+++ b/workers/dc-api/migrations/0007_add_parent_interaction_id.sql
@@ -1,0 +1,5 @@
+-- Link retry attempts to their original interaction for proper attempt tracking.
+-- parent_interaction_id references the first interaction in a retry chain.
+ALTER TABLE ai_interactions ADD COLUMN parent_interaction_id TEXT REFERENCES ai_interactions(id);
+
+CREATE INDEX idx_ai_interactions_parent ON ai_interactions(parent_interaction_id);

--- a/workers/dc-api/src/routes/ai.ts
+++ b/workers/dc-api/src/routes/ai.ts
@@ -66,6 +66,7 @@ ai.post("/rewrite", async (c) => {
     chapterTitle: body.chapterTitle ?? "",
     projectDescription: body.projectDescription ?? "",
     chapterId: body.chapterId ?? "",
+    parentInteractionId: body.parentInteractionId,
   };
 
   const validationErr = service.validateInput(input);

--- a/workers/dc-api/src/services/ai-interaction.ts
+++ b/workers/dc-api/src/services/ai-interaction.ts
@@ -21,6 +21,7 @@ export interface AIInteraction {
   latencyMs: number;
   accepted: boolean | null;
   attemptNumber: number;
+  parentInteractionId: string | null;
   createdAt: string;
 }
 
@@ -36,6 +37,7 @@ interface AIInteractionRow {
   latency_ms: number;
   accepted: number | null;
   attempt_number: number;
+  parent_interaction_id: string | null;
   created_at: string;
 }
 
@@ -51,7 +53,7 @@ export class AIInteractionService {
     const interaction = await this.db
       .prepare(
         `SELECT id, user_id, chapter_id, action, instruction, input_chars, output_chars,
-                model, latency_ms, accepted, attempt_number, created_at
+                model, latency_ms, accepted, attempt_number, parent_interaction_id, created_at
          FROM ai_interactions
          WHERE id = ? AND user_id = ?`,
       )
@@ -80,7 +82,7 @@ export class AIInteractionService {
     const interaction = await this.db
       .prepare(
         `SELECT id, user_id, chapter_id, action, instruction, input_chars, output_chars,
-                model, latency_ms, accepted, attempt_number, created_at
+                model, latency_ms, accepted, attempt_number, parent_interaction_id, created_at
          FROM ai_interactions
          WHERE id = ? AND user_id = ?`,
       )
@@ -113,6 +115,7 @@ export class AIInteractionService {
       latencyMs: row.latency_ms,
       accepted: row.accepted === null ? null : row.accepted === 1,
       attemptNumber: row.attempt_number,
+      parentInteractionId: row.parent_interaction_id,
       createdAt: row.created_at,
     };
   }


### PR DESCRIPTION
## Summary
- **Attempt tracking**: Adds `parent_interaction_id` column to `ai_interactions` (migration 0007). Retry requests now link back to the first interaction in a chain, and `attempt_number` is computed from the chain length instead of always being 1.
- **429 rate limit handling**: Frontend now detects HTTP 429 responses and shows an amber toast with the server's message, auto-dismissing after 5 seconds.
- **Dead code cleanup**: Removes unused `instruction` parameter destructuring (`...[]: [instruction: string]`) and excessive comments in `use-ai-rewrite.ts` `handleRetry`.

## Files Changed
- `workers/dc-api/migrations/0007_add_parent_interaction_id.sql` - New migration
- `workers/dc-api/src/services/ai-rewrite.ts` - Accept `parentInteractionId`, compute `attempt_number` from chain
- `workers/dc-api/src/services/ai-interaction.ts` - Add `parentInteractionId` to interface and SELECT queries
- `workers/dc-api/src/routes/ai.ts` - Pass `parentInteractionId` from request body
- `web/src/app/(protected)/editor/[projectId]/page.tsx` - Send `parentInteractionId` on retries, handle 429
- `web/src/hooks/use-ai-rewrite.ts` - Clean up dead code

## Test plan
- [ ] Verify typecheck, lint, and tests pass (CI)
- [ ] Test AI rewrite flow: first request creates interaction with `attempt_number=1`, `parent_interaction_id=NULL`
- [ ] Test retry: subsequent requests set `parent_interaction_id` to the first interaction's ID and increment `attempt_number`
- [ ] Test 429: when rate limited, amber toast appears and auto-dismisses
- [ ] Run migration on remote D1 before deploying worker

🤖 Generated with [Claude Code](https://claude.com/claude-code)