### PR TITLE
feat: reusable rate limiting middleware

### DIFF
--- a/workers/dc-api/src/middleware/index.ts
+++ b/workers/dc-api/src/middleware/index.ts
@@ -10,3 +10,4 @@ export {
 } from "./error-handler.js";
 export { corsMiddleware } from "./cors.js";
 export { requireAuth, optionalAuth, type AuthContext, type ClerkJWTPayload } from "./auth.js";
+export { rateLimit, standardRateLimit, aiRateLimit, exportRateLimit } from "./rate-limit.js";

--- a/workers/dc-api/src/middleware/rate-limit.ts
+++ b/workers/dc-api/src/middleware/rate-limit.ts
@@ -1,0 +1,72 @@
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../types/index.js";
+import { rateLimited } from "./error-handler.js";
+
+interface RateLimitConfig {
+  /** KV key prefix (e.g. "standard", "ai", "export") */
+  prefix: string;
+  /** Maximum requests allowed in the window */
+  maxRequests: number;
+  /** Window duration in seconds */
+  windowSeconds: number;
+}
+
+/**
+ * Rate limiting middleware using Cloudflare KV counters with TTL.
+ *
+ * Per project instructions:
+ * - Standard endpoints: 60 req/min
+ * - AI endpoints: 10 req/min
+ * - Export endpoints: 5 req/min
+ *
+ * Must be applied after requireAuth so userId is available.
+ * Sets X-RateLimit-Remaining header on successful responses.
+ */
+export function rateLimit(config: RateLimitConfig): MiddlewareHandler<{ Bindings: Env }> {
+  return async (c, next) => {
+    const auth = c.get("auth");
+    if (!auth?.userId) {
+      // If no auth context, skip rate limiting (auth middleware will reject)
+      await next();
+      return;
+    }
+
+    const key = `ratelimit:${config.prefix}:${auth.userId}`;
+    const current = await c.env.CACHE.get(key);
+    const count = current ? parseInt(current, 10) : 0;
+
+    if (count >= config.maxRequests) {
+      rateLimited(`Rate limit exceeded. Please wait before making more requests.`);
+    }
+
+    await c.env.CACHE.put(key, String(count + 1), {
+      expirationTtl: config.windowSeconds,
+    });
+
+    const remaining = config.maxRequests - count - 1;
+    await next();
+
+    c.header("X-RateLimit-Remaining", String(remaining));
+  };
+}
+
+/** Standard rate limit: 60 req/min */
+export const standardRateLimit = rateLimit({
+  prefix: "standard",
+  maxRequests: 60,
+  windowSeconds: 60,
+});
+
+/** AI rate limit: 10 req/min */
+export const aiRateLimit = rateLimit({
+  prefix: "ai-rewrite",
+  maxRequests: 10,
+  windowSeconds: 60,
+});
+
+/** Export rate limit: 5 req/min */
+export const exportRateLimit = rateLimit({
+  prefix: "export",
+  maxRequests: 5,
+  windowSeconds: 60,
+});

--- a/workers/dc-api/src/routes/chapters.ts
+++ b/workers/dc-api/src/routes/chapters.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "../types/index.js";
 import { requireAuth } from "../middleware/auth.js";
+import { standardRateLimit } from "../middleware/rate-limit.js";
 import { validationError } from "../middleware/error-handler.js";
 import { ProjectService } from "../services/project.js";
 import { ContentService } from "../services/content.js";
@@ -26,6 +27,7 @@ const chapters = new Hono<{ Bindings: Env }>();
 
 // All chapter routes require authentication
 chapters.use("*", requireAuth);
+chapters.use("*", standardRateLimit);
 
 /**
  * POST /projects/:projectId/chapters

--- a/workers/dc-api/src/routes/drive.ts
+++ b/workers/dc-api/src/routes/drive.ts
@@ -14,6 +14,7 @@ import { Hono } from "hono";
 import { ulid } from "ulid";
 import type { Env } from "../types/index.js";
 import { requireAuth, validationError, AppError } from "../middleware/index.js";
+import { standardRateLimit } from "../middleware/rate-limit.js";
 import { DriveService } from "../services/drive.js";
 
 const drive = new Hono<{ Bindings: Env }>();
@@ -32,7 +33,7 @@ function driveNotConnected(message = "Google Drive not connected"): never {
  * Returns Google OAuth authorization URL.
  * Per PRD Section 8 (US-005): OAuth with drive.file scope, redirect-based flow only.
  */
-drive.get("/authorize", requireAuth, async (c) => {
+drive.get("/authorize", requireAuth, standardRateLimit, async (c) => {
   const { userId } = c.get("auth");
   const driveService = new DriveService(c.env);
 
@@ -124,7 +125,7 @@ drive.get("/callback", async (c) => {
  * Creates a Book Folder in Google Drive.
  * Per PRD Section 8 (US-006): Auto-creates folder named after project title.
  */
-drive.post("/folders", requireAuth, async (c) => {
+drive.post("/folders", requireAuth, standardRateLimit, async (c) => {
   const { userId } = c.get("auth");
   const driveService = new DriveService(c.env);
 
@@ -164,7 +165,7 @@ drive.post("/folders", requireAuth, async (c) => {
  * Lists DraftCrane-created files in a Book Folder.
  * Per PRD Section 8 (US-007): Read-only listing of DraftCrane-created files.
  */
-drive.get("/folders/:folderId/children", requireAuth, async (c) => {
+drive.get("/folders/:folderId/children", requireAuth, standardRateLimit, async (c) => {
   const { userId } = c.get("auth");
   const folderId = c.req.param("folderId");
   const driveService = new DriveService(c.env);
@@ -203,7 +204,7 @@ drive.get("/folders/:folderId/children", requireAuth, async (c) => {
  * Disconnects Google Drive - revokes token and deletes from D1.
  * Per PRD Section 8 (US-008): Revokes OAuth token, deletes from D1. Drive files remain untouched.
  */
-drive.delete("/connection", requireAuth, async (c) => {
+drive.delete("/connection", requireAuth, standardRateLimit, async (c) => {
   const { userId } = c.get("auth");
   const driveService = new DriveService(c.env);
 

--- a/workers/dc-api/src/routes/projects.ts
+++ b/workers/dc-api/src/routes/projects.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import type { Env } from "../types/index.js";
 import { requireAuth } from "../middleware/auth.js";
+import { standardRateLimit } from "../middleware/rate-limit.js";
 import { validationError } from "../middleware/error-handler.js";
 import { ProjectService } from "../services/project.js";
 
@@ -21,6 +22,7 @@ const projects = new Hono<{ Bindings: Env }>();
 
 // All project routes require authentication
 projects.use("*", requireAuth);
+projects.use("*", standardRateLimit);
 
 /**
  * POST /projects

--- a/workers/dc-api/src/routes/users.ts
+++ b/workers/dc-api/src/routes/users.ts
@@ -1,12 +1,13 @@
 import { Hono } from "hono";
 import type { Env } from "../types/index.js";
 import { requireAuth } from "../middleware/auth.js";
+import { standardRateLimit } from "../middleware/rate-limit.js";
 import { notFound } from "../middleware/index.js";
 
 const users = new Hono<{ Bindings: Env }>();
 
-// All user routes require authentication
 users.use("*", requireAuth);
+users.use("*", standardRateLimit);
 
 /**
  * GET /users/me


### PR DESCRIPTION
## Summary
- Extracts rate limiting from `AIRewriteService` into a reusable Hono middleware (`middleware/rate-limit.ts`)
- Three configurable tiers using Cloudflare KV counters with auto-expiring TTL:
  - **Standard**: 60 req/min (projects, chapters, users, drive)
  - **AI**: 10 req/min (AI rewrite)
  - **Export**: 5 req/min (ready for export routes when built)
- Applied to all authenticated route groups
- Sets `X-RateLimit-Remaining` header on all rate-limited responses
- Removes `checkRateLimit()` and `cache` dependency from `AIRewriteService`

## Test plan
- [ ] CI passes (typecheck, lint, format, tests)
- [ ] Standard routes return 429 after 60 requests in 60 seconds
- [ ] AI rewrite returns 429 after 10 requests in 60 seconds
- [ ] X-RateLimit-Remaining header present on responses
- [ ] OAuth callback (`/drive/callback`) is NOT rate limited
- [ ] Unauthenticated requests skip rate limiting (auth middleware rejects first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)