### PR TITLE
fix: Geist font override and chapter title keyboard accessibility

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -665,8 +665,15 @@ export default function EditorPage() {
             ) : (
               <h1
                 className="text-3xl font-semibold text-foreground mb-6 outline-none cursor-text
-                           hover:bg-gray-50 rounded px-1 -mx-1 transition-colors"
+                           hover:bg-gray-50 focus:bg-gray-50 focus:ring-2 focus:ring-blue-500
+                           rounded px-1 -mx-1 transition-colors"
                 onClick={handleTitleEdit}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    handleTitleEdit();
+                  }
+                }}
                 role="button"
                 tabIndex={0}
                 aria-label={`Edit chapter title: ${activeChapter?.title || "Untitled Chapter"}`}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -22,7 +22,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-geist-sans), sans-serif;
 }
 
 /* ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Fix #56**: Replace hard-coded `font-family: Arial` in globals.css with `var(--font-geist-sans)` so the Geist font actually renders
- **Fix #52**: Add `onKeyDown` handler (Enter/Space activates edit mode) and `focus:ring-2` to the chapter title, completing keyboard accessibility

Closes #56, closes #52

## Test plan
- [ ] Open app — text renders in Geist, not Arial
- [ ] Tab to chapter title — visible blue focus ring appears
- [ ] Press Enter or Space on focused title — enters edit mode
- [ ] Press Escape — cancels edit
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)