### PR TITLE
feat: add word count display in editor and sidebar (#27)

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -113,6 +113,9 @@ export default function EditorPage() {
     saveNowRef.current = saveNow;
   }, [saveNow]);
 
+  // Word count state (US-024)
+  const [selectionWordCount, setSelectionWordCount] = useState(0);
+
   // AI rewrite state
   const [hasTextSelection, setHasTextSelection] = useState(false);
   const [isStreamingRewrite, setIsStreamingRewrite] = useState(false);
@@ -434,6 +437,10 @@ export default function EditorPage() {
     setHasTextSelection(hasSelection);
   }, []);
 
+  const handleSelectionWordCountChange = useCallback((count: number) => {
+    setSelectionWordCount(count);
+  }, []);
+
   const handleOpenAiRewrite = useCallback(() => {
     const editor = editorRef.current?.getEditor();
     if (!editor) return;
@@ -562,6 +569,7 @@ export default function EditorPage() {
           onChapterSelect={handleChapterSelect}
           onAddChapter={handleAddChapter}
           totalWordCount={totalWordCount}
+          activeChapterWordCount={currentWordCount}
           collapsed={sidebarCollapsed}
           onToggleCollapsed={() => setSidebarCollapsed(!sidebarCollapsed)}
         />
@@ -574,6 +582,7 @@ export default function EditorPage() {
           onChapterSelect={handleChapterSelect}
           onAddChapter={handleAddChapter}
           totalWordCount={totalWordCount}
+          activeChapterWordCount={currentWordCount}
           collapsed={true}
           onToggleCollapsed={() => setMobileOverlayOpen(true)}
         />
@@ -585,6 +594,7 @@ export default function EditorPage() {
             onChapterSelect={handleChapterSelect}
             onAddChapter={handleAddChapter}
             totalWordCount={totalWordCount}
+            activeChapterWordCount={currentWordCount}
             collapsed={false}
             onToggleCollapsed={() => setMobileOverlayOpen(false)}
           />
@@ -689,6 +699,7 @@ export default function EditorPage() {
               onUpdate={handleContentChange}
               onRewrite={handleOpenAiRewrite}
               onSelectionChange={handleSelectionChange}
+              onSelectionWordCountChange={handleSelectionWordCountChange}
             />
 
             {rateLimitMessage && (
@@ -744,7 +755,9 @@ export default function EditorPage() {
               </div>
 
               <span className="text-sm text-muted-foreground tabular-nums">
-                {currentWordCount.toLocaleString()} words
+                {selectionWordCount > 0
+                  ? `${selectionWordCount.toLocaleString()} / ${currentWordCount.toLocaleString()} words`
+                  : `${currentWordCount.toLocaleString()} words`}
               </span>
             </div>
           </div>

--- a/web/src/components/chapter-editor.tsx
+++ b/web/src/components/chapter-editor.tsx
@@ -36,6 +36,8 @@ interface ChapterEditorProps {
   onEditorReady?: (editor: Editor) => void;
   /** Callback when text selection changes */
   onSelectionChange?: (hasSelection: boolean) => void;
+  /** Callback when selection word count changes (0 when no selection) */
+  onSelectionWordCountChange?: (selectionWordCount: number) => void;
 }
 
 /**
@@ -66,6 +68,7 @@ export const ChapterEditor = forwardRef<ChapterEditorHandle, ChapterEditorProps>
       editable = true,
       onEditorReady,
       onSelectionChange,
+      onSelectionWordCountChange,
     },
     ref,
   ) {
@@ -107,6 +110,11 @@ export const ChapterEditor = forwardRef<ChapterEditorHandle, ChapterEditorProps>
 
     // Track text selection for floating action bar (200ms delay per US-016)
     const textSelection = useTextSelection(editor, editorContainerRef, 200);
+
+    // Notify parent of selection word count changes (US-024)
+    useEffect(() => {
+      onSelectionWordCountChange?.(textSelection.wordCount);
+    }, [textSelection.wordCount, onSelectionWordCountChange]);
 
     // Notify parent when editor is ready
     useEffect(() => {


### PR DESCRIPTION
## Summary
- Real-time word count for active chapter displayed in sidebar (updates as user types without saving)
- Total word count at bottom of sidebar recalculated in real-time using active chapter's live count
- Selection word count shown in editor footer when text is selected (e.g., "142 / 3,400 words")

## Changes
- `web/src/components/sidebar.tsx`: Added `activeChapterWordCount` prop to override stored word count for active chapter; computed `effectiveTotalWordCount` for real-time total
- `web/src/components/chapter-editor.tsx`: Added `onSelectionWordCountChange` callback prop; propagates selection word count from existing `useTextSelection` hook to parent
- `web/src/app/(protected)/editor/[projectId]/page.tsx`: Wired real-time `currentWordCount` to sidebar via `activeChapterWordCount`; added selection word count state and display logic ("X / Y words" format)

## Test Plan
- [ ] Word count updates in real time as user types (visible in sidebar and editor footer)
- [ ] Selection word count shows when text is selected (e.g., "142 / 3,400 words")
- [ ] Per-chapter word counts visible in sidebar (active chapter uses real-time count)
- [ ] Total word count at bottom of sidebar updates in real time
- [ ] Non-active chapters show their stored word count (unchanged)
- [ ] Works correctly on iPad Safari in both portrait and landscape

Closes #27

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>