### PR TITLE
feat: connect Google Drive via OAuth (#14)

### DIFF
--- a/web/src/app/(protected)/drive/error/page.tsx
+++ b/web/src/app/(protected)/drive/error/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense } from "react";
+
+const ERROR_MESSAGES: Record<string, string> = {
+  access_denied:
+    "You declined the Google Drive connection. You can connect anytime from the editor.",
+  token_exchange_failed: "We could not complete the connection to Google Drive. Please try again.",
+};
+
+/**
+ * Drive OAuth Error Page
+ *
+ * Handles errors from the Google OAuth flow. The API callback redirects here
+ * with an error query parameter. Shows a friendly message and allows retry.
+ *
+ * Per PRD Section 8 (US-005): "Maybe later" - Drive connection is optional.
+ */
+function DriveErrorContent() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const errorCode = searchParams.get("error") || "unknown";
+  const errorMessage =
+    ERROR_MESSAGES[errorCode] ||
+    "Something went wrong connecting to Google Drive. Please try again.";
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-4">
+      <div className="w-full max-w-md text-center">
+        {/* Error icon */}
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-amber-100">
+          <svg
+            className="h-8 w-8 text-amber-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+        </div>
+
+        <h1 className="text-2xl font-semibold text-foreground mb-2">Drive Connection Issue</h1>
+
+        <p className="text-muted-foreground">{errorMessage}</p>
+
+        <div className="mt-6 flex flex-col items-center gap-3">
+          <button
+            onClick={() => router.push("/dashboard")}
+            className="inline-flex h-11 items-center justify-center rounded-lg bg-blue-600 px-6 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          >
+            Back to DraftCrane
+          </button>
+
+          <p className="text-sm text-muted-foreground">
+            You can connect Google Drive anytime from the editor.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function DriveErrorPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-[60vh] items-center justify-center">
+          <div className="text-muted-foreground">Loading...</div>
+        </div>
+      }
+    >
+      <DriveErrorContent />
+    </Suspense>
+  );
+}

--- a/web/src/app/(protected)/drive/success/page.tsx
+++ b/web/src/app/(protected)/drive/success/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useDriveStatus } from "@/hooks/use-drive-status";
+
+/**
+ * Drive OAuth Success Page
+ *
+ * After the OAuth callback redirects here, we confirm the connection
+ * succeeded and redirect the user back to their previous context
+ * (dashboard or editor). This page auto-redirects after a brief confirmation.
+ *
+ * Per PRD Section 8 (US-005): Works with iPad Safari redirect flow.
+ */
+export default function DriveSuccessPage() {
+  const router = useRouter();
+  const { status, isLoading } = useDriveStatus();
+  const [countdown, setCountdown] = useState(3);
+
+  // Auto-redirect after 3 seconds
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          router.push("/dashboard");
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [router]);
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center p-4">
+      <div className="w-full max-w-md text-center">
+        {/* Success checkmark */}
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-green-100">
+          <svg
+            className="h-8 w-8 text-green-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+
+        <h1 className="text-2xl font-semibold text-foreground mb-2">Google Drive Connected</h1>
+
+        {isLoading ? (
+          <p className="text-muted-foreground">Verifying connection...</p>
+        ) : status?.connected ? (
+          <p className="text-muted-foreground">
+            Connected as <span className="font-medium text-foreground">{status.email}</span>. Your
+            chapters will be safely stored in your Google Drive.
+          </p>
+        ) : (
+          <p className="text-muted-foreground">
+            Your Google Drive is now connected. Your chapters will be safely stored in your Google
+            Drive.
+          </p>
+        )}
+
+        <p className="mt-4 text-sm text-muted-foreground">
+          Redirecting in {countdown} second{countdown !== 1 ? "s" : ""}...
+        </p>
+
+        <button
+          onClick={() => router.push("/dashboard")}
+          className="mt-6 inline-flex h-11 items-center justify-center rounded-lg bg-blue-600 px-6 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+        >
+          Continue to DraftCrane
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -5,9 +5,11 @@ import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 import { Sidebar, SidebarOverlay, type ChapterData } from "@/components/sidebar";
 import { DriveBanner } from "@/components/drive-banner";
+import { DriveStatusIndicator } from "@/components/drive-status-indicator";
 import { ChapterEditor, type ChapterEditorHandle } from "@/components/chapter-editor";
 import { AIRewriteSheet, type AIRewriteResult } from "@/components/ai-rewrite-sheet";
 import { useAIRewrite } from "@/hooks/use-ai-rewrite";
+import { useDriveStatus } from "@/hooks/use-drive-status";
 import { SaveIndicator } from "@/components/save-indicator";
 import { CrashRecoveryDialog } from "@/components/crash-recovery-dialog";
 import { useAutoSave } from "@/hooks/use-auto-save";
@@ -20,11 +22,6 @@ interface Project {
   status: string;
   createdAt: string;
   updatedAt: string;
-}
-
-interface DriveStatus {
-  connected: boolean;
-  email?: string;
 }
 
 interface Chapter {
@@ -68,7 +65,6 @@ export default function EditorPage() {
 
   const [projectData, setProjectData] = useState<ProjectData | null>(null);
   const [activeChapterId, setActiveChapterId] = useState<string | null>(null);
-  const [driveStatus, setDriveStatus] = useState<DriveStatus | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -76,6 +72,9 @@ export default function EditorPage() {
 
   // Editor ref for AI rewrite text replacement
   const editorRef = useRef<ChapterEditorHandle>(null);
+
+  // Drive connection status (US-005)
+  const { status: driveStatus, connect: connectDrive } = useDriveStatus();
 
   // AI rewrite hook
   const aiRewrite = useAIRewrite({
@@ -125,20 +124,15 @@ export default function EditorPage() {
     firstInteractionId?: string;
   } | null>(null);
 
-  // Fetch project data and drive status
+  // Fetch project data
   useEffect(() => {
     async function fetchData() {
       try {
         const token = await getToken();
 
-        const [projectResponse, userResponse] = await Promise.all([
-          fetch(`${API_URL}/projects/${projectId}`, {
-            headers: { Authorization: `Bearer ${token}` },
-          }),
-          fetch(`${API_URL}/users/me`, {
-            headers: { Authorization: `Bearer ${token}` },
-          }),
-        ]);
+        const projectResponse = await fetch(`${API_URL}/projects/${projectId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
 
         if (!projectResponse.ok) {
           if (projectResponse.status === 404) {
@@ -154,11 +148,6 @@ export default function EditorPage() {
         if (data.chapters.length > 0 && !activeChapterId) {
           const sortedChapters = [...data.chapters].sort((a, b) => a.sortOrder - b.sortOrder);
           setActiveChapterId(sortedChapters[0].id);
-        }
-
-        if (userResponse.ok) {
-          const userData = await userResponse.json();
-          setDriveStatus(userData.drive);
         }
       } catch (err) {
         setError(err instanceof Error ? err.message : "An error occurred");
@@ -600,6 +589,17 @@ export default function EditorPage() {
           </div>
 
           <div className="flex items-center gap-2">
+            {/* Persistent Drive connection status (US-005) */}
+            {driveStatus && (
+              <DriveStatusIndicator
+                connected={driveStatus.connected}
+                email={driveStatus.email}
+                onConnect={connectDrive}
+              />
+            )}
+
+            <div className="w-px h-5 bg-border" aria-hidden="true" />
+
             {/* Save status indicator (US-015) */}
             <SaveIndicator status={saveStatus} />
 
@@ -639,10 +639,17 @@ export default function EditorPage() {
 
         <div className="flex-1 overflow-auto">
           <div className="max-w-[700px] mx-auto px-6 py-8">
-            {/* Drive connection banner - contextual, not blocking */}
+            {/* Drive connection banner - contextual, not blocking (US-005) */}
             {driveStatus && !driveStatus.connected && (
               <div className="mb-6">
-                <DriveBanner connected={false} dismissible={true} />
+                <DriveBanner connected={false} dismissible={true} onConnect={connectDrive} />
+              </div>
+            )}
+
+            {/* Drive connected confirmation banner */}
+            {driveStatus?.connected && (
+              <div className="mb-6">
+                <DriveBanner connected={true} email={driveStatus.email} dismissible={true} />
               </div>
             )}
 

--- a/web/src/components/drive-banner.tsx
+++ b/web/src/components/drive-banner.tsx
@@ -10,6 +10,8 @@ interface DriveBannerProps {
   email?: string;
   /** Whether banner can be dismissed */
   dismissible?: boolean;
+  /** Optional custom connect handler (uses default OAuth flow if not provided) */
+  onConnect?: () => void | Promise<void>;
 }
 
 /**
@@ -25,7 +27,7 @@ interface DriveBannerProps {
  * - "Maybe later" option available
  * - When not connected, persistent indicator shows degraded state
  */
-export function DriveBanner({ connected, email, dismissible = true }: DriveBannerProps) {
+export function DriveBanner({ connected, email, dismissible = true, onConnect }: DriveBannerProps) {
   const { getToken } = useAuth();
   const [isDismissed, setIsDismissed] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
@@ -57,7 +59,7 @@ export function DriveBanner({ connected, email, dismissible = true }: DriveBanne
           </div>
 
           <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-green-800">Google Drive connected</p>
+            <p className="text-sm font-medium text-green-800">Connected to Google Drive</p>
             {email && <p className="text-sm text-green-700 truncate">Connected as {email}</p>}
           </div>
 
@@ -77,6 +79,11 @@ export function DriveBanner({ connected, email, dismissible = true }: DriveBanne
 
   // Not connected state - show warning banner
   async function handleConnect() {
+    if (onConnect) {
+      await onConnect();
+      return;
+    }
+
     setIsConnecting(true);
     try {
       const token = await getToken();
@@ -129,9 +136,7 @@ export function DriveBanner({ connected, email, dismissible = true }: DriveBanne
         </div>
 
         <div className="flex-1">
-          <p className="text-sm font-medium text-amber-800">
-            Connect your Google Drive to keep your book safe
-          </p>
+          <p className="text-sm font-medium text-amber-800">Not connected to Google Drive</p>
           <p className="text-sm text-amber-700 mt-1">
             Your work is saved on this device only. Connect Drive to save your chapters in your own
             cloud account.

--- a/web/src/components/drive-status-indicator.tsx
+++ b/web/src/components/drive-status-indicator.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+interface DriveStatusIndicatorProps {
+  /** Whether Drive is connected */
+  connected: boolean;
+  /** Email of connected Drive account */
+  email?: string;
+  /** Handler for clicking when not connected */
+  onConnect?: () => void;
+}
+
+/**
+ * Compact Drive connection status indicator for the editor toolbar.
+ *
+ * Per PRD Section 8 (US-005):
+ * - When Drive NOT connected: persistent indicator "Not connected to Google Drive.
+ *   Your work is saved on this device only."
+ * - When Drive IS connected: green checkmark with "Connected to Google Drive"
+ *
+ * This is a compact version for the toolbar; the full DriveBanner is shown
+ * in the editor content area.
+ */
+export function DriveStatusIndicator({ connected, email, onConnect }: DriveStatusIndicatorProps) {
+  if (connected) {
+    return (
+      <div
+        className="flex items-center gap-1.5 text-xs text-green-700"
+        title={email ? `Connected to Google Drive as ${email}` : "Connected to Google Drive"}
+      >
+        <svg
+          className="w-3.5 h-3.5 text-green-600 shrink-0"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
+        </svg>
+        <span className="hidden sm:inline truncate max-w-[120px]">Drive connected</span>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={onConnect}
+      className="flex items-center gap-1.5 text-xs text-amber-700 hover:text-amber-900 transition-colors min-h-[44px]"
+      title="Not connected to Google Drive. Your work is saved on this device only."
+    >
+      <svg
+        className="w-3.5 h-3.5 text-amber-500 shrink-0"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01" />
+        <circle cx="12" cy="12" r="10" strokeWidth={2} />
+      </svg>
+      <span className="hidden sm:inline">Drive not connected</span>
+    </button>
+  );
+}
+
+export default DriveStatusIndicator;

--- a/web/src/hooks/use-drive-status.ts
+++ b/web/src/hooks/use-drive-status.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useAuth } from "@clerk/nextjs";
+import { useState, useEffect, useCallback } from "react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+export interface DriveStatus {
+  connected: boolean;
+  email?: string;
+  connectedAt?: string;
+}
+
+interface UseDriveStatusOptions {
+  /** Whether to fetch on mount. Defaults to true. */
+  enabled?: boolean;
+}
+
+/**
+ * Hook to fetch and manage Google Drive connection status.
+ * Per PRD Section 8 (US-005): Tokens are never sent to the frontend.
+ * Only connection metadata (connected, email) is returned.
+ */
+export function useDriveStatus(options: UseDriveStatusOptions = {}) {
+  const { enabled = true } = options;
+  const { getToken } = useAuth();
+  const [status, setStatus] = useState<DriveStatus | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const token = await getToken();
+      const response = await fetch(`${API_URL}/drive/connection`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to fetch Drive connection status");
+      }
+
+      const data: DriveStatus = await response.json();
+      setStatus(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+      setStatus({ connected: false });
+    } finally {
+      setIsLoading(false);
+    }
+  }, [getToken]);
+
+  useEffect(() => {
+    if (enabled) {
+      fetchStatus();
+    }
+  }, [enabled, fetchStatus]);
+
+  /** Initiate the Google OAuth flow by redirecting to the authorization URL. */
+  const connect = useCallback(async () => {
+    try {
+      const token = await getToken();
+      const response = await fetch(`${API_URL}/drive/authorize`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to get authorization URL");
+      }
+
+      const { authorizationUrl } = await response.json();
+
+      // Validate URL points to Google OAuth before redirecting (open redirect prevention)
+      if (
+        typeof authorizationUrl !== "string" ||
+        !authorizationUrl.startsWith("https://accounts.google.com/")
+      ) {
+        throw new Error("Invalid authorization URL");
+      }
+
+      // Redirect to Google OAuth - redirect-based flow per PRD (Safari popup blocker mitigation)
+      window.location.href = authorizationUrl;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to connect");
+    }
+  }, [getToken]);
+
+  return {
+    status,
+    isLoading,
+    error,
+    connect,
+    refetch: fetchStatus,
+  };
+}


### PR DESCRIPTION
## Summary
- Add `GET /drive/connection` backend endpoint for Drive status checks (tokens never exposed)
- Create `useDriveStatus` hook and `DriveStatusIndicator` component for persistent Drive status in editor toolbar
- Add OAuth callback landing pages (`/drive/success` and `/drive/error`) for the redirect-based flow
- Wire up "Connect Google Drive" button in dashboard, editor, and post-project-creation setup step
- Add "Maybe later" skip option on setup page per PRD Section 8 (US-005)

## Changes
- `workers/dc-api/src/routes/drive.ts` - Add `GET /drive/connection` endpoint
- `web/src/hooks/use-drive-status.ts` - New hook for Drive status + connect flow
- `web/src/components/drive-status-indicator.tsx` - New compact toolbar indicator
- `web/src/components/drive-banner.tsx` - Add `onConnect` prop, update messaging
- `web/src/app/(protected)/drive/success/page.tsx` - OAuth success landing page
- `web/src/app/(protected)/drive/error/page.tsx` - OAuth error landing page
- `web/src/app/(protected)/editor/[projectId]/page.tsx` - Add persistent Drive status to toolbar, use `useDriveStatus` hook
- `web/src/app/(protected)/dashboard/page.tsx` - Replace inline banner with `DriveBanner` component, use `useDriveStatus` hook
- `web/src/app/(protected)/setup/page.tsx` - Add Drive connection step after project creation

## Test Plan
- [ ] Verify "Connect Google Drive" button appears in dashboard when not connected
- [ ] Verify "Connect Google Drive" button appears in editor banner when not connected
- [ ] Verify OAuth redirect flow works (redirects to Google, callback stores tokens, redirects to /drive/success)
- [ ] Verify /drive/success page shows confirmation and auto-redirects to dashboard
- [ ] Verify /drive/error page shows error message with retry option
- [ ] Verify persistent Drive status indicator in editor toolbar shows correct state
- [ ] Verify green checkmark "Connected to Google Drive" shown when connected
- [ ] Verify "Maybe later" link on setup page skips Drive connection and goes to editor
- [ ] Verify iPad Safari redirect flow works (no popups)
- [ ] Verify tokens are never sent to frontend (only email/connected status)

Closes #14

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>