### PR TITLE
feat: auto-create book folder in Google Drive (#15)

### DIFF
--- a/web/src/app/(protected)/drive/success/page.tsx
+++ b/web/src/app/(protected)/drive/success/page.tsx
@@ -1,38 +1,107 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useCallback, useSyncExternalStore } from "react";
 import { useRouter } from "next/navigation";
 import { useDriveStatus } from "@/hooks/use-drive-status";
+import { useDriveFolder } from "@/hooks/use-drive-folder";
+
+const STORAGE_KEY = "dc_pending_drive_project";
+
+/**
+ * Module-level snapshot for the pending project ID.
+ * Read once from sessionStorage and cleared immediately.
+ * This avoids ref-during-render and setState-in-effect lint issues.
+ */
+let pendingProjectSnapshot: string | null = null;
+let snapshotRead = false;
+
+function readPendingProject(): string | null {
+  if (!snapshotRead && typeof window !== "undefined") {
+    const value = sessionStorage.getItem(STORAGE_KEY);
+    if (value) {
+      pendingProjectSnapshot = value;
+      sessionStorage.removeItem(STORAGE_KEY);
+    }
+    snapshotRead = true;
+  }
+  return pendingProjectSnapshot;
+}
+
+function subscribePendingProject(): () => void {
+  // Value is read once and never changes - no subscription needed
+  return () => {};
+}
+
+function getServerSnapshot(): string | null {
+  return null;
+}
 
 /**
  * Drive OAuth Success Page
  *
- * After the OAuth callback redirects here, we confirm the connection
- * succeeded and redirect the user back to their previous context
- * (dashboard or editor). This page auto-redirects after a brief confirmation.
+ * After the OAuth callback redirects here, we:
+ * 1. Confirm the Drive connection succeeded
+ * 2. If a project ID is stored in sessionStorage (from setup or editor),
+ *    auto-create the book folder in Google Drive (US-006)
+ * 3. Show folder confirmation with name, green checkmark, and "View in Google Drive" link
+ * 4. If folder creation fails, show error and retry button
+ * 5. Auto-redirect to editor (if project) or dashboard after success
  *
- * Per PRD Section 8 (US-005): Works with iPad Safari redirect flow.
+ * Per PRD Section 8 (US-005/US-006): Works with iPad Safari redirect flow.
  */
 export default function DriveSuccessPage() {
   const router = useRouter();
-  const { status, isLoading } = useDriveStatus();
-  const [countdown, setCountdown] = useState(3);
+  const { status, isLoading: isLoadingDrive } = useDriveStatus();
+  const { createFolder, folder, isCreating, error: folderError } = useDriveFolder();
+  const projectId = useSyncExternalStore(
+    subscribePendingProject,
+    readPendingProject,
+    getServerSnapshot,
+  );
+  const folderAttemptedRef = useRef(false);
+  const redirectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Auto-redirect after 3 seconds
+  // Auto-create the folder once Drive is confirmed connected and we have a project ID
   useEffect(() => {
-    const timer = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) {
-          clearInterval(timer);
-          router.push("/dashboard");
-          return 0;
-        }
-        return prev - 1;
-      });
-    }, 1000);
+    if (!isLoadingDrive && status?.connected && projectId && !folderAttemptedRef.current) {
+      folderAttemptedRef.current = true;
+      createFolder(projectId);
+    }
+  }, [isLoadingDrive, status?.connected, projectId, createFolder]);
 
-    return () => clearInterval(timer);
-  }, [router]);
+  // Auto-redirect after folder creation or when no project
+  useEffect(() => {
+    const shouldRedirect =
+      !isLoadingDrive && status?.connected && (folder || (!projectId && !isCreating));
+
+    if (!shouldRedirect) return;
+
+    redirectTimerRef.current = setTimeout(() => {
+      const destination = projectId ? `/editor/${projectId}` : "/dashboard";
+      router.push(destination);
+    }, 3000);
+
+    return () => {
+      if (redirectTimerRef.current) {
+        clearTimeout(redirectTimerRef.current);
+      }
+    };
+  }, [isLoadingDrive, status?.connected, folder, projectId, isCreating, router]);
+
+  const handleRetry = useCallback(() => {
+    if (projectId) {
+      folderAttemptedRef.current = false;
+      createFolder(projectId);
+    }
+  }, [projectId, createFolder]);
+
+  const handleContinue = useCallback(() => {
+    if (redirectTimerRef.current) {
+      clearTimeout(redirectTimerRef.current);
+    }
+    const destination = projectId ? `/editor/${projectId}` : "/dashboard";
+    router.push(destination);
+  }, [projectId, router]);
 
   return (
     <div className="flex min-h-[60vh] items-center justify-center p-4">
@@ -51,30 +120,111 @@ export default function DriveSuccessPage() {
 
         <h1 className="text-2xl font-semibold text-foreground mb-2">Google Drive Connected</h1>
 
-        {isLoading ? (
+        {isLoadingDrive ? (
           <p className="text-muted-foreground">Verifying connection...</p>
         ) : status?.connected ? (
           <p className="text-muted-foreground">
-            Connected as <span className="font-medium text-foreground">{status.email}</span>. Your
-            chapters will be safely stored in your Google Drive.
+            Connected as <span className="font-medium text-foreground">{status.email}</span>.
           </p>
         ) : (
-          <p className="text-muted-foreground">
-            Your Google Drive is now connected. Your chapters will be safely stored in your Google
-            Drive.
-          </p>
+          <p className="text-muted-foreground">Your Google Drive is now connected.</p>
         )}
 
-        <p className="mt-4 text-sm text-muted-foreground">
-          Redirecting in {countdown} second{countdown !== 1 ? "s" : ""}...
-        </p>
+        {/* Folder creation status */}
+        {projectId && (
+          <div className="mt-6">
+            {isCreating && (
+              <div className="flex items-center justify-center gap-2 text-muted-foreground">
+                <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                  />
+                </svg>
+                <span>Creating book folder in Drive...</span>
+              </div>
+            )}
 
-        <button
-          onClick={() => router.push("/dashboard")}
-          className="mt-6 inline-flex h-11 items-center justify-center rounded-lg bg-blue-600 px-6 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
-        >
-          Continue to DraftCrane
-        </button>
+            {folder && (
+              <div className="bg-green-50 border border-green-200 rounded-lg p-4 text-left">
+                <div className="flex items-center gap-3">
+                  <div className="shrink-0 w-8 h-8 rounded-full bg-green-100 flex items-center justify-center">
+                    <svg
+                      className="w-5 h-5 text-green-600"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M5 13l4 4L19 7"
+                      />
+                    </svg>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium text-green-800">Book folder created</p>
+                    <p className="text-sm text-green-700 truncate">{folder.name}</p>
+                  </div>
+                </div>
+                <a
+                  href={folder.webViewLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-green-700 hover:text-green-900 underline"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                    />
+                  </svg>
+                  View in Google Drive
+                </a>
+              </div>
+            )}
+
+            {folderError && (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-left">
+                <p className="text-sm font-medium text-red-800">Failed to create book folder</p>
+                <p className="text-sm text-red-700 mt-1">{folderError}</p>
+                <button
+                  onClick={handleRetry}
+                  className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors min-h-[44px]"
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Redirect info */}
+        {(folder || (!projectId && !isCreating && !isLoadingDrive && status?.connected)) && (
+          <p className="mt-4 text-sm text-muted-foreground">Redirecting automatically...</p>
+        )}
+
+        {/* Show continue button when folder is done or there's an error */}
+        {(folder || folderError || !projectId) && !isCreating && (
+          <button
+            onClick={handleContinue}
+            className="mt-6 inline-flex h-11 items-center justify-center rounded-lg bg-blue-600 px-6 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+          >
+            {projectId ? "Continue to Editor" : "Continue to DraftCrane"}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -77,6 +77,16 @@ export default function EditorPage() {
   // Drive connection status (US-005)
   const { status: driveStatus, connect: connectDrive } = useDriveStatus();
 
+  /**
+   * Connect Drive with project context (US-006).
+   * Stores the project ID in sessionStorage so the Drive success page
+   * can auto-create the book folder after OAuth completes.
+   */
+  const connectDriveWithProject = useCallback(() => {
+    sessionStorage.setItem("dc_pending_drive_project", projectId);
+    connectDrive();
+  }, [projectId, connectDrive]);
+
   // AI rewrite hook
   const aiRewrite = useAIRewrite({
     getToken,
@@ -605,7 +615,7 @@ export default function EditorPage() {
               <DriveStatusIndicator
                 connected={driveStatus.connected}
                 email={driveStatus.email}
-                onConnect={connectDrive}
+                onConnect={connectDriveWithProject}
               />
             )}
 
@@ -653,7 +663,11 @@ export default function EditorPage() {
             {/* Drive connection banner - contextual, not blocking (US-005) */}
             {driveStatus && !driveStatus.connected && (
               <div className="mb-6">
-                <DriveBanner connected={false} dismissible={true} onConnect={connectDrive} />
+                <DriveBanner
+                  connected={false}
+                  dismissible={true}
+                  onConnect={connectDriveWithProject}
+                />
               </div>
             )}
 

--- a/web/src/app/(protected)/setup/page.tsx
+++ b/web/src/app/(protected)/setup/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 import { DriveBanner } from "@/components/drive-banner";
 import { useDriveStatus } from "@/hooks/use-drive-status";
+import { useDriveFolder } from "@/hooks/use-drive-folder";
 
 /**
  * Book Setup Screen
@@ -19,6 +20,10 @@ import { useDriveStatus } from "@/hooks/use-drive-status";
  * - After project creation, shows "Connect Google Drive" option
  * - "Maybe later" link available - Drive connection is optional
  *
+ * Per PRD Section 8 (US-006):
+ * - After Drive OAuth completes, auto-create folder named after project title
+ * - Store project ID in sessionStorage so Drive success page can create the folder
+ *
  * Per PRD Section 8:
  * - Title max 500 chars
  * - Description max 1000 chars
@@ -27,6 +32,12 @@ export default function SetupPage() {
   const router = useRouter();
   const { getToken } = useAuth();
   const { status: driveStatus, connect: connectDrive } = useDriveStatus();
+  const {
+    createFolder,
+    folder: driveFolder,
+    isCreating: isFolderCreating,
+    error: folderError,
+  } = useDriveFolder();
 
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -69,9 +80,11 @@ export default function SetupPage() {
 
       const project = await response.json();
 
-      // If Drive is already connected, go straight to the editor
+      // If Drive is already connected, auto-create the folder and go to editor
       if (driveStatus?.connected) {
-        router.push(`/editor/${project.id}`);
+        // Fire-and-forget folder creation; redirect immediately
+        createFolder(project.id);
+        setCreatedProjectId(project.id);
         return;
       }
 
@@ -84,8 +97,146 @@ export default function SetupPage() {
     }
   }
 
+  /**
+   * Connect Drive with project context.
+   * Stores the project ID in sessionStorage so the Drive success page
+   * can auto-create the book folder after OAuth completes.
+   */
+  const connectDriveWithProject = useCallback(() => {
+    if (createdProjectId) {
+      sessionStorage.setItem("dc_pending_drive_project", createdProjectId);
+    }
+    connectDrive();
+  }, [createdProjectId, connectDrive]);
+
+  const handleRetryFolderCreation = useCallback(() => {
+    if (createdProjectId) {
+      createFolder(createdProjectId);
+    }
+  }, [createdProjectId, createFolder]);
+
   // Step 2: Drive connection (shown after project creation)
   if (createdProjectId) {
+    // If Drive is already connected, show folder creation status
+    if (driveStatus?.connected) {
+      return (
+        <div className="min-h-dvh flex items-center justify-center p-4 bg-background">
+          <div className="w-full max-w-lg">
+            <div className="text-center mb-8">
+              <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+                <svg
+                  className="h-6 w-6 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+              </div>
+              <h1 className="text-2xl font-semibold text-foreground mb-2">Book Created</h1>
+            </div>
+
+            {/* Folder creation status */}
+            <div className="mb-6">
+              {isFolderCreating && (
+                <div className="flex items-center justify-center gap-2 text-muted-foreground p-4">
+                  <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  <span>Creating book folder in Drive...</span>
+                </div>
+              )}
+
+              {driveFolder && (
+                <div className="bg-green-50 border border-green-200 rounded-lg p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="shrink-0 w-8 h-8 rounded-full bg-green-100 flex items-center justify-center">
+                      <svg
+                        className="w-5 h-5 text-green-600"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M5 13l4 4L19 7"
+                        />
+                      </svg>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium text-green-800">Book folder created</p>
+                      <p className="text-sm text-green-700 truncate">{driveFolder.name}</p>
+                    </div>
+                  </div>
+                  <a
+                    href={driveFolder.webViewLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-green-700 hover:text-green-900 underline"
+                  >
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                      />
+                    </svg>
+                    View in Google Drive
+                  </a>
+                </div>
+              )}
+
+              {folderError && (
+                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+                  <p className="text-sm font-medium text-red-800">Failed to create book folder</p>
+                  <p className="text-sm text-red-700 mt-1">{folderError}</p>
+                  <button
+                    onClick={handleRetryFolderCreation}
+                    className="mt-3 inline-flex items-center gap-1.5 px-4 py-2 text-sm font-medium bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors min-h-[44px]"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* Continue to editor */}
+            {(driveFolder || folderError) && !isFolderCreating && (
+              <div className="text-center">
+                <button
+                  onClick={() => router.push(`/editor/${createdProjectId}`)}
+                  className="inline-flex h-11 items-center justify-center rounded-lg bg-blue-600 px-6 text-sm font-medium text-white hover:bg-blue-700 transition-colors"
+                >
+                  Start Writing
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    // Drive not connected - show connection prompt
     return (
       <div className="min-h-dvh flex items-center justify-center p-4 bg-background">
         <div className="w-full max-w-lg">
@@ -111,13 +262,12 @@ export default function SetupPage() {
             </p>
           </div>
 
-          {/* Drive connection banner */}
+          {/* Drive connection banner - uses project-aware connect handler */}
           <div className="mb-6">
             <DriveBanner
-              connected={driveStatus?.connected ?? false}
-              email={driveStatus?.email}
+              connected={false}
               dismissible={false}
-              onConnect={connectDrive}
+              onConnect={connectDriveWithProject}
             />
           </div>
 

--- a/web/src/hooks/use-drive-folder.ts
+++ b/web/src/hooks/use-drive-folder.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useAuth } from "@clerk/nextjs";
+import { useState, useCallback } from "react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+export interface DriveFolderResult {
+  id: string;
+  name: string;
+  webViewLink: string;
+  alreadyExisted: boolean;
+}
+
+/**
+ * Hook to create a Google Drive folder for a project.
+ * Per PRD Section 8 (US-006): Auto-creates folder named after project title.
+ *
+ * Usage:
+ *   const { createFolder, folder, isCreating, error } = useDriveFolder();
+ *   await createFolder(projectId);
+ */
+export function useDriveFolder() {
+  const { getToken } = useAuth();
+  const [folder, setFolder] = useState<DriveFolderResult | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const createFolder = useCallback(
+    async (projectId: string): Promise<DriveFolderResult | null> => {
+      try {
+        setIsCreating(true);
+        setError(null);
+        const token = await getToken();
+        const response = await fetch(`${API_URL}/drive/folders`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ projectId }),
+        });
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error((data as { error?: string }).error || "Failed to create Drive folder");
+        }
+
+        const result: DriveFolderResult = await response.json();
+        setFolder(result);
+        return result;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Failed to create Drive folder";
+        setError(message);
+        return null;
+      } finally {
+        setIsCreating(false);
+      }
+    },
+    [getToken],
+  );
+
+  const reset = useCallback(() => {
+    setFolder(null);
+    setError(null);
+    setIsCreating(false);
+  }, []);
+
+  return {
+    createFolder,
+    folder,
+    isCreating,
+    error,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary
- **Backend**: `POST /drive/folders` now accepts `{ projectId }`, looks up the project title from D1, creates a Google Drive folder via the Drive API, and stores the returned `drive_folder_id` on the project record. Idempotent: returns existing folder if already created.
- **Frontend**: New `useDriveFolder` hook. Drive success page auto-creates the folder when a project ID is available (passed via `sessionStorage` across the OAuth redirect). Setup page and editor store the project ID before initiating OAuth. Shows folder name, green checkmark, "View in Google Drive" link, and retry on failure.

## Changes
- `workers/dc-api/src/routes/drive.ts` -- Rewired `POST /drive/folders` to accept `projectId`, look up project title, create folder, store `drive_folder_id`
- `web/src/hooks/use-drive-folder.ts` -- New hook for Drive folder creation with loading/error/retry state
- `web/src/app/(protected)/drive/success/page.tsx` -- Auto-creates folder after OAuth, shows confirmation with folder name and Drive link
- `web/src/app/(protected)/setup/page.tsx` -- Stores project ID in sessionStorage before OAuth; shows folder creation status when Drive already connected
- `web/src/app/(protected)/editor/[projectId]/page.tsx` -- Stores project context before Drive OAuth redirect

## Test Plan
- [ ] After Drive OAuth, folder is auto-created in Google Drive
- [ ] Folder name matches project title at time of creation
- [ ] "View in Google Drive" link opens the correct folder
- [ ] If project already has a folder, endpoint returns existing folder (idempotent)
- [ ] Retry button works when folder creation fails
- [ ] Setup flow: create book -> connect Drive -> folder auto-created -> "Start Writing" goes to editor
- [ ] Editor flow: connect Drive from editor -> folder auto-created -> redirect back to editor
- [ ] Dashboard flow: connect Drive without project context -> no folder creation, redirect to dashboard
- [ ] Folder name is NOT auto-renamed if project title changes later (by design)

Closes #15

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>