### PR TITLE
feat: download export locally

### DIFF
--- a/workers/dc-api/src/routes/export.ts
+++ b/workers/dc-api/src/routes/export.ts
@@ -86,6 +86,26 @@ exportRoutes.post("/projects/:projectId/chapters/:chapterId/export", async (c) =
 });
 
 /**
+ * GET /exports/:jobId
+ * Get the status of an export job.
+ *
+ * Per US-022: Returns job status + download URL for completed exports.
+ * Download URL points to the authenticated download endpoint (1-hour cache).
+ *
+ * Response: { jobId, status, format, fileName, downloadUrl, chapterCount,
+ *             totalWordCount, error, createdAt, completedAt }
+ */
+exportRoutes.get("/exports/:jobId", async (c) => {
+  const { userId } = c.get("auth");
+  const jobId = c.req.param("jobId");
+
+  const service = createExportService(c.env);
+  const status = await service.getExportStatus(userId, jobId);
+
+  return c.json(status);
+});
+
+/**
  * GET /exports/:jobId/download
  * Download a completed export file from R2.
  *


### PR DESCRIPTION
## Summary
Add export job status endpoint and persistent download button so authors can download their exported PDF/EPUB files to their device, with cross-browser support including iPad Safari.

## Changes
- Add `GET /exports/:jobId` API endpoint returning job status, format, file metadata, and download URL for completed exports
- Add `ExportJobStatus` interface and `getExportStatus` service method with R2 metadata lookup
- Add "Download" button to export completion toast for manual re-download after auto-download
- Improve `triggerDownload` with explicit MIME types (`application/pdf`, `application/epub+zip`) and typed Blob for Safari/iPad Files app compatibility
- Extend cleanup timeout from 1s to 5s to ensure download completes before blob URL revocation
- Track `jobId` in frontend export completion state

## Test Plan
- [ ] Export a book as PDF, verify auto-download triggers and file opens correctly
- [ ] Export a book as EPUB, verify auto-download triggers and file opens correctly
- [ ] After export, click the "Download" button in the success toast to re-download
- [ ] Verify `GET /exports/:jobId` returns correct status and download URL
- [ ] Test on Safari (iPad) - verify file saves to Files app
- [ ] Test on Chrome and Firefox desktop - verify download works
- [ ] Verify download button has 44pt touch target for iPad
- [ ] Verify export without Drive connection still shows download button

Closes #37

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>