### PR TITLE
feat: rename chapters inline in sidebar and editor

### DIFF
--- a/workers/dc-api/src/routes/chapters.ts
+++ b/workers/dc-api/src/routes/chapters.ts
@@ -5,6 +5,7 @@ import { standardRateLimit } from "../middleware/rate-limit.js";
 import { validationError } from "../middleware/error-handler.js";
 import { ProjectService } from "../services/project.js";
 import { ContentService } from "../services/content.js";
+import { DriveService } from "../services/drive.js";
 
 /**
  * Chapters API routes
@@ -120,6 +121,22 @@ chapters.patch("/chapters/:chapterId", async (c) => {
 
   const service = new ProjectService(c.env.DB);
   const chapter = await service.updateChapter(userId, chapterId, body);
+
+  // If title was updated and chapter has a Drive file, rename it (fire-and-forget)
+  // Per PRD US-013: If Drive is connected, Drive file renamed to match new chapter title
+  if (body.title !== undefined && chapter.driveFileId) {
+    const driveService = new DriveService(c.env);
+    driveService
+      .getValidTokens(userId)
+      .then((tokens) => {
+        if (tokens) {
+          return driveService.renameFile(tokens.accessToken, chapter.driveFileId!, chapter.title);
+        }
+      })
+      .catch((err) => {
+        console.error("Drive file rename failed (non-blocking):", err);
+      });
+  }
 
   return c.json(chapter);
 });

--- a/workers/dc-api/src/services/drive.ts
+++ b/workers/dc-api/src/services/drive.ts
@@ -359,6 +359,31 @@ export class DriveService {
   }
 
   /**
+   * Renames a file in Google Drive.
+   * Per PRD US-013: When a chapter is renamed, the Drive file name should match.
+   *
+   * @param accessToken - Valid access token
+   * @param fileId - The Drive file ID to rename
+   * @param newName - The new file name
+   */
+  async renameFile(accessToken: string, fileId: string, newName: string): Promise<void> {
+    const response = await fetch(`${GOOGLE_DRIVE_API}/files/${fileId}`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: newName }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("Drive file rename failed:", error);
+      throw new Error("Failed to rename Drive file");
+    }
+  }
+
+  /**
    * Revokes the OAuth token with Google.
    * Per PRD Section 8 (US-008): Disconnects Drive, revokes token.
    *


### PR DESCRIPTION
## Summary
Add inline chapter rename via double-tap in the sidebar and click-to-edit in the editor title field, with Drive file rename support when connected.

## Changes
- Add `onChapterRename` callback and double-tap inline editing to `Sidebar` component (new `ChapterListItem` and `InlineRenameInput` sub-components)
- Refactor editor page to share a single `handleChapterRename` function for both sidebar and editor title field rename
- Add `renameFile` method to `DriveService` for Google Drive file rename via PATCH API
- Wire Drive file rename (fire-and-forget) into `PATCH /chapters/:chapterId` route when chapter has a `drive_file_id`
- Enforce 200-character max and empty-title-to-"Untitled Chapter" fallback on both frontend and backend

## Test Plan
- [ ] Double-click a chapter title in the sidebar to enter inline edit mode
- [ ] Verify Enter commits the rename and Escape cancels
- [ ] Verify clicking away (blur) commits the rename
- [ ] Verify empty title reverts to "Untitled Chapter"
- [ ] Verify title is limited to 200 characters
- [ ] Click the chapter title in the editor area to rename
- [ ] Verify both sidebar and editor title stay in sync after rename
- [ ] Verify sidebar rename updates the active chapter title if it's the same chapter
- [ ] If Drive is connected with a chapter file, verify the Drive file is renamed to match

Closes #24

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>