### PR TITLE
feat: add sign-out with cache clearing and auto-save

### DIFF
--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@clerk/nextjs";
 import Link from "next/link";
 import { DriveBanner } from "@/components/drive-banner";
 import { useDriveStatus } from "@/hooks/use-drive-status";
+import { useSignOut } from "@/hooks/use-sign-out";
 
 interface Project {
   id: string;
@@ -46,6 +47,7 @@ export default function DashboardPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { status: driveStatus, connect: connectDrive } = useDriveStatus();
+  const { handleSignOut, isSigningOut } = useSignOut();
 
   useEffect(() => {
     async function fetchUserData() {
@@ -137,6 +139,16 @@ export default function DashboardPage() {
             Connected to Google Drive{driveStatus.email ? ` as ${driveStatus.email}` : ""}
           </p>
         )}
+
+        {/* Sign out option (US-003) */}
+        <button
+          onClick={handleSignOut}
+          disabled={isSigningOut}
+          className="mt-8 text-sm text-gray-500 hover:text-gray-700 transition-colors
+                     disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isSigningOut ? "Signing out\u2026" : "Sign out"}
+        </button>
       </div>
     </div>
   );

--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -16,6 +16,7 @@ import { ExportMenu } from "@/components/export-menu";
 import { DeleteProjectDialog } from "@/components/delete-project-dialog";
 import { DeleteChapterDialog } from "@/components/delete-chapter-dialog";
 import { useAutoSave } from "@/hooks/use-auto-save";
+import { useSignOut } from "@/hooks/use-sign-out";
 
 interface Project {
   id: string;
@@ -118,6 +119,9 @@ export default function EditorPage() {
     getToken: getToken as () => Promise<string | null>,
     apiUrl: API_URL,
   });
+
+  // Sign-out with auto-save flush (US-003)
+  const { handleSignOut, isSigningOut } = useSignOut(saveNow);
 
   // Ref to hold saveNow for chapter switch
   const saveNowRef = useRef(saveNow);
@@ -851,6 +855,37 @@ export default function EditorPage() {
                       />
                     </svg>
                     Delete Project
+                  </button>
+
+                  {/* Separator */}
+                  <div className="my-1 border-t border-gray-200" role="separator" />
+
+                  {/* Sign out (US-003) */}
+                  <button
+                    onClick={() => {
+                      setSettingsMenuOpen(false);
+                      handleSignOut();
+                    }}
+                    disabled={isSigningOut}
+                    className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                               transition-colors min-h-[44px] flex items-center gap-2
+                               disabled:opacity-50 disabled:cursor-not-allowed"
+                    role="menuitem"
+                  >
+                    <svg
+                      className="w-4 h-4 shrink-0"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+                      />
+                    </svg>
+                    {isSigningOut ? "Signing out\u2026" : "Sign Out"}
                   </button>
                 </div>
               )}

--- a/web/src/hooks/use-sign-out.ts
+++ b/web/src/hooks/use-sign-out.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useClerk } from "@clerk/nextjs";
+import { clearAllDrafts } from "@/lib/indexeddb";
+
+/**
+ * useSignOut - Handles the complete sign-out flow per US-003.
+ *
+ * Acceptance criteria:
+ * 1. Auto-save completes before session termination (wait for pending save)
+ * 2. Session terminated server-side (Clerk session revoked)
+ * 3. Cached data cleared from browser including IndexedDB
+ * 4. User redirected to landing page after sign-out
+ * 5. Subsequent visits require re-authentication
+ *
+ * @param saveNow - Optional function to flush any pending auto-save before sign-out.
+ *                  When called from the editor, pass the auto-save's saveNow function.
+ */
+export function useSignOut(saveNow?: () => Promise<void>) {
+  const { signOut } = useClerk();
+  const [isSigningOut, setIsSigningOut] = useState(false);
+
+  const handleSignOut = useCallback(async () => {
+    if (isSigningOut) return;
+    setIsSigningOut(true);
+
+    try {
+      // Step 1: Wait for any pending auto-save to complete (US-003 AC: auto-save before termination)
+      if (saveNow) {
+        await saveNow();
+      }
+
+      // Step 2: Clear all cached data from IndexedDB (US-003 AC: clear cached data)
+      await clearAllDrafts();
+
+      // Step 3: Clear any sessionStorage/localStorage app data
+      if (typeof window !== "undefined") {
+        // Remove app-specific storage items (preserve Clerk's own storage)
+        sessionStorage.removeItem("dc_pending_drive_project");
+      }
+
+      // Step 4: Sign out via Clerk (revokes session server-side) and redirect to landing page
+      // Clerk's signOut handles session revocation and redirect (US-003 AC: session terminated, redirect)
+      await signOut({ redirectUrl: "/" });
+    } catch (err) {
+      console.error("Sign-out failed:", err);
+      setIsSigningOut(false);
+      // Even if cleanup fails, attempt sign-out to ensure security
+      try {
+        await signOut({ redirectUrl: "/" });
+      } catch {
+        // Last resort: force redirect
+        window.location.href = "/";
+      }
+    }
+  }, [isSigningOut, saveNow, signOut]);
+
+  return { handleSignOut, isSigningOut };
+}


### PR DESCRIPTION
## Summary
Implements US-003 (Sign Out) with a complete sign-out flow that waits for pending auto-saves, clears IndexedDB cached data, revokes the Clerk session server-side, and redirects to the landing page.

## Changes
- Added `useSignOut` hook that orchestrates the full sign-out sequence: flush auto-save, clear IndexedDB, clear sessionStorage, invoke Clerk `signOut()` with redirect
- Added `clearAllDrafts()` to `web/src/lib/indexeddb.ts` that properly closes the DB connection and deletes the entire database
- Added "Sign Out" menu item to the editor Settings gear dropdown (with separator, icon, and loading state)
- Added "Sign out" button to the dashboard welcome/empty-state view

## Test Plan
- [ ] Open the editor with unsaved changes, click Settings > Sign Out -- verify content is saved before redirect
- [ ] After sign-out, verify redirect to landing page (`/`)
- [ ] After sign-out, navigate to `/dashboard` -- verify re-authentication is required
- [ ] Open DevTools > Application > IndexedDB -- verify `draftcrane_autosave` database is deleted after sign-out
- [ ] On the dashboard (no projects), click "Sign out" -- verify redirect to landing page
- [ ] Verify the sign-out button shows "Signing out..." loading state during the process
- [ ] Verify the Clerk `UserButton` in the header still works for sign-out as an alternative path

Closes #11

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>