### PR TITLE
feat: reorder chapters via drag-and-drop in sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1073,6 +1073,59 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
@@ -11244,6 +11297,9 @@
       "version": "0.1.0",
       "dependencies": {
         "@clerk/nextjs": "^6.37.3",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@tiptap/extension-placeholder": "^3.19.0",
         "@tiptap/pm": "^3.19.0",
         "@tiptap/react": "^3.19.0",

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "@clerk/nextjs": "^6.37.3",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@tiptap/extension-placeholder": "^3.19.0",
     "@tiptap/pm": "^3.19.0",
     "@tiptap/react": "^3.19.0",


### PR DESCRIPTION
## Summary
Implements US-012A: chapter reorder via drag-and-drop in the sidebar. Uses @dnd-kit for touch-friendly sorting that works on iPad Safari, with visual feedback (drag overlay with shadow) and keyboard shortcuts (Ctrl+Up/Down).

## Changes
- Added `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` dependencies to web workspace
- Wrapped sidebar chapter list with DndContext + SortableContext for drag-and-drop reorder
- Added drag handle (grip dots icon) to each chapter list item with touch-none for proper iPad behavior
- DragOverlay renders a styled ghost of the dragged item; source item fades to 40% opacity
- TouchSensor with 250ms delay activation distinguishes long-press-drag from normal taps
- PointerSensor with 8px distance threshold for desktop mouse/trackpad
- KeyboardSensor for accessible drag-and-drop via keyboard
- Ctrl+Up / Ctrl+Down keyboard shortcuts to move the active chapter (when focus is in sidebar)
- Added `onChapterReorder` callback to Sidebar props and wired it in all three Sidebar instances in the editor page
- `handleChapterReorder` optimistically updates local state, calls `PATCH /projects/:projectId/chapters/reorder`, and rolls back on failure
- Backend reorder endpoint and service method were already implemented

## Test Plan
- [ ] Drag chapter via grip handle on desktop (mouse) -- chapter moves to new position
- [ ] Long-press and drag chapter on iPad Safari -- reorder works with touch
- [ ] During drag: source item is semi-transparent, overlay shows shadow/border
- [ ] Drop chapter: order persists after page refresh (API called)
- [ ] Single tap on chapter still selects it (not blocked by drag sensors)
- [ ] Double-tap to rename still works (not blocked by drag)
- [ ] Ctrl+ArrowUp moves active chapter up in sidebar
- [ ] Ctrl+ArrowDown moves active chapter down in sidebar
- [ ] Drive file names are NOT changed when chapters are reordered
- [ ] Only one chapter: no reorder needed, drag handle still visible but no-op
- [ ] Network error during reorder: optimistic update reverts

Closes #23

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>