### PR TITLE
feat: save export to Google Drive

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -790,6 +790,7 @@ export default function EditorPage() {
               activeChapterId={activeChapterId}
               getToken={getToken as () => Promise<string | null>}
               apiUrl={API_URL}
+              driveConnected={driveStatus?.connected ?? false}
             />
 
             {/* Settings dropdown menu (US-023) */}


### PR DESCRIPTION
## Summary
Add the ability for authors to save completed PDF/EPUB exports directly to their Google Drive, stored in the `_exports/` subfolder of the project's Book Folder. When Drive is not connected, only the download button is shown.

## Changes
- **DriveService** (`workers/dc-api/src/services/drive.ts`): Added `findOrCreateSubfolder()` to locate or create the `_exports/` subfolder, and `uploadFile()` for multipart file upload to Google Drive
- **ExportService** (`workers/dc-api/src/services/export.ts`): Added `saveToDrive()` method that orchestrates the full flow: verify export job, find project Drive folder, find/create `_exports/` subfolder, fetch artifact from R2, upload to Drive, update `drive_file_id` in D1
- **Export routes** (`workers/dc-api/src/routes/export.ts`): Added `POST /exports/:jobId/to-drive` endpoint with auth and rate limiting
- **ExportMenu** (`web/src/components/export-menu.tsx`): Added `driveConnected` prop, "Save to Drive" button (hidden when Drive not connected), saving progress spinner, "View in Drive" link after success, and Drive error state
- **Editor page** (`web/src/app/(protected)/editor/[projectId]/page.tsx`): Pass `driveConnected` prop from existing `useDriveStatus` hook to `ExportMenu`

## Test Plan
- [ ] Generate a PDF export for a project with Drive connected and book folder created
- [ ] Verify "Save to Drive" button appears in the export completion toast
- [ ] Click "Save to Drive" and verify spinner shows while saving
- [ ] Verify file appears in `_exports/` subfolder in Google Drive
- [ ] Verify "View in Drive" link opens the file in Google Drive
- [ ] Verify date-stamped file name format: `{Book Title} - YYYY-MM-DD.pdf`
- [ ] Click "Save to Drive" again and verify idempotent behavior (returns existing file)
- [ ] Generate an export with Drive disconnected and verify only Download button shows
- [ ] Generate an export for a project without a Drive folder and verify appropriate error
- [ ] Test with EPUB format as well
- [ ] Test on iPad Safari for 44pt touch targets

Closes #36

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>