### PR TITLE
feat: configure 30-day session persistence with clean expiry redirect

### DIFF
--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -11,7 +11,13 @@ interface ProtectedLayoutProps {
  * Protected layout that requires authentication.
  * Per PRD Section 8:
  * - US-002: Returning user signs in and is taken directly to Writing Environment
- * - US-004: 30-day session lifetime
+ * - US-004: 30-day session lifetime (configured in Clerk Dashboard)
+ *
+ * Session expiry handling (US-004):
+ * - When a session expires (after 30 days of inactivity), auth() returns no userId.
+ * - This layout redirects to /sign-in cleanly with no error page or stale state.
+ * - Returning users within the 30-day window are served directly without re-auth
+ *   because the Clerk middleware refreshes the session token automatically.
  *
  * This layout wraps all authenticated routes and redirects to sign-in if not authenticated.
  * Includes a simple header with DraftCrane logo/title and user button for sign out.

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -10,10 +10,21 @@ interface ProvidersProps {
  * Application providers wrapper.
  * Per PRD Section 7: Clean Clerk-hosted authentication.
  * Per PRD Section 8 US-002: Session via Clerk JWT (httpOnly, Secure, SameSite=Lax cookie).
+ *
+ * Session persistence (US-004):
+ * - 30-day session lifetime is configured in the Clerk Dashboard
+ *   (Settings > Sessions > Session lifetime = 30 days, Inactivity timeout = 30 days).
+ * - Sliding window renewal is handled automatically by Clerk's token refresh.
+ * - afterSignInUrl/afterSignUpUrl direct authenticated users to the writing environment.
  */
 export function Providers({ children }: ProvidersProps) {
   return (
-    <ClerkProvider signInUrl="/sign-in" signUpUrl="/sign-up" afterSignInUrl="/" afterSignUpUrl="/">
+    <ClerkProvider
+      signInUrl="/sign-in"
+      signUpUrl="/sign-up"
+      afterSignInUrl="/dashboard"
+      afterSignUpUrl="/dashboard"
+    >
       {children}
     </ClerkProvider>
   );

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,4 +1,5 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
 /**
  * Routes that are publicly accessible without authentication.
@@ -11,11 +12,30 @@ const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)"]);
  * Per PRD Section 8:
  * - US-002: Returning user signs in and is taken directly to Writing Environment
  * - US-004: 30-day session lifetime, returning users go directly to Writing Environment
+ *
+ * Session persistence (US-004):
+ * - 30-day session lifetime is configured in the Clerk Dashboard
+ *   (Settings > Sessions > Session lifetime = 30 days).
+ * - Sliding window renewal: Clerk automatically refreshes the session token
+ *   on each request via the middleware, extending the session on user activity.
+ * - Expired sessions: auth.protect() redirects to the sign-in page cleanly
+ *   with no error page or flash. The unauthenticatedUrl ensures the redirect
+ *   target is explicit.
+ *
+ * Ops setup required in Clerk Dashboard:
+ * 1. Go to Settings > Sessions
+ * 2. Set "Session lifetime" to 30 days (2,592,000 seconds)
+ * 3. Set "Inactivity timeout" to 30 days (or disable if not needed)
+ * 4. These settings enable the sliding window behavior described in US-004.
  */
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {
-    await auth.protect();
+    await auth.protect({
+      unauthenticatedUrl: new URL("/sign-in", req.url).toString(),
+    });
   }
+
+  return NextResponse.next();
 });
 
 export const config = {


### PR DESCRIPTION
## Summary
Configures session persistence so returning users within 30 days go directly to the Writing Environment without re-authentication, and expired sessions redirect cleanly to sign-in with no error page.

## Changes
- Fix `afterSignInUrl` and `afterSignUpUrl` in ClerkProvider to point to `/dashboard` instead of `/` so authenticated users land in the Writing Environment
- Add `unauthenticatedUrl` to `auth.protect()` in middleware to ensure expired sessions redirect cleanly to `/sign-in` without error pages
- Document Clerk Dashboard ops configuration (30-day session lifetime, sliding window) in code comments across middleware, providers, and protected layout

## Test Plan
- [ ] Verify that signing in redirects to `/dashboard` (not landing page)
- [ ] Verify that signing up redirects to `/dashboard`
- [ ] Verify that accessing a protected route (e.g., `/dashboard`) while unauthenticated redirects to `/sign-in` cleanly
- [ ] Verify that no error page is shown during session expiry redirect
- [ ] Verify Clerk Dashboard is configured with 30-day session lifetime (ops step)
- [ ] Verify that returning users within the session window are served directly without re-auth

Closes #12

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>