### PR TITLE
feat: add landing page and first-time onboarding tooltips

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -17,6 +17,7 @@ import { DeleteProjectDialog } from "@/components/delete-project-dialog";
 import { DeleteChapterDialog } from "@/components/delete-chapter-dialog";
 import { useAutoSave } from "@/hooks/use-auto-save";
 import { useSignOut } from "@/hooks/use-sign-out";
+import { OnboardingTooltips } from "@/components/onboarding-tooltips";
 
 interface Project {
   id: string;
@@ -774,6 +775,9 @@ export default function EditorPage() {
 
   return (
     <div className="flex h-[calc(100dvh-3.5rem)]">
+      {/* First-time onboarding tooltips (#38) */}
+      <OnboardingTooltips />
+
       {/* Crash recovery dialog */}
       {recoveryPrompt && (
         <CrashRecoveryDialog

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -10,6 +10,7 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+  --font-serif: var(--font-lora);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Lora } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 
@@ -11,6 +11,12 @@ const geistSans = Geist({
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const lora = Lora({
+  variable: "--font-lora",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -34,7 +40,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} ${lora.variable} antialiased`}>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -2,38 +2,44 @@ import Link from "next/link";
 
 /**
  * Landing Page for DraftCrane.
- * Per PRD Section 7 Step 1:
+ * Per PRD Section 7 Step 1 and Section 9:
  * - Simple page with tagline and 2-3 sentence description
  * - "Get Started" button linking to /sign-up
  * - Language for authors, not technologists
  * - Avoid: "platform", "integrate", "workflow", "pipeline", "orchestration"
  * - Use: "write", "organize", "export", "your book", "your files"
+ * - No feature matrix, no pricing table
+ * - iPad-first: 44pt minimum touch targets
+ * - Serif font for headings to match book-writing theme
  */
 export default function LandingPage() {
   return (
     <div className="flex min-h-dvh flex-col items-center justify-center bg-white px-6 py-12">
       <main className="flex max-w-xl flex-col items-center text-center">
-        {/* Logo/Title */}
-        <h1 className="mb-2 text-4xl font-semibold tracking-tight text-gray-900">DraftCrane</h1>
+        {/* Logo/Title - serif font for book-writing theme */}
+        <h1 className="mb-4 font-serif text-5xl font-semibold tracking-tight text-gray-900">
+          DraftCrane
+        </h1>
 
         {/* Tagline */}
-        <p className="mb-8 text-xl text-gray-600">
-          Your book. Your files. Your cloud.
+        <p className="mb-8 font-serif text-xl leading-relaxed text-gray-600">
+          Write your book.
           <br />
-          With an AI writing partner.
+          Keep your files.
+          <br />
+          Get AI help when you need it.
         </p>
 
-        {/* Description */}
-        <p className="mb-10 max-w-md text-lg leading-relaxed text-gray-700">
-          Write and organize your nonfiction book in one place. Get AI help when you need it. Export
-          to PDF or EPUB when you are ready. Your chapters stay in your Google Drive, where they
-          belong.
+        {/* Description - author-friendly language, no tech jargon */}
+        <p className="mb-10 max-w-md text-lg leading-relaxed text-gray-500">
+          A quiet place to write and organize your nonfiction book, chapter by chapter. When you are
+          ready, export to PDF or EPUB. Your chapters stay in your Google Drive, always yours.
         </p>
 
         {/* CTA Button - 44pt minimum touch target for iPad */}
         <Link
           href="/sign-up"
-          className="inline-flex h-12 min-w-[140px] items-center justify-center rounded-lg bg-gray-900 px-8 text-lg font-medium text-white transition-colors hover:bg-gray-800 active:bg-gray-950"
+          className="inline-flex h-12 min-w-[160px] items-center justify-center rounded-lg bg-gray-900 px-8 text-lg font-medium text-white transition-colors hover:bg-gray-800 active:bg-gray-950"
         >
           Get Started
         </Link>

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -13,7 +13,12 @@ interface ProvidersProps {
  */
 export function Providers({ children }: ProvidersProps) {
   return (
-    <ClerkProvider signInUrl="/sign-in" signUpUrl="/sign-up" afterSignInUrl="/" afterSignUpUrl="/">
+    <ClerkProvider
+      signInUrl="/sign-in"
+      signUpUrl="/sign-up"
+      afterSignInUrl="/dashboard"
+      afterSignUpUrl="/dashboard"
+    >
       {children}
     </ClerkProvider>
   );

--- a/web/src/components/onboarding-tooltips.tsx
+++ b/web/src/components/onboarding-tooltips.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+const ONBOARDING_KEY = "dc_onboarding_completed";
+
+interface OnboardingStep {
+  /** Unique key for the step */
+  key: string;
+  /** Main text shown to the user */
+  text: string;
+  /** Which region of the editor this step points to */
+  target: "editor" | "sidebar" | "text-selection";
+}
+
+/**
+ * The three onboarding steps per issue #38:
+ * 1. "This is your chapter" - pointing at editor
+ * 2. "Use the sidebar for chapters" - pointing at sidebar
+ * 3. "Select text for AI" - pointing at text area
+ */
+const STEPS: OnboardingStep[] = [
+  {
+    key: "chapter",
+    text: "This is your chapter. Start writing here, or paste what you already have.",
+    target: "editor",
+  },
+  {
+    key: "sidebar",
+    text: "Use the sidebar to switch between chapters or add new ones.",
+    target: "sidebar",
+  },
+  {
+    key: "ai",
+    text: "Select any text to get AI suggestions for rewriting.",
+    target: "text-selection",
+  },
+];
+
+/**
+ * OnboardingTooltips - First-time tooltip flow for the Writing Environment.
+ *
+ * Per Issue #38:
+ * - 3 steps max
+ * - Small floating card with text and Next/Done buttons
+ * - Stored in localStorage so tooltips only show once
+ * - iPad-first: 44pt minimum touch targets
+ *
+ * Positioning strategy:
+ * - "editor" target: centered in the main content area
+ * - "sidebar" target: positioned near the left sidebar
+ * - "text-selection" target: centered in the main content area
+ *
+ * The component uses fixed positioning with simple layout-based placement
+ * rather than measuring DOM elements, for reliability across iPad Safari.
+ */
+export function OnboardingTooltips() {
+  const [currentStep, setCurrentStep] = useState<number | null>(null);
+
+  // Check localStorage on mount - only show if not completed
+  useEffect(() => {
+    try {
+      const completed = localStorage.getItem(ONBOARDING_KEY);
+      if (!completed) {
+        // Delay slightly so the editor has time to render
+        const timer = setTimeout(() => setCurrentStep(0), 800);
+        return () => clearTimeout(timer);
+      }
+    } catch {
+      // localStorage unavailable (private browsing, etc.) - skip onboarding
+    }
+  }, []);
+
+  const handleNext = useCallback(() => {
+    setCurrentStep((prev) => {
+      if (prev === null) return null;
+      if (prev >= STEPS.length - 1) {
+        // Mark onboarding as complete
+        try {
+          localStorage.setItem(ONBOARDING_KEY, "true");
+        } catch {
+          // Silently fail if localStorage unavailable
+        }
+        return null;
+      }
+      return prev + 1;
+    });
+  }, []);
+
+  const handleSkip = useCallback(() => {
+    try {
+      localStorage.setItem(ONBOARDING_KEY, "true");
+    } catch {
+      // Silently fail
+    }
+    setCurrentStep(null);
+  }, []);
+
+  if (currentStep === null || currentStep >= STEPS.length) {
+    return null;
+  }
+
+  const step = STEPS[currentStep];
+  const isLastStep = currentStep === STEPS.length - 1;
+
+  // Position classes based on target
+  const positionClasses = getPositionClasses(step.target);
+
+  return (
+    <div className="pointer-events-none fixed inset-0 z-[100]">
+      {/* Semi-transparent backdrop to draw attention */}
+      <div
+        className="pointer-events-auto absolute inset-0 bg-black/20"
+        onClick={handleSkip}
+        aria-hidden="true"
+      />
+
+      {/* Tooltip card */}
+      <div
+        className={`pointer-events-auto absolute ${positionClasses}`}
+        role="dialog"
+        aria-label={`Tip ${currentStep + 1} of ${STEPS.length}`}
+        aria-live="polite"
+      >
+        <div className="w-72 rounded-xl bg-white p-5 shadow-xl ring-1 ring-gray-200">
+          {/* Step indicator */}
+          <div className="mb-3 flex items-center gap-1.5">
+            {STEPS.map((_, i) => (
+              <div
+                key={i}
+                className={`h-1.5 rounded-full transition-colors ${
+                  i === currentStep ? "w-6 bg-blue-600" : "w-1.5 bg-gray-300"
+                }`}
+                aria-hidden="true"
+              />
+            ))}
+          </div>
+
+          {/* Step text */}
+          <p className="mb-4 text-sm leading-relaxed text-gray-700">{step.text}</p>
+
+          {/* Actions - 44pt minimum touch targets */}
+          <div className="flex items-center justify-between">
+            <button
+              onClick={handleSkip}
+              className="min-h-[44px] px-3 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+            >
+              Skip
+            </button>
+
+            <button
+              onClick={handleNext}
+              className="min-h-[44px] min-w-[80px] rounded-lg bg-gray-900 px-4 text-sm font-medium text-white transition-colors hover:bg-gray-800 active:bg-gray-950"
+            >
+              {isLastStep ? "Done" : "Next"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Returns Tailwind positioning classes based on which area the tooltip targets.
+ * Uses safe, responsive positioning that works on iPad in both orientations.
+ */
+function getPositionClasses(target: OnboardingStep["target"]): string {
+  switch (target) {
+    case "editor":
+      // Center of the content area, slightly above middle
+      return "top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2";
+    case "sidebar":
+      // Near the left edge where the sidebar lives
+      return "top-1/3 left-4 lg:left-[270px]";
+    case "text-selection":
+      // Center of the content area, slightly below middle
+      return "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2";
+    default:
+      return "top-1/3 left-1/2 -translate-x-1/2 -translate-y-1/2";
+  }
+}
+
+export default OnboardingTooltips;


### PR DESCRIPTION
## Summary
Implements the landing page with author-friendly copy and serif headings, plus a 3-step first-time onboarding tooltip flow in the Writing Environment.

## Changes
- Enhanced landing page (`web/src/app/page.tsx`) with Lora serif font for headings, refined tagline and description using author-friendly language, 44pt touch targets for iPad
- Added `--font-serif` (Lora) to the Tailwind theme via `globals.css` and registered the font in `layout.tsx`
- Created `OnboardingTooltips` component (`web/src/components/onboarding-tooltips.tsx`) with 3-step flow: "This is your chapter", "Use the sidebar for chapters", "Select text for AI"
- Onboarding uses localStorage to show tooltips only once, with Skip and Next/Done buttons
- Fixed `ClerkProvider` `afterSignInUrl`/`afterSignUpUrl` to redirect to `/dashboard` instead of `/` (the landing page)

## Test Plan
- [ ] Visit `/` as unauthenticated user: see landing page with serif "DraftCrane" heading, tagline, description, "Get Started" button
- [ ] Verify no feature matrix or pricing table on landing page
- [ ] Click "Get Started" leads to Clerk sign-up screen
- [ ] Click "Sign in" leads to Clerk sign-in screen
- [ ] After sign-in, user is redirected to `/dashboard` (not landing page)
- [ ] Open editor for a project: onboarding tooltips appear (3 steps with Next/Done)
- [ ] Complete or skip onboarding, refresh page: tooltips do not reappear
- [ ] Clear `dc_onboarding_completed` from localStorage, refresh: tooltips appear again
- [ ] Test on iPad Safari: touch targets are at least 44pt, layout works in both orientations
- [ ] Sign out redirects to `/` (landing page)

Closes #38

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>