### PR TITLE
feat: disconnect Google Drive with token revocation and confirmation

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -15,6 +15,7 @@ import { CrashRecoveryDialog } from "@/components/crash-recovery-dialog";
 import { ExportMenu } from "@/components/export-menu";
 import { DeleteProjectDialog } from "@/components/delete-project-dialog";
 import { DeleteChapterDialog } from "@/components/delete-chapter-dialog";
+import { DisconnectDriveDialog } from "@/components/disconnect-drive-dialog";
 import { useAutoSave } from "@/hooks/use-auto-save";
 import { useSignOut } from "@/hooks/use-sign-out";
 import { OnboardingTooltips } from "@/components/onboarding-tooltips";
@@ -78,8 +79,12 @@ export default function EditorPage() {
   // Editor ref for AI rewrite text replacement
   const editorRef = useRef<ChapterEditorHandle>(null);
 
-  // Drive connection status (US-005)
-  const { status: driveStatus, connect: connectDrive } = useDriveStatus();
+  // Drive connection status (US-005, US-008)
+  const {
+    status: driveStatus,
+    connect: connectDrive,
+    disconnect: disconnectDrive,
+  } = useDriveStatus();
 
   /**
    * Connect Drive with project context (US-006).
@@ -141,6 +146,9 @@ export default function EditorPage() {
   // Delete chapter dialog state (US-014)
   const [deleteChapterDialogOpen, setDeleteChapterDialogOpen] = useState(false);
   const [chapterToDelete, setChapterToDelete] = useState<string | null>(null);
+
+  // Disconnect Drive dialog state (US-008)
+  const [disconnectDriveDialogOpen, setDisconnectDriveDialogOpen] = useState(false);
 
   // AI rewrite state
   const [hasTextSelection, setHasTextSelection] = useState(false);
@@ -902,6 +910,37 @@ export default function EditorPage() {
                   role="menu"
                   aria-label="Project settings"
                 >
+                  {/* Disconnect Google Drive (US-008) - only shown when connected */}
+                  {driveStatus?.connected && (
+                    <>
+                      <button
+                        onClick={() => {
+                          setSettingsMenuOpen(false);
+                          setDisconnectDriveDialogOpen(true);
+                        }}
+                        className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                                   transition-colors min-h-[44px] flex items-center gap-2"
+                        role="menuitem"
+                      >
+                        <svg
+                          className="w-4 h-4 shrink-0"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.59 6.59m7.532 7.532l3.29 3.29M3 3l18 18"
+                          />
+                        </svg>
+                        Disconnect Google Drive
+                      </button>
+                      <div className="my-1 border-t border-gray-200" role="separator" />
+                    </>
+                  )}
+
                   <button
                     onClick={() => {
                       setSettingsMenuOpen(false);
@@ -1110,6 +1149,17 @@ export default function EditorPage() {
           setDeleteChapterDialogOpen(false);
           setChapterToDelete(null);
         }}
+      />
+
+      {/* Disconnect Google Drive confirmation dialog (US-008) */}
+      <DisconnectDriveDialog
+        email={driveStatus?.email}
+        isOpen={disconnectDriveDialogOpen}
+        onConfirm={async () => {
+          await disconnectDrive();
+          setDisconnectDriveDialogOpen(false);
+        }}
+        onCancel={() => setDisconnectDriveDialogOpen(false)}
       />
 
       <AIRewriteSheet

--- a/web/src/components/disconnect-drive-dialog.tsx
+++ b/web/src/components/disconnect-drive-dialog.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState } from "react";
+
+interface DisconnectDriveDialogProps {
+  /** The Google Drive email to display in the confirmation message */
+  email?: string;
+  /** Whether the dialog is open */
+  isOpen: boolean;
+  /** Called when the user confirms disconnection */
+  onConfirm: () => Promise<void>;
+  /** Called when the user cancels */
+  onCancel: () => void;
+}
+
+/**
+ * DisconnectDriveDialog - Confirmation dialog for disconnecting Google Drive.
+ *
+ * Per US-008 acceptance criteria:
+ * - Confirmation dialog before disconnecting
+ * - Reassures user that Drive files remain untouched (no deletion)
+ * - After disconnect, save indicator changes to device-only mode
+ * - User can reconnect anytime
+ * - iPad-first: 44pt minimum touch targets
+ */
+export function DisconnectDriveDialog({
+  email,
+  isOpen,
+  onConfirm,
+  onCancel,
+}: DisconnectDriveDialogProps) {
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  if (!isOpen) return null;
+
+  async function handleConfirm() {
+    setIsDisconnecting(true);
+    try {
+      await onConfirm();
+    } finally {
+      setIsDisconnecting(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="disconnect-drive-title"
+      aria-describedby="disconnect-drive-description"
+    >
+      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
+        {/* Warning icon */}
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-amber-100">
+          <svg
+            className="h-6 w-6 text-amber-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
+            />
+          </svg>
+        </div>
+
+        <h2
+          id="disconnect-drive-title"
+          className="text-lg font-semibold text-gray-900 mb-2 text-center"
+        >
+          Disconnect Google Drive
+        </h2>
+
+        <p id="disconnect-drive-description" className="text-sm text-gray-600 mb-2 text-center">
+          {email
+            ? `Disconnect your Google Drive account (${email})?`
+            : "Disconnect your Google Drive account?"}
+        </p>
+
+        <p className="text-sm text-gray-500 mb-2 text-center">
+          Your files in Google Drive will not be deleted or modified.
+        </p>
+
+        <p className="text-sm text-gray-500 mb-6 text-center">
+          After disconnecting, your work will be saved on this device only. You can reconnect
+          anytime.
+        </p>
+
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={onCancel}
+            disabled={isDisconnecting}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg
+                       hover:bg-gray-200 transition-colors min-h-[44px]
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={isDisconnecting}
+            className="px-4 py-2 text-sm font-medium text-white bg-amber-600 rounded-lg
+                       hover:bg-amber-700 transition-colors min-h-[44px]
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isDisconnecting ? "Disconnecting..." : "Disconnect"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DisconnectDriveDialog;

--- a/web/src/hooks/use-drive-status.ts
+++ b/web/src/hooks/use-drive-status.ts
@@ -90,11 +90,35 @@ export function useDriveStatus(options: UseDriveStatusOptions = {}) {
     }
   }, [getToken]);
 
+  /** Disconnect Google Drive by calling DELETE /drive/connection and refreshing status. */
+  const disconnect = useCallback(async () => {
+    try {
+      const token = await getToken();
+      const response = await fetch(`${API_URL}/drive/connection`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error("Failed to disconnect Google Drive");
+      }
+
+      // Refresh status to reflect disconnected state
+      await fetchStatus();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to disconnect");
+      throw err;
+    }
+  }, [getToken, fetchStatus]);
+
   return {
     status,
     isLoading,
     error,
     connect,
+    disconnect,
     refetch: fetchStatus,
   };
 }

--- a/workers/dc-api/src/routes/drive.ts
+++ b/workers/dc-api/src/routes/drive.ts
@@ -300,6 +300,13 @@ drive.delete("/connection", requireAuth, standardRateLimit, async (c) => {
   // Delete from D1
   await driveService.deleteConnection(userId);
 
+  // Clear drive_folder_id from all user's projects so they can reconnect fresh
+  await c.env.DB.prepare(
+    `UPDATE projects SET drive_folder_id = NULL, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now') WHERE user_id = ?`,
+  )
+    .bind(userId)
+    .run();
+
   return c.json({
     success: true,
     message: "Google Drive disconnected. Your files in Drive remain untouched.",


### PR DESCRIPTION
## Summary
Implements US-008: users can disconnect Google Drive from the Settings menu in the editor. A confirmation dialog warns that files in Drive will not be affected, then calls `DELETE /drive/connection` to revoke the OAuth token, delete stored credentials, and clear `drive_folder_id` from all projects. After disconnect, the Drive status indicator automatically reflects the disconnected state and the auto-save falls back to IndexedDB-only mode.

## Changes
- **Backend** (`workers/dc-api/src/routes/drive.ts`): Added `drive_folder_id` clearing from all user projects on disconnect so a future reconnect starts fresh
- **Hook** (`web/src/hooks/use-drive-status.ts`): Added `disconnect()` function that calls `DELETE /drive/connection` and refreshes status
- **New component** (`web/src/components/disconnect-drive-dialog.tsx`): Confirmation dialog following existing `DeleteProjectDialog` pattern with proper ARIA attributes and 44pt touch targets
- **Editor page** (`web/src/app/(protected)/editor/[projectId]/page.tsx`): Added "Disconnect Google Drive" menu item in Settings dropdown (visible only when connected), wired to the confirmation dialog

## Test Plan
- [ ] Connect Google Drive, verify "Disconnect Google Drive" option appears in Settings menu
- [ ] Click "Disconnect Google Drive", verify confirmation dialog appears with email and reassurance text
- [ ] Click Cancel, verify dialog closes and Drive remains connected
- [ ] Click Disconnect, verify Drive status indicator changes to disconnected state
- [ ] Verify the DriveBanner shows "Not connected to Google Drive" after disconnect
- [ ] Verify Drive files remain untouched in Google Drive after disconnect
- [ ] Verify user can reconnect Google Drive after disconnecting (re-runs OAuth flow)
- [ ] Verify `drive_folder_id` is cleared from projects after disconnect (reconnect creates new folder)

Closes #17

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>