### PR TITLE
feat: add privacy policy and terms of service pages

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -52,6 +52,18 @@ export default function LandingPage() {
           </Link>
         </p>
       </main>
+
+      {/* Footer with legal links */}
+      <footer className="mt-auto pb-8 pt-12 text-center text-sm text-gray-400">
+        <div className="flex justify-center gap-6">
+          <Link href="/privacy" className="hover:text-gray-600">
+            Privacy Policy
+          </Link>
+          <Link href="/terms" className="hover:text-gray-600">
+            Terms of Service
+          </Link>
+        </div>
+      </footer>
     </div>
   );
 }

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -1,0 +1,267 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy - DraftCrane",
+  description: "How DraftCrane handles your data, manuscripts, and Google Drive access.",
+};
+
+/**
+ * Privacy Policy page.
+ * Public route (no auth required).
+ * Required for Google OAuth verification and user trust.
+ */
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="min-h-dvh bg-white px-6 py-12">
+      <article className="mx-auto max-w-2xl">
+        {/* Back link */}
+        <Link href="/" className="mb-8 inline-block text-sm text-gray-500 hover:text-gray-700">
+          &larr; Back to DraftCrane
+        </Link>
+
+        <h1 className="mb-2 font-serif text-4xl font-semibold tracking-tight text-gray-900">
+          Privacy Policy
+        </h1>
+        <p className="mb-10 text-sm text-gray-500">Effective date: February 16, 2026</p>
+
+        <div className="space-y-8 text-base leading-relaxed text-gray-700">
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              What DraftCrane Is
+            </h2>
+            <p>
+              DraftCrane is a browser-based writing environment for nonfiction authors. It helps you
+              organize, write, and export your book chapter by chapter. Your manuscripts are stored
+              in your own Google Drive account. DraftCrane provides AI-assisted rewriting tools to
+              help you improve your prose.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Information We Collect
+            </h2>
+
+            <h3 className="mb-2 mt-4 text-lg font-semibold text-gray-800">Account information</h3>
+            <p>
+              When you create an account, we collect your name, email address, and profile
+              information through our authentication provider, Clerk. If you sign in with Google, we
+              receive basic profile information (name, email, profile photo) from Google OAuth.
+            </p>
+
+            <h3 className="mb-2 mt-4 text-lg font-semibold text-gray-800">
+              Google Drive file metadata
+            </h3>
+            <p>
+              When you connect your Google Drive, DraftCrane accesses file metadata (file names,
+              folder structure, modification dates) for files that DraftCrane creates. We store this
+              metadata in our database to power the dashboard and chapter list.
+            </p>
+
+            <h3 className="mb-2 mt-4 text-lg font-semibold text-gray-800">Manuscript content</h3>
+            <p>
+              When you open a chapter in the editor, DraftCrane reads the chapter content from your
+              Google Drive to display it. When you use the AI rewrite feature, the selected text is
+              sent to our AI provider for processing. The full content of your manuscripts is never
+              stored on our servers. Your Google Drive is the canonical store for your writing.
+            </p>
+
+            <h3 className="mb-2 mt-4 text-lg font-semibold text-gray-800">Usage data</h3>
+            <p>
+              We collect basic usage information such as pages visited and features used to improve
+              the product. We do not use third-party analytics or advertising trackers.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Google Drive Access
+            </h2>
+            <p>
+              DraftCrane requests the{" "}
+              <code className="rounded bg-gray-100 px-1.5 py-0.5 text-sm">drive.file</code> scope
+              from Google. This is the most restrictive file-access scope available. It means:
+            </p>
+            <ul className="mt-3 list-disc space-y-2 pl-6">
+              <li>
+                DraftCrane can <strong>only</strong> access files and folders that DraftCrane itself
+                creates in your Google Drive.
+              </li>
+              <li>
+                DraftCrane <strong>cannot</strong> see, read, or modify any other files in your
+                Drive, including documents, photos, or files created by other apps.
+              </li>
+              <li>
+                If you revoke access, DraftCrane immediately loses the ability to read or write any
+                files in your Drive. Your files remain in your Drive, fully accessible to you.
+              </li>
+            </ul>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">AI Processing</h2>
+            <p>
+              When you use the AI rewrite feature, the text you select is sent to OpenAI (our AI
+              provider) for processing. Here is what you should know:
+            </p>
+            <ul className="mt-3 list-disc space-y-2 pl-6">
+              <li>
+                Only the specific text you select for rewriting is sent to OpenAI. We do not send
+                your entire manuscript.
+              </li>
+              <li>
+                OpenAI processes the text to generate a rewrite suggestion, which is returned to you
+                for review. You always choose whether to accept or reject the suggestion.
+              </li>
+              <li>
+                We do not use your content to train AI models. Our agreement with OpenAI specifies
+                that data sent through the API is not used for model training.
+              </li>
+              <li>
+                AI interaction metadata (timestamps, word counts, accept/reject decisions) is stored
+                in our database for product improvement. The actual text content is not retained
+                after the request completes.
+              </li>
+            </ul>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Where Your Data Lives
+            </h2>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>
+                <strong>Your manuscripts:</strong> In your own Google Drive account, always under
+                your control.
+              </li>
+              <li>
+                <strong>Project and chapter metadata:</strong> In our database (Cloudflare D1),
+                including project names, chapter titles, and file references.
+              </li>
+              <li>
+                <strong>Export files:</strong> Temporarily cached in cloud storage (Cloudflare R2)
+                when you generate PDF or EPUB exports. These are treated as temporary artifacts.
+              </li>
+              <li>
+                <strong>Authentication tokens:</strong> Google OAuth refresh tokens are stored
+                server-side, encrypted with AES-256-GCM. They are used solely to maintain your
+                Google Drive connection.
+              </li>
+            </ul>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Authentication</h2>
+            <p>
+              DraftCrane uses Clerk as its authentication provider. When you sign in, Clerk handles
+              your credentials securely. DraftCrane never sees or stores your password. If you sign
+              in with Google, the OAuth flow is handled by Clerk and Google directly. For details on
+              how Clerk handles your authentication data, see{" "}
+              <a
+                href="https://clerk.com/privacy"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-gray-900 underline hover:text-gray-700"
+              >
+                Clerk&apos;s Privacy Policy
+              </a>
+              .
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              What We Do Not Do
+            </h2>
+            <ul className="list-disc space-y-2 pl-6">
+              <li>We do not sell your data to anyone.</li>
+              <li>We do not use your manuscripts to train AI models.</li>
+              <li>We do not show you ads.</li>
+              <li>We do not share your content with other users.</li>
+              <li>
+                We do not access files in your Google Drive beyond the ones DraftCrane creates.
+              </li>
+            </ul>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Deleting Your Data
+            </h2>
+            <p>You can request account deletion at any time by contacting us. When you do:</p>
+            <ul className="mt-3 list-disc space-y-2 pl-6">
+              <li>
+                Your account and all associated metadata (project records, chapter records, AI
+                interaction logs) will be permanently deleted from our database.
+              </li>
+              <li>Any cached export files in our cloud storage will be deleted.</li>
+              <li>Your Google OAuth tokens will be revoked and deleted.</li>
+              <li>
+                Your files in Google Drive are <strong>not</strong> deleted, because they belong to
+                you. They remain in your Drive, fully accessible.
+              </li>
+            </ul>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Data Security</h2>
+            <p>
+              We use industry-standard security practices to protect your data. All connections use
+              HTTPS. OAuth tokens are encrypted at rest with AES-256-GCM. Our infrastructure runs on
+              Cloudflare, which provides DDoS protection and edge security. Access to production
+              systems is restricted and audited.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Changes to This Policy
+            </h2>
+            <p>
+              If we make significant changes to this privacy policy, we will notify you by email or
+              through a notice in the app before the changes take effect.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Contact</h2>
+            <p>
+              If you have questions about this privacy policy or your data, contact us at{" "}
+              <a
+                href="mailto:privacy@draftcrane.app"
+                className="text-gray-900 underline hover:text-gray-700"
+              >
+                privacy@draftcrane.app
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+
+        {/* Footer links */}
+        <footer className="mt-12 border-t border-gray-200 pt-6 text-sm text-gray-500">
+          <div className="flex gap-6">
+            <Link href="/terms" className="hover:text-gray-700">
+              Terms of Service
+            </Link>
+            <Link href="/" className="hover:text-gray-700">
+              Home
+            </Link>
+          </div>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -50,6 +50,19 @@ export default function SignUpPage() {
         }}
         forceRedirectUrl="/dashboard"
       />
+
+      {/* Consent notice */}
+      <p className="mt-6 max-w-md text-center text-xs leading-relaxed text-gray-500">
+        By signing up, you agree to our{" "}
+        <Link href="/terms" className="text-gray-700 underline hover:text-gray-900">
+          Terms of Service
+        </Link>{" "}
+        and{" "}
+        <Link href="/privacy" className="text-gray-700 underline hover:text-gray-900">
+          Privacy Policy
+        </Link>
+        .
+      </p>
     </div>
   );
 }

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -1,0 +1,262 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Terms of Service - DraftCrane",
+  description: "Terms of service for using DraftCrane, the nonfiction book writing environment.",
+};
+
+/**
+ * Terms of Service page.
+ * Public route (no auth required).
+ * Required for Google OAuth verification and user trust.
+ */
+export default function TermsOfServicePage() {
+  return (
+    <div className="min-h-dvh bg-white px-6 py-12">
+      <article className="mx-auto max-w-2xl">
+        {/* Back link */}
+        <Link href="/" className="mb-8 inline-block text-sm text-gray-500 hover:text-gray-700">
+          &larr; Back to DraftCrane
+        </Link>
+
+        <h1 className="mb-2 font-serif text-4xl font-semibold tracking-tight text-gray-900">
+          Terms of Service
+        </h1>
+        <p className="mb-10 text-sm text-gray-500">Effective date: February 16, 2026</p>
+
+        <div className="space-y-8 text-base leading-relaxed text-gray-700">
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              What DraftCrane Is
+            </h2>
+            <p>
+              DraftCrane is a writing environment for nonfiction authors. It helps you write,
+              organize, and export your book. DraftCrane includes AI-assisted rewriting tools that
+              suggest changes to your prose, which you can accept or reject.
+            </p>
+            <p className="mt-3">
+              DraftCrane is a <strong>tool for writers</strong>. It is not a ghostwriting service, a
+              publishing platform, or a content generation service. You write your book. DraftCrane
+              helps you do it more effectively.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Your Account</h2>
+            <p>
+              To use DraftCrane, you create an account using your email address or Google account.
+              You are responsible for keeping your account credentials secure. If you believe your
+              account has been compromised, contact us immediately.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Your Content and Intellectual Property
+            </h2>
+            <p>
+              <strong>You own everything you write.</strong> DraftCrane does not claim any
+              ownership, license, or rights to your manuscripts, notes, chapters, or any other
+              content you create using the service.
+            </p>
+            <p className="mt-3">
+              When you use the AI rewrite feature, the resulting text belongs to you. AI-generated
+              suggestions are tools to help you write. You are the author. You decide what to keep,
+              what to change, and what to discard.
+            </p>
+            <p className="mt-3">
+              We do not use your content to train AI models, build datasets, or create derivative
+              works. Your unpublished manuscripts are treated as confidential.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Google Drive Access
+            </h2>
+            <p>
+              DraftCrane stores your manuscripts in your Google Drive account using the{" "}
+              <code className="rounded bg-gray-100 px-1.5 py-0.5 text-sm">drive.file</code> scope.
+              This means DraftCrane can only access files and folders that it creates. It cannot
+              access any other files in your Drive.
+            </p>
+            <p className="mt-3">
+              Your files always remain in your Google Drive, under your control. If you stop using
+              DraftCrane or revoke access, your files stay in your Drive. You can open, edit, or
+              delete them independently of DraftCrane at any time.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              AI-Assisted Writing
+            </h2>
+            <p>DraftCrane offers AI rewrite tools powered by OpenAI. When you use these tools:</p>
+            <ul className="mt-3 list-disc space-y-2 pl-6">
+              <li>
+                You select the text to rewrite and choose the type of rewrite. DraftCrane never
+                rewrites your text without your explicit action.
+              </li>
+              <li>
+                The AI generates a suggestion. You review it and choose to accept, reject, or retry.
+                Nothing changes in your manuscript without your approval.
+              </li>
+              <li>
+                AI suggestions are starting points, not final copy. You are responsible for the
+                accuracy, originality, and quality of your published work.
+              </li>
+              <li>
+                If you are publishing work that includes AI-assisted passages, you should follow the
+                disclosure guidelines of your publisher or institution.
+              </li>
+            </ul>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Data Portability
+            </h2>
+            <p>
+              Your content lives in your Google Drive. This is a deliberate choice. You are never
+              locked in to DraftCrane. You can:
+            </p>
+            <ul className="mt-3 list-disc space-y-2 pl-6">
+              <li>Access your manuscript files directly in Google Drive at any time.</li>
+              <li>Open and edit your files with any application that reads Google Docs.</li>
+              <li>Download your files from Google Drive in multiple formats.</li>
+              <li>Stop using DraftCrane entirely without losing access to any of your writing.</li>
+            </ul>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Acceptable Use</h2>
+            <p>You agree not to use DraftCrane to:</p>
+            <ul className="mt-3 list-disc space-y-2 pl-6">
+              <li>
+                Violate any laws or regulations, including copyright and intellectual property laws.
+              </li>
+              <li>
+                Generate content that is harmful, abusive, or designed to harass or deceive others.
+              </li>
+              <li>Attempt to access other users&apos; accounts or data.</li>
+              <li>
+                Interfere with or disrupt the service, including reverse engineering or overloading
+                infrastructure.
+              </li>
+              <li>Resell or redistribute DraftCrane as your own product.</li>
+            </ul>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Service Availability
+            </h2>
+            <p>
+              We strive to keep DraftCrane available and reliable. However, we cannot guarantee
+              uninterrupted access. The service may be temporarily unavailable for maintenance,
+              updates, or due to circumstances beyond our control.
+            </p>
+            <p className="mt-3">
+              Because your manuscripts are stored in your Google Drive, your content is accessible
+              even if DraftCrane is temporarily unavailable.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Account Termination
+            </h2>
+            <p>
+              You can stop using DraftCrane and request account deletion at any time. When your
+              account is deleted:
+            </p>
+            <ul className="mt-3 list-disc space-y-2 pl-6">
+              <li>
+                All account data, project metadata, and AI interaction records are permanently
+                removed from our systems.
+              </li>
+              <li>Any cached export files are deleted from our cloud storage.</li>
+              <li>Your Google OAuth connection is revoked.</li>
+              <li>
+                Your files in Google Drive are <strong>not</strong> deleted. They are yours and
+                remain in your Drive.
+              </li>
+            </ul>
+            <p className="mt-3">
+              We may suspend or terminate accounts that violate these terms. If we do, we will
+              notify you by email and give you an opportunity to download any export files before
+              they are removed.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Limitation of Liability
+            </h2>
+            <p>
+              DraftCrane is provided &ldquo;as is&rdquo; without warranties of any kind. To the
+              fullest extent permitted by law, DraftCrane and its operators are not liable for any
+              indirect, incidental, special, consequential, or punitive damages, including loss of
+              data, revenue, or manuscripts.
+            </p>
+            <p className="mt-3">
+              Because your manuscripts are stored in your Google Drive, data loss due to DraftCrane
+              service issues does not affect your canonical manuscript files.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+              Changes to These Terms
+            </h2>
+            <p>
+              We may update these terms from time to time. If we make significant changes, we will
+              notify you by email or through a notice in the app before the changes take effect.
+              Continued use of DraftCrane after changes take effect constitutes acceptance of the
+              updated terms.
+            </p>
+          </section>
+
+          {/* ------------------------------------------------------------ */}
+          <section>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Contact</h2>
+            <p>
+              If you have questions about these terms, contact us at{" "}
+              <a
+                href="mailto:support@draftcrane.app"
+                className="text-gray-900 underline hover:text-gray-700"
+              >
+                support@draftcrane.app
+              </a>
+              .
+            </p>
+          </section>
+        </div>
+
+        {/* Footer links */}
+        <footer className="mt-12 border-t border-gray-200 pt-6 text-sm text-gray-500">
+          <div className="flex gap-6">
+            <Link href="/privacy" className="hover:text-gray-700">
+              Privacy Policy
+            </Link>
+            <Link href="/" className="hover:text-gray-700">
+              Home
+            </Link>
+          </div>
+        </footer>
+      </article>
+    </div>
+  );
+}

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -5,7 +5,13 @@ import { NextResponse } from "next/server";
  * Routes that are publicly accessible without authentication.
  * Per PRD Section 7: Landing page is pre-auth.
  */
-const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)"]);
+const isPublicRoute = createRouteMatcher([
+  "/",
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+  "/privacy",
+  "/terms",
+]);
 
 /**
  * Clerk middleware for route protection.


### PR DESCRIPTION
## Summary
Add public privacy policy and terms of service pages with real legal content covering DraftCrane's data practices, Google Drive access, AI processing, and user rights. Include consent mechanism on the sign-up page and footer links on the landing page.

## Changes
- Add `/privacy` page with full privacy policy (data collection, Google Drive `drive.file` scope, OpenAI AI processing, data storage locations, deletion rights, security practices)
- Add `/terms` page with full terms of service (IP ownership, AI-assisted writing disclosure, data portability, acceptable use, liability)
- Update Clerk middleware to make `/privacy` and `/terms` public routes (no auth required)
- Add consent text ("By signing up, you agree to our Terms and Privacy Policy") on the sign-up page below the Clerk form
- Add footer links to Privacy Policy and Terms of Service on the landing page

## Test Plan
- [ ] Visit `/privacy` without being signed in — page loads with full privacy policy content
- [ ] Visit `/terms` without being signed in — page loads with full terms of service content
- [ ] Landing page (`/`) shows Privacy Policy and Terms of Service links in footer
- [ ] Sign-up page (`/sign-up`) shows consent text with links to both pages
- [ ] Navigation links between privacy, terms, and home pages all work
- [ ] Pages render correctly on iPad Safari (serif headings, readable text, proper spacing)
- [ ] Lint, typecheck, format, and test all pass

Closes #58

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>