### PR TITLE
test: add auth, CORS, and encryption test suites

### DIFF
--- a/workers/dc-api/src/index.ts
+++ b/workers/dc-api/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { Env } from "./types/index.js";
-import { errorHandler, corsMiddleware } from "./middleware/index.js";
+import { AppError, corsMiddleware } from "./middleware/index.js";
 import { health } from "./routes/health.js";
 import { auth } from "./routes/auth.js";
 import { users } from "./routes/users.js";
@@ -9,11 +9,23 @@ import { projects } from "./routes/projects.js";
 import { chapters } from "./routes/chapters.js";
 import { ai } from "./routes/ai.js";
 import { exportRoutes } from "./routes/export.js";
+import type { ErrorCode } from "./types/index.js";
 
 const app = new Hono<{ Bindings: Env }>();
 
+// Global error handler (Hono's onError is invoked by the internal compose
+// function and reliably catches errors thrown in sub-route middleware,
+// unlike a middleware-based try/catch which can be bypassed by compose).
+app.onError((err, c) => {
+  if (err instanceof AppError) {
+    return c.json({ error: err.message, code: err.code }, err.statusCode as 400);
+  }
+
+  console.error("Unhandled error:", err);
+  return c.json({ error: "Internal server error", code: "INTERNAL_ERROR" as ErrorCode }, 500);
+});
+
 // Global middleware
-app.use("*", errorHandler);
 app.use("*", corsMiddleware());
 
 // Route mounting

--- a/workers/dc-api/test/auth.test.ts
+++ b/workers/dc-api/test/auth.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { SELF } from "cloudflare:test";
+
+/**
+ * Auth middleware tests.
+ *
+ * These test the requireAuth middleware by sending requests to a protected
+ * route (/projects) with various invalid authentication states.
+ * The middleware should reject all of them with 401 AUTH_REQUIRED.
+ */
+describe("Auth middleware", () => {
+  it("returns 401 AUTH_REQUIRED when no token is provided", async () => {
+    const response = await SELF.fetch("http://localhost/projects");
+    expect(response.status).toBe(401);
+
+    const body = (await response.json()) as { error: string; code: string };
+    expect(body.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("returns 401 when token is malformed (not a valid JWT)", async () => {
+    const response = await SELF.fetch("http://localhost/projects", {
+      headers: {
+        Authorization: "Bearer not-a-valid-jwt",
+      },
+    });
+    expect(response.status).toBe(401);
+
+    const body = (await response.json()) as { error: string; code: string };
+    expect(body.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("returns 401 when token is expired", async () => {
+    // Build a JWT with an expired exp claim
+    const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT", kid: "test-kid" }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const payload = btoa(
+      JSON.stringify({
+        sub: "user_test123",
+        iss: "https://test.clerk.accounts.dev",
+        exp: Math.floor(Date.now() / 1000) - 3600, // expired 1 hour ago
+        iat: Math.floor(Date.now() / 1000) - 7200,
+      }),
+    )
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const fakeSignature = "fakesignature";
+    const token = `${header}.${payload}.${fakeSignature}`;
+
+    const response = await SELF.fetch("http://localhost/projects", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    expect(response.status).toBe(401);
+
+    const body = (await response.json()) as { error: string; code: string };
+    expect(body.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("returns 401 when token has wrong issuer", async () => {
+    // Build a JWT with a valid exp but wrong issuer
+    const header = btoa(JSON.stringify({ alg: "RS256", typ: "JWT", kid: "test-kid" }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const payload = btoa(
+      JSON.stringify({
+        sub: "user_test123",
+        iss: "https://evil-issuer.example.com",
+        exp: Math.floor(Date.now() / 1000) + 3600, // valid for 1 hour
+        iat: Math.floor(Date.now() / 1000),
+      }),
+    )
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+    const fakeSignature = "fakesignature";
+    const token = `${header}.${payload}.${fakeSignature}`;
+
+    const response = await SELF.fetch("http://localhost/projects", {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    expect(response.status).toBe(401);
+
+    const body = (await response.json()) as { error: string; code: string };
+    expect(body.code).toBe("AUTH_REQUIRED");
+  });
+});

--- a/workers/dc-api/test/cors.test.ts
+++ b/workers/dc-api/test/cors.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { SELF } from "cloudflare:test";
+
+/**
+ * CORS middleware tests.
+ *
+ * The CORS middleware reads FRONTEND_URL from wrangler.toml [vars] and only
+ * allows that specific origin. All other origins are rejected (empty
+ * Access-Control-Allow-Origin). Uses /health endpoint since it requires no auth.
+ */
+describe("CORS middleware", () => {
+  // FRONTEND_URL is set to "https://draftcrane.app" in wrangler.toml [vars]
+  const ALLOWED_ORIGIN = "https://draftcrane.app";
+
+  it("returns proper CORS headers for allowed origin", async () => {
+    const response = await SELF.fetch("http://localhost/health", {
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(ALLOWED_ORIGIN);
+    expect(response.headers.get("Access-Control-Allow-Credentials")).toBe("true");
+  });
+
+  it("does not return Access-Control-Allow-Origin for blocked origin", async () => {
+    const response = await SELF.fetch("http://localhost/health", {
+      headers: {
+        Origin: "https://evil-site.example.com",
+      },
+    });
+
+    expect(response.status).toBe(200);
+    // Blocked origins should not get an allow-origin header
+    const allowOrigin = response.headers.get("Access-Control-Allow-Origin");
+    expect(!allowOrigin || allowOrigin === "").toBe(true);
+  });
+
+  it("responds correctly to preflight OPTIONS request", async () => {
+    const response = await SELF.fetch("http://localhost/health", {
+      method: "OPTIONS",
+      headers: {
+        Origin: ALLOWED_ORIGIN,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "Content-Type, Authorization",
+      },
+    });
+
+    // Preflight should return 204 (no content)
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe(ALLOWED_ORIGIN);
+    expect(response.headers.get("Access-Control-Allow-Methods")).toContain("POST");
+    expect(response.headers.get("Access-Control-Allow-Headers")).toContain("Content-Type");
+    expect(response.headers.get("Access-Control-Allow-Headers")).toContain("Authorization");
+    expect(response.headers.get("Access-Control-Max-Age")).toBe("86400");
+  });
+});

--- a/workers/dc-api/test/crypto.test.ts
+++ b/workers/dc-api/test/crypto.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { encrypt, decrypt } from "../src/services/crypto.js";
+
+/**
+ * Crypto service tests.
+ *
+ * Tests the AES-256-GCM encrypt/decrypt functions used for storing
+ * OAuth tokens securely. Uses random IVs, so identical plaintext
+ * produces different ciphertext on each call.
+ */
+describe("Crypto service", () => {
+  const TEST_KEY = "test-encryption-key-for-unit-tests";
+
+  it("encrypt + decrypt round-trip returns original plaintext", async () => {
+    const plaintext = "oauth-access-token-abc123";
+    const encrypted = await encrypt(plaintext, TEST_KEY);
+    const decrypted = await decrypt(encrypted, TEST_KEY);
+
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("same input produces different ciphertext (random IV)", async () => {
+    const plaintext = "same-input-every-time";
+    const encrypted1 = await encrypt(plaintext, TEST_KEY);
+    const encrypted2 = await encrypt(plaintext, TEST_KEY);
+
+    // Both should decrypt to the same value
+    expect(await decrypt(encrypted1, TEST_KEY)).toBe(plaintext);
+    expect(await decrypt(encrypted2, TEST_KEY)).toBe(plaintext);
+
+    // But the ciphertext should differ due to random IV
+    expect(encrypted1).not.toBe(encrypted2);
+  });
+
+  it("wrong key fails to decrypt", async () => {
+    const plaintext = "secret-data";
+    const encrypted = await encrypt(plaintext, TEST_KEY);
+
+    await expect(decrypt(encrypted, "wrong-key-entirely")).rejects.toThrow();
+  });
+
+  it("empty string round-trip", async () => {
+    const plaintext = "";
+    const encrypted = await encrypt(plaintext, TEST_KEY);
+    const decrypted = await decrypt(encrypted, TEST_KEY);
+
+    expect(decrypted).toBe(plaintext);
+  });
+
+  it("unicode content round-trip", async () => {
+    const plaintext = "Hello \u4e16\u754c \ud83c\udf0d \u00e9\u00e0\u00fc\u00f1 \u2603\ufe0f";
+    const encrypted = await encrypt(plaintext, TEST_KEY);
+    const decrypted = await decrypt(encrypted, TEST_KEY);
+
+    expect(decrypted).toBe(plaintext);
+  });
+});


### PR DESCRIPTION
## Summary
Add 12 new tests covering security-critical code paths (auth middleware, CORS policy, encryption service) and fix the global error handler to use Hono's `app.onError()` pattern.

## Changes
- Add `test/auth.test.ts` (4 tests): verifies no-token, malformed, expired, and wrong-issuer JWTs all return 401 AUTH_REQUIRED
- Add `test/cors.test.ts` (3 tests): verifies allowed origin gets CORS headers, blocked origin is rejected, preflight OPTIONS returns correct headers
- Add `test/crypto.test.ts` (5 tests): verifies encrypt/decrypt round-trip, random IV uniqueness, wrong-key rejection, empty string and unicode handling
- Fix global error handler in `src/index.ts` to use `app.onError()` instead of middleware-based try/catch, which was silently bypassed by Hono's internal compose function

## Test Plan
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run format:check` passes
- [x] `npm run test` passes (28 tests: 16 existing + 12 new)

Closes #57

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>