### PR TITLE
feat: progressive AI streaming UX + multi-tier edge AI

### DIFF
--- a/docs/adr/ADR-006-multi-tier-ai.md
+++ b/docs/adr/ADR-006-multi-tier-ai.md
@@ -1,0 +1,65 @@
+# ADR-006: Multi-Tier AI (Edge + Frontier)
+
+## Status
+
+**Accepted** - 2026-02-17
+
+## Context
+
+User testing revealed AI rewrite latency is too high. GPT-4o (frontier tier) takes 2-5+ seconds to first token when routed through the OpenAI API. Combined with the original implementation that accumulated all tokens before showing results, perceived latency equaled the full streaming duration.
+
+Cloudflare Workers AI provides edge inference that can dramatically reduce time-to-first-token (TTFT) by running models on the same network as the worker. The GLM-4.7-Flash model is available and suitable for common rewrite tasks (grammar, clarity, concision).
+
+## Decision
+
+Implement a two-tier AI architecture:
+
+1. **Edge tier** (`@cf/zai-org/glm-4.7-flash` via Workers AI binding) — fast, runs on Cloudflare edge. Default for initial rewrites.
+2. **Frontier tier** (GPT-4o via OpenAI API) — higher quality, higher latency. Available via "Go Deeper" escalation.
+
+The frontend defaults to `edge` tier. After seeing the edge result, the user can tap "Go Deeper" to re-run the same instruction through the frontier model. This is a fresh rewrite, not a refinement of the edge result.
+
+The default tier is controlled by `AI_DEFAULT_TIER` in wrangler.toml vars, initially set to `"frontier"` until edge quality is validated via B0 quality gate.
+
+## Rationale
+
+- **Latency**: Edge inference eliminates the internet round-trip. Expected TTFT < 1 second vs 2-5+ seconds.
+- **Cost**: Workers AI is included in the Cloudflare Workers plan. Edge rewrites have zero marginal API cost.
+- **Quality tradeoff**: GLM-4.7-Flash is adequate for "Improve this text" style instructions but may underperform on nuanced creative requests. The "Go Deeper" escape hatch addresses this.
+- **Progressive disclosure**: Most rewrites don't need frontier quality. Users who want more can escalate explicitly.
+- **Infrastructure simplicity**: Workers AI is a binding — no new external service, no API key management.
+
+## Implementation
+
+- `WorkersAIProvider` implements the same `AIProvider` interface as `OpenAIProvider`
+- Workers AI streaming format (`{"response":"..."}`) is handled by a separate transform function
+- `tier` column added to `ai_interactions` table for analytics
+- `AI_DEFAULT_TIER` env var controls which tier is used by default
+- Both tiers share the same rate limit counter (10 req/min)
+
+## Quality Gate (B0)
+
+Before flipping `AI_DEFAULT_TIER` to `"edge"`:
+
+- Run 20-30 representative rewrite scenarios through GLM-4.7-Flash
+- Compare against GPT-4o on same inputs
+- Pass criteria: acceptable for grammar/clarity/concision instructions
+- If quality is insufficient, keep frontier as default and revisit when better edge models are available
+
+## Cost Analysis
+
+| Tier              | Cost                     | TTFT          |
+| ----------------- | ------------------------ | ------------- |
+| Edge (Workers AI) | Included in plan         | < 1s expected |
+| Frontier (GPT-4o) | ~$0.005-0.02 per rewrite | 2-5s          |
+
+At Phase 0 scale (5-10 users), frontier costs are negligible. Edge-first reduces costs as usage scales.
+
+## Consequences
+
+- **Positive**: Dramatically improved perceived latency for most rewrites
+- **Positive**: Zero marginal cost for edge rewrites
+- **Positive**: Users have explicit control over quality/speed tradeoff
+- **Negative**: Two code paths for AI streaming (OpenAI SSE vs Workers AI SSE formats)
+- **Negative**: Edge model quality may not match frontier for all instruction types
+- **Risk**: Workers AI model availability and quality may change; `AI_DEFAULT_TIER` provides a quick rollback

--- a/web/src/components/chapter-editor.tsx
+++ b/web/src/components/chapter-editor.tsx
@@ -34,8 +34,6 @@ interface ChapterEditorProps {
   editable?: boolean;
   /** Callback when editor instance is ready */
   onEditorReady?: (editor: Editor) => void;
-  /** Callback when text selection changes */
-  onSelectionChange?: (hasSelection: boolean) => void;
   /** Callback when selection word count changes (0 when no selection) */
   onSelectionWordCountChange?: (selectionWordCount: number) => void;
 }
@@ -67,7 +65,6 @@ export const ChapterEditor = forwardRef<ChapterEditorHandle, ChapterEditorProps>
       placeholder = "Start writing, or paste your existing notes here...",
       editable = true,
       onEditorReady,
-      onSelectionChange,
       onSelectionWordCountChange,
     },
     ref,
@@ -101,10 +98,6 @@ export const ChapterEditor = forwardRef<ChapterEditorHandle, ChapterEditorProps>
       },
       onUpdate: ({ editor: ed }) => {
         onUpdate?.(ed.getHTML());
-      },
-      onSelectionUpdate: ({ editor: ed }) => {
-        const { from, to } = ed.state.selection;
-        onSelectionChange?.(from !== to);
       },
     });
 

--- a/workers/dc-api/migrations/0008_add_ai_tier.sql
+++ b/workers/dc-api/migrations/0008_add_ai_tier.sql
@@ -1,0 +1,2 @@
+-- Add tier column to ai_interactions for multi-tier AI tracking (edge vs frontier)
+ALTER TABLE ai_interactions ADD COLUMN tier TEXT NOT NULL DEFAULT 'frontier';

--- a/workers/dc-api/src/services/ai-interaction.ts
+++ b/workers/dc-api/src/services/ai-interaction.ts
@@ -22,6 +22,7 @@ export interface AIInteraction {
   accepted: boolean | null;
   attemptNumber: number;
   parentInteractionId: string | null;
+  tier: "edge" | "frontier";
   createdAt: string;
 }
 
@@ -38,6 +39,7 @@ interface AIInteractionRow {
   accepted: number | null;
   attempt_number: number;
   parent_interaction_id: string | null;
+  tier: string;
   created_at: string;
 }
 
@@ -53,7 +55,7 @@ export class AIInteractionService {
     const interaction = await this.db
       .prepare(
         `SELECT id, user_id, chapter_id, action, instruction, input_chars, output_chars,
-                model, latency_ms, accepted, attempt_number, parent_interaction_id, created_at
+                model, latency_ms, accepted, attempt_number, parent_interaction_id, tier, created_at
          FROM ai_interactions
          WHERE id = ? AND user_id = ?`,
       )
@@ -82,7 +84,7 @@ export class AIInteractionService {
     const interaction = await this.db
       .prepare(
         `SELECT id, user_id, chapter_id, action, instruction, input_chars, output_chars,
-                model, latency_ms, accepted, attempt_number, parent_interaction_id, created_at
+                model, latency_ms, accepted, attempt_number, parent_interaction_id, tier, created_at
          FROM ai_interactions
          WHERE id = ? AND user_id = ?`,
       )
@@ -116,6 +118,7 @@ export class AIInteractionService {
       accepted: row.accepted === null ? null : row.accepted === 1,
       attemptNumber: row.attempt_number,
       parentInteractionId: row.parent_interaction_id,
+      tier: (row.tier as "edge" | "frontier") || "frontier",
       createdAt: row.created_at,
     };
   }

--- a/workers/dc-api/src/types/env.ts
+++ b/workers/dc-api/src/types/env.ts
@@ -3,6 +3,7 @@ export interface Env {
   DB: D1Database;
   EXPORTS_BUCKET: R2Bucket;
   CACHE: KVNamespace;
+  AI: Ai;
 
   // Clerk
   CLERK_PUBLISHABLE_KEY: string;
@@ -18,6 +19,7 @@ export interface Env {
   // AI Provider
   OPENAI_API_KEY: string;
   AI_MODEL?: string; // Default: gpt-4o
+  AI_DEFAULT_TIER?: string; // "edge" | "frontier", default: "frontier"
 
   // Cloudflare Browser Rendering (PDF export)
   CF_ACCOUNT_ID: string;

--- a/workers/dc-api/wrangler.toml
+++ b/workers/dc-api/wrangler.toml
@@ -29,9 +29,14 @@ id = "15db632cefe04003a94f1e6e7460c858"
 # CF_API_TOKEN           - Cloudflare Browser Rendering (PDF export)
 # ENCRYPTION_KEY         - AES-256-GCM token encryption
 
+# Workers AI
+[ai]
+binding = "AI"
+
 [vars]
 FRONTEND_URL = "https://draftcrane.app"
 AI_MODEL = "gpt-4o"
+AI_DEFAULT_TIER = "frontier"
 API_BASE_URL = "https://dc-api.automation-ab6.workers.dev"
 CLERK_ISSUER_URL = "https://viable-wombat-59.clerk.accounts.dev"
 GOOGLE_REDIRECT_URI = "https://dc-api.automation-ab6.workers.dev/drive/callback"


### PR DESCRIPTION
## Summary

- **Fix no-feedback UX**: Sheet opens instantly on AI Rewrite click with progressive token streaming and blinking cursor — no more waiting for full response before seeing anything
- **Fix conflicting buttons**: Removed duplicate bottom AI Rewrite button; added toolbar fallback icon (visible when text selected) as reliable iPad entry point alongside the floating action bar
- **Add multi-tier AI**: Workers AI edge tier (`@cf/zai-org/glm-4.7-flash`) for sub-second TTFT, with "Go Deeper" button to escalate to frontier model (GPT-4o)

## Changes

### Phase A: UX Fixes
| File | Change |
|------|--------|
| `workers/dc-api/src/services/ai-rewrite.ts` | Emit `start` SSE event with `interactionId` before tokens |
| `web/src/hooks/use-ai-rewrite.ts` | State-machine hook (`idle`/`streaming`/`complete`) replaces boolean soup |
| `web/src/components/ai-rewrite-sheet.tsx` | Streaming cursor, disabled actions during stream, inline errors, "Go Deeper" button |
| `web/src/app/(protected)/editor/[projectId]/page.tsx` | Progressive streaming, toolbar fallback, remove bottom button, replaceText error handling |
| `web/src/components/chapter-editor.tsx` | Remove unused `onSelectionChange` prop |

### Phase B: Multi-Tier AI
| File | Change |
|------|--------|
| `workers/dc-api/wrangler.toml` | `[ai]` binding, `AI_DEFAULT_TIER` var |
| `workers/dc-api/src/types/env.ts` | `AI: Ai`, `AI_DEFAULT_TIER` |
| `workers/dc-api/src/services/ai-provider.ts` | `WorkersAIProvider` + `createWorkersAITransform()` |
| `workers/dc-api/src/routes/ai.ts` | Tier-based provider selection |
| `workers/dc-api/src/services/ai-interaction.ts` | `tier` field in types |
| `workers/dc-api/migrations/0008_add_ai_tier.sql` | Add `tier` column |
| `docs/adr/ADR-006-multi-tier-ai.md` | Decision record |

## Test plan

- [ ] `npx tsc --noEmit` clean in both `workers/dc-api/` and `web/` (verified)
- [ ] `npm test` in `workers/dc-api/` — 28/28 pass (verified)
- [ ] Select text, tap AI Rewrite → sheet opens instantly with streaming indicator
- [ ] Tokens appear progressively with blinking cursor
- [ ] No bottom button below editor; toolbar icon visible when text selected
- [ ] Cancel during streaming → request aborts, sheet closes
- [ ] Edit text after initiating rewrite, accept → inline error shown
- [ ] Edge rewrite TTFT < 1s (after `AI_DEFAULT_TIER` flipped to `edge`)
- [ ] "Go Deeper" appears after edge result, streams frontier response
- [ ] Run migration: `npx wrangler d1 migrations apply dc-main --remote`

Closes #92, closes #93, closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)