### PR TITLE
refactor: extract SettingsMenu, expand test coverage

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -25,6 +25,7 @@ import { useEditorAI } from "@/hooks/use-editor-ai";
 import { useEditorTitle } from "@/hooks/use-editor-title";
 import { useProjectActions } from "@/hooks/use-project-actions";
 import { ProjectSwitcher } from "@/components/project-switcher";
+import { SettingsMenu } from "@/components/settings-menu";
 
 interface Chapter {
   id: string;
@@ -225,10 +226,8 @@ export default function EditorPage() {
   // Word count state (US-024)
   const [selectionWordCount, setSelectionWordCount] = useState(0);
 
-  // Settings menu and delete dialog state (US-023)
-  const [settingsMenuOpen, setSettingsMenuOpen] = useState(false);
+  // Delete dialog state (US-023)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
-  const settingsMenuRef = useRef<HTMLDivElement>(null);
 
   // Disconnect Drive dialog state (US-008)
   const [disconnectDriveDialogOpen, setDisconnectDriveDialogOpen] = useState(false);
@@ -346,34 +345,6 @@ export default function EditorPage() {
     };
   }, [activeChapterId, getToken, setContent]);
 
-  // Settings menu: close on outside click (US-023)
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (settingsMenuRef.current && !settingsMenuRef.current.contains(event.target as Node)) {
-        setSettingsMenuOpen(false);
-      }
-    }
-
-    if (settingsMenuOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-      return () => document.removeEventListener("mousedown", handleClickOutside);
-    }
-  }, [settingsMenuOpen]);
-
-  // Settings menu: close on Escape (US-023)
-  useEffect(() => {
-    function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === "Escape") {
-        setSettingsMenuOpen(false);
-      }
-    }
-
-    if (settingsMenuOpen) {
-      document.addEventListener("keydown", handleKeyDown);
-      return () => document.removeEventListener("keydown", handleKeyDown);
-    }
-  }, [settingsMenuOpen]);
-
   // Handle project deletion (US-023)
   const handleDeleteProject = useCallback(async () => {
     try {
@@ -416,9 +387,10 @@ export default function EditorPage() {
   const countWords = useCallback((html: string): number => {
     const text = html
       .replace(/<[^>]*>/g, " ")
+      .replace(/&nbsp;/g, " ")
       .replace(/\s+/g, " ")
       .trim();
-    return text ? text.split(" ").length : 0;
+    return text.length > 0 ? text.split(" ").length : 0;
   }, []);
 
   const currentWordCount = countWords(currentContent);
@@ -594,207 +566,18 @@ export default function EditorPage() {
             />
 
             {/* Settings dropdown menu (US-023) */}
-            <div className="relative" ref={settingsMenuRef}>
-              <button
-                onClick={() => setSettingsMenuOpen(!settingsMenuOpen)}
-                className="h-9 w-9 flex items-center justify-center rounded-lg hover:bg-gray-100 transition-colors"
-                aria-label="Settings"
-                aria-expanded={settingsMenuOpen}
-                aria-haspopup="true"
-              >
-                <svg
-                  className="w-5 h-5 text-muted-foreground"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                  />
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                  />
-                </svg>
-              </button>
-
-              {settingsMenuOpen && (
-                <div
-                  className="absolute right-0 top-full mt-1 w-52 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50"
-                  role="menu"
-                  aria-label="Project settings"
-                >
-                  {/* View Drive Files (US-007) - shown when Drive is connected and project has a folder */}
-                  {driveStatus?.connected && projectData?.driveFolderId && (
-                    <>
-                      <button
-                        onClick={() => {
-                          setSettingsMenuOpen(false);
-                          openDriveFiles();
-                        }}
-                        className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
-                                   transition-colors min-h-[44px] flex items-center gap-2"
-                        role="menuitem"
-                      >
-                        <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor">
-                          <path d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z" />
-                        </svg>
-                        View Drive Files
-                      </button>
-                      <div className="my-1 border-t border-gray-200" role="separator" />
-                    </>
-                  )}
-
-                  {/* Disconnect Google Drive (US-008) - only shown when connected */}
-                  {driveStatus?.connected && (
-                    <>
-                      <button
-                        onClick={() => {
-                          setSettingsMenuOpen(false);
-                          setDisconnectDriveDialogOpen(true);
-                        }}
-                        className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
-                                   transition-colors min-h-[44px] flex items-center gap-2"
-                        role="menuitem"
-                      >
-                        <svg
-                          className="w-4 h-4 shrink-0"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.59 6.59m7.532 7.532l3.29 3.29M3 3l18 18"
-                          />
-                        </svg>
-                        Disconnect Google Drive
-                      </button>
-                      <div className="my-1 border-t border-gray-200" role="separator" />
-                    </>
-                  )}
-
-                  {/* Rename Book */}
-                  <button
-                    onClick={() => {
-                      setSettingsMenuOpen(false);
-                      handleOpenRenameDialog();
-                    }}
-                    className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
-                               transition-colors min-h-[44px] flex items-center gap-2"
-                    role="menuitem"
-                  >
-                    <svg
-                      className="w-4 h-4 shrink-0"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                      />
-                    </svg>
-                    Rename Book
-                  </button>
-
-                  {/* Duplicate Book */}
-                  <button
-                    onClick={() => {
-                      setSettingsMenuOpen(false);
-                      openDuplicateDialog();
-                    }}
-                    disabled={isDuplicating}
-                    className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
-                               transition-colors min-h-[44px] flex items-center gap-2
-                               disabled:opacity-50 disabled:cursor-not-allowed"
-                    role="menuitem"
-                  >
-                    <svg
-                      className="w-4 h-4 shrink-0"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
-                      />
-                    </svg>
-                    {isDuplicating ? "Duplicating..." : "Duplicate Book"}
-                  </button>
-
-                  <div className="my-1 border-t border-gray-200" role="separator" />
-
-                  <button
-                    onClick={() => {
-                      setSettingsMenuOpen(false);
-                      setDeleteDialogOpen(true);
-                    }}
-                    className="w-full text-left px-4 py-2.5 text-sm text-red-600 hover:bg-red-50
-                               transition-colors min-h-[44px] flex items-center gap-2"
-                    role="menuitem"
-                  >
-                    <svg
-                      className="w-4 h-4 shrink-0"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                      />
-                    </svg>
-                    Delete Project
-                  </button>
-
-                  {/* Separator */}
-                  <div className="my-1 border-t border-gray-200" role="separator" />
-
-                  {/* Sign out (US-003) */}
-                  <button
-                    onClick={() => {
-                      setSettingsMenuOpen(false);
-                      handleSignOut();
-                    }}
-                    disabled={isSigningOut}
-                    className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
-                               transition-colors min-h-[44px] flex items-center gap-2
-                               disabled:opacity-50 disabled:cursor-not-allowed"
-                    role="menuitem"
-                  >
-                    <svg
-                      className="w-4 h-4 shrink-0"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-                      />
-                    </svg>
-                    {isSigningOut ? "Signing out\u2026" : "Sign Out"}
-                  </button>
-                </div>
-              )}
-            </div>
+            <SettingsMenu
+              driveConnected={driveStatus?.connected ?? false}
+              hasDriveFolder={!!projectData?.driveFolderId}
+              onViewDriveFiles={openDriveFiles}
+              onDisconnectDrive={() => setDisconnectDriveDialogOpen(true)}
+              onRenameBook={handleOpenRenameDialog}
+              onDuplicateBook={openDuplicateDialog}
+              isDuplicating={isDuplicating}
+              onDeleteProject={() => setDeleteDialogOpen(true)}
+              onSignOut={handleSignOut}
+              isSigningOut={isSigningOut}
+            />
           </div>
         </div>
 

--- a/web/src/components/settings-menu.tsx
+++ b/web/src/components/settings-menu.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useState, useRef, useEffect, useCallback } from "react";
+
+interface SettingsMenuProps {
+  /** Whether Google Drive is connected */
+  driveConnected: boolean;
+  /** Whether the project has a Drive folder linked */
+  hasDriveFolder: boolean;
+  /** Open Drive files sheet */
+  onViewDriveFiles: () => void;
+  /** Open disconnect Drive dialog */
+  onDisconnectDrive: () => void;
+  /** Open rename book dialog */
+  onRenameBook: () => void;
+  /** Open duplicate book dialog */
+  onDuplicateBook: () => void;
+  /** Whether a duplication is in progress */
+  isDuplicating: boolean;
+  /** Open delete project dialog */
+  onDeleteProject: () => void;
+  /** Sign out handler */
+  onSignOut: () => void;
+  /** Whether sign-out is in progress */
+  isSigningOut: boolean;
+}
+
+/**
+ * SettingsMenu - Settings dropdown for the editor toolbar.
+ *
+ * Per US-023: project-level settings accessible from the toolbar.
+ * Includes Drive management, rename, duplicate, delete, and sign out.
+ * iPad-first: 44pt touch targets.
+ */
+export function SettingsMenu({
+  driveConnected,
+  hasDriveFolder,
+  onViewDriveFiles,
+  onDisconnectDrive,
+  onRenameBook,
+  onDuplicateBook,
+  isDuplicating,
+  onDeleteProject,
+  onSignOut,
+  isSigningOut,
+}: SettingsMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click (US-023)
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      return () => document.removeEventListener("mousedown", handleClickOutside);
+    }
+  }, [isOpen]);
+
+  // Close on Escape (US-023)
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      return () => document.removeEventListener("keydown", handleKeyDown);
+    }
+  }, [isOpen]);
+
+  const handleMenuItem = useCallback((action: () => void) => {
+    setIsOpen(false);
+    action();
+  }, []);
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="h-9 w-9 flex items-center justify-center rounded-lg hover:bg-gray-100 transition-colors"
+        aria-label="Settings"
+        aria-expanded={isOpen}
+        aria-haspopup="true"
+      >
+        <svg
+          className="w-5 h-5 text-muted-foreground"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+          />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute right-0 top-full mt-1 w-52 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50"
+          role="menu"
+          aria-label="Project settings"
+        >
+          {/* View Drive Files (US-007) - shown when Drive is connected and project has a folder */}
+          {driveConnected && hasDriveFolder && (
+            <>
+              <button
+                onClick={() => handleMenuItem(onViewDriveFiles)}
+                className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                           transition-colors min-h-[44px] flex items-center gap-2"
+                role="menuitem"
+              >
+                <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z" />
+                </svg>
+                View Drive Files
+              </button>
+              <div className="my-1 border-t border-gray-200" role="separator" />
+            </>
+          )}
+
+          {/* Disconnect Google Drive (US-008) - only shown when connected */}
+          {driveConnected && (
+            <>
+              <button
+                onClick={() => handleMenuItem(onDisconnectDrive)}
+                className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                           transition-colors min-h-[44px] flex items-center gap-2"
+                role="menuitem"
+              >
+                <svg
+                  className="w-4 h-4 shrink-0"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.59 6.59m7.532 7.532l3.29 3.29M3 3l18 18"
+                  />
+                </svg>
+                Disconnect Google Drive
+              </button>
+              <div className="my-1 border-t border-gray-200" role="separator" />
+            </>
+          )}
+
+          {/* Rename Book */}
+          <button
+            onClick={() => handleMenuItem(onRenameBook)}
+            className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                       transition-colors min-h-[44px] flex items-center gap-2"
+            role="menuitem"
+          >
+            <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+              />
+            </svg>
+            Rename Book
+          </button>
+
+          {/* Duplicate Book */}
+          <button
+            onClick={() => handleMenuItem(onDuplicateBook)}
+            disabled={isDuplicating}
+            className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                       transition-colors min-h-[44px] flex items-center gap-2
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+            role="menuitem"
+          >
+            <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+              />
+            </svg>
+            {isDuplicating ? "Duplicating..." : "Duplicate Book"}
+          </button>
+
+          <div className="my-1 border-t border-gray-200" role="separator" />
+
+          <button
+            onClick={() => handleMenuItem(onDeleteProject)}
+            className="w-full text-left px-4 py-2.5 text-sm text-red-600 hover:bg-red-50
+                       transition-colors min-h-[44px] flex items-center gap-2"
+            role="menuitem"
+          >
+            <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+            Delete Project
+          </button>
+
+          {/* Separator */}
+          <div className="my-1 border-t border-gray-200" role="separator" />
+
+          {/* Sign out (US-003) */}
+          <button
+            onClick={() => handleMenuItem(onSignOut)}
+            disabled={isSigningOut}
+            className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                       transition-colors min-h-[44px] flex items-center gap-2
+                       disabled:opacity-50 disabled:cursor-not-allowed"
+            role="menuitem"
+          >
+            <svg className="w-4 h-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+              />
+            </svg>
+            {isSigningOut ? "Signing out\u2026" : "Sign Out"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/test/hooks/use-ai-rewrite.test.ts
+++ b/web/test/hooks/use-ai-rewrite.test.ts
@@ -1,0 +1,491 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAIRewrite } from "@/hooks/use-ai-rewrite";
+import type { AIRewriteResult } from "@/components/ai-rewrite-sheet";
+
+/**
+ * Tests for useAIRewrite — the AI rewrite state machine hook.
+ *
+ * State machine: idle -> streaming -> complete
+ *
+ * The hook manages:
+ * - Sheet open/close state
+ * - Streaming token accumulation
+ * - Accept/reject/retry/discard actions
+ * - API logging of interactions (fire-and-forget)
+ */
+
+function makeOptions(overrides?: Partial<Parameters<typeof useAIRewrite>[0]>) {
+  return {
+    getToken: vi.fn().mockResolvedValue("test-token"),
+    apiUrl: "https://api.test",
+    ...overrides,
+  };
+}
+
+function makeResult(overrides?: Partial<AIRewriteResult>): AIRewriteResult {
+  return {
+    interactionId: "int-123",
+    originalText: "The quick brown fox",
+    rewriteText: "A swift auburn fox",
+    instruction: "Make it more vivid",
+    attemptNumber: 1,
+    tier: "frontier",
+    ...overrides,
+  };
+}
+
+describe("useAIRewrite", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    global.fetch = vi.fn().mockResolvedValue({ ok: true });
+  });
+
+  // ────────────────────────────────────────────
+  // Initial state
+  // ────────────────────────────────────────────
+
+  it("starts in idle state with no result or error", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    expect(result.current.sheetState).toBe("idle");
+    expect(result.current.currentResult).toBeNull();
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  // ────────────────────────────────────────────
+  // State transitions: idle -> streaming -> complete
+  // ────────────────────────────────────────────
+
+  it("transitions from idle to streaming on startStreaming", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Original text", "Simplify this", "edge");
+    });
+
+    expect(result.current.sheetState).toBe("streaming");
+    expect(result.current.currentResult).not.toBeNull();
+    expect(result.current.currentResult!.originalText).toBe("Original text");
+    expect(result.current.currentResult!.instruction).toBe("Simplify this");
+    expect(result.current.currentResult!.tier).toBe("edge");
+    expect(result.current.currentResult!.rewriteText).toBe("");
+    expect(result.current.currentResult!.interactionId).toBe("");
+    expect(result.current.currentResult!.attemptNumber).toBe(0);
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it("accumulates tokens during streaming via appendToken", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Original", "Rewrite", "frontier");
+    });
+
+    act(() => {
+      result.current.appendToken("A ");
+    });
+    expect(result.current.currentResult!.rewriteText).toBe("A ");
+
+    act(() => {
+      result.current.appendToken("swift ");
+    });
+    expect(result.current.currentResult!.rewriteText).toBe("A swift ");
+
+    act(() => {
+      result.current.appendToken("fox");
+    });
+    expect(result.current.currentResult!.rewriteText).toBe("A swift fox");
+  });
+
+  it("transitions from streaming to complete on completeStreaming", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Original", "Rewrite", "frontier");
+    });
+    act(() => {
+      result.current.appendToken("Final text");
+    });
+    act(() => {
+      result.current.completeStreaming("int-456", 1);
+    });
+
+    expect(result.current.sheetState).toBe("complete");
+    expect(result.current.currentResult!.interactionId).toBe("int-456");
+    expect(result.current.currentResult!.attemptNumber).toBe(1);
+    expect(result.current.currentResult!.rewriteText).toBe("Final text");
+  });
+
+  it("full lifecycle: idle -> streaming -> complete -> idle (accept)", async () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    // idle
+    expect(result.current.sheetState).toBe("idle");
+
+    // idle -> streaming
+    act(() => {
+      result.current.startStreaming("Original text", "Fix grammar", "edge");
+    });
+    expect(result.current.sheetState).toBe("streaming");
+
+    // streaming: accumulate tokens
+    act(() => {
+      result.current.appendToken("Corrected text");
+    });
+
+    // streaming -> complete
+    act(() => {
+      result.current.completeStreaming("int-789", 1);
+    });
+    expect(result.current.sheetState).toBe("complete");
+
+    // complete -> idle (accept)
+    const accepted = result.current.currentResult!;
+    await act(async () => {
+      await result.current.handleAccept(accepted);
+    });
+    expect(result.current.sheetState).toBe("idle");
+    expect(result.current.currentResult).toBeNull();
+  });
+
+  // ────────────────────────────────────────────
+  // Reset / discard
+  // ────────────────────────────────────────────
+
+  it("closeSheet resets all state to idle", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Text", "Instruction", "frontier");
+    });
+    act(() => {
+      result.current.appendToken("Some tokens");
+    });
+
+    expect(result.current.sheetState).toBe("streaming");
+
+    act(() => {
+      result.current.closeSheet();
+    });
+
+    expect(result.current.sheetState).toBe("idle");
+    expect(result.current.currentResult).toBeNull();
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.hasTokens()).toBe(false);
+  });
+
+  it("handleDiscard logs rejection and resets to idle", async () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    const resultData = makeResult();
+
+    await act(async () => {
+      await result.current.handleDiscard(resultData);
+    });
+
+    // Should have called the reject API
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.test/ai/interactions/int-123/reject",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+
+    expect(result.current.sheetState).toBe("idle");
+    expect(result.current.currentResult).toBeNull();
+  });
+
+  it("handleDiscard skips API call when interactionId is empty", async () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    const resultData = makeResult({ interactionId: "" });
+
+    await act(async () => {
+      await result.current.handleDiscard(resultData);
+    });
+
+    // logInteraction should bail out for empty interactionId
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.sheetState).toBe("idle");
+  });
+
+  // ────────────────────────────────────────────
+  // Error state handling
+  // ────────────────────────────────────────────
+
+  it("abortStreaming with error message and partial tokens shows error inline", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Text", "Instruction", "frontier");
+    });
+    act(() => {
+      result.current.appendToken("Partial output");
+    });
+    act(() => {
+      result.current.abortStreaming("Stream interrupted");
+    });
+
+    expect(result.current.sheetState).toBe("complete");
+    expect(result.current.errorMessage).toBe("Stream interrupted");
+    // Partial text should still be available in the result
+    expect(result.current.currentResult).not.toBeNull();
+  });
+
+  it("abortStreaming with error message and no tokens shows error then complete", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Text", "Instruction", "frontier");
+    });
+
+    // No tokens appended
+    act(() => {
+      result.current.abortStreaming("Connection failed");
+    });
+
+    expect(result.current.sheetState).toBe("complete");
+    expect(result.current.errorMessage).toBe("Connection failed");
+  });
+
+  it("abortStreaming without error message (user cancel) resets to idle", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Text", "Instruction", "frontier");
+    });
+    act(() => {
+      result.current.appendToken("Some text");
+    });
+
+    // User cancels — no error message
+    act(() => {
+      result.current.abortStreaming();
+    });
+
+    expect(result.current.sheetState).toBe("idle");
+    expect(result.current.currentResult).toBeNull();
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  // ────────────────────────────────────────────
+  // Accept / reject / retry
+  // ────────────────────────────────────────────
+
+  it("handleAccept logs acceptance and returns the result", async () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    const rewriteResult = makeResult();
+
+    let returnedResult: AIRewriteResult | undefined;
+    await act(async () => {
+      returnedResult = await result.current.handleAccept(rewriteResult);
+    });
+
+    expect(returnedResult).toEqual(rewriteResult);
+
+    // Should have called the accept API endpoint
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.test/ai/interactions/int-123/accept",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      }),
+    );
+
+    // Sheet should be closed
+    expect(result.current.sheetState).toBe("idle");
+  });
+
+  it("handleRetry logs rejection for the current result", async () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    const rewriteResult = makeResult();
+
+    await act(async () => {
+      await result.current.handleRetry(rewriteResult, "Try a different approach");
+    });
+
+    // Should have called the reject API endpoint
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.test/ai/interactions/int-123/reject",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+
+  it("handleAccept does not crash when API logging fails", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    const rewriteResult = makeResult();
+
+    let returnedResult: AIRewriteResult | undefined;
+    await act(async () => {
+      returnedResult = await result.current.handleAccept(rewriteResult);
+    });
+
+    // Accept should still return the result and close the sheet
+    expect(returnedResult).toEqual(rewriteResult);
+    expect(result.current.sheetState).toBe("idle");
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  // ────────────────────────────────────────────
+  // setTier
+  // ────────────────────────────────────────────
+
+  it("setTier updates the tier on the current result", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Text", "Instruction", "edge");
+    });
+    expect(result.current.currentResult!.tier).toBe("edge");
+
+    act(() => {
+      result.current.setTier("frontier");
+    });
+    expect(result.current.currentResult!.tier).toBe("frontier");
+  });
+
+  it("setTier is a no-op when there is no current result", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    // Should not throw
+    act(() => {
+      result.current.setTier("frontier");
+    });
+
+    expect(result.current.currentResult).toBeNull();
+  });
+
+  // ────────────────────────────────────────────
+  // hasTokens
+  // ────────────────────────────────────────────
+
+  it("hasTokens returns false before any tokens are appended", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    expect(result.current.hasTokens()).toBe(false);
+  });
+
+  it("hasTokens returns true after tokens are appended", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Text", "Instruction", "frontier");
+    });
+    act(() => {
+      result.current.appendToken("token");
+    });
+
+    expect(result.current.hasTokens()).toBe(true);
+  });
+
+  it("hasTokens returns false after closeSheet resets state", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    act(() => {
+      result.current.startStreaming("Text", "Instruction", "frontier");
+    });
+    act(() => {
+      result.current.appendToken("token");
+    });
+    act(() => {
+      result.current.closeSheet();
+    });
+
+    expect(result.current.hasTokens()).toBe(false);
+  });
+
+  // ────────────────────────────────────────────
+  // startStreaming clears previous error state
+  // ────────────────────────────────────────────
+
+  it("startStreaming clears any previous error message", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    // Create an error state
+    act(() => {
+      result.current.startStreaming("Text", "Instruction", "frontier");
+    });
+    act(() => {
+      result.current.abortStreaming("Something went wrong");
+    });
+    expect(result.current.errorMessage).toBe("Something went wrong");
+
+    // Start a new streaming session
+    act(() => {
+      result.current.startStreaming("New text", "New instruction", "edge");
+    });
+
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.sheetState).toBe("streaming");
+    expect(result.current.currentResult!.originalText).toBe("New text");
+  });
+
+  // ────────────────────────────────────────────
+  // Token accumulation resets between sessions
+  // ────────────────────────────────────────────
+
+  it("tokens from a previous session do not leak into a new session", () => {
+    const { result } = renderHook(() => useAIRewrite(makeOptions()));
+
+    // Session 1
+    act(() => {
+      result.current.startStreaming("Text 1", "Instr 1", "frontier");
+    });
+    act(() => {
+      result.current.appendToken("Old tokens");
+    });
+    act(() => {
+      result.current.closeSheet();
+    });
+
+    // Session 2
+    act(() => {
+      result.current.startStreaming("Text 2", "Instr 2", "edge");
+    });
+
+    // The rewriteText should be empty, not carry over "Old tokens"
+    expect(result.current.currentResult!.rewriteText).toBe("");
+
+    // Append new tokens
+    act(() => {
+      result.current.appendToken("New tokens");
+    });
+    expect(result.current.currentResult!.rewriteText).toBe("New tokens");
+  });
+
+  // ────────────────────────────────────────────
+  // getToken failure does not crash logging
+  // ────────────────────────────────────────────
+
+  it("handleAccept does not crash when getToken returns null", async () => {
+    const { result } = renderHook(() =>
+      useAIRewrite(makeOptions({ getToken: vi.fn().mockResolvedValue(null) })),
+    );
+
+    const rewriteResult = makeResult();
+
+    let returnedResult: AIRewriteResult | undefined;
+    await act(async () => {
+      returnedResult = await result.current.handleAccept(rewriteResult);
+    });
+
+    // Should return the result and close sheet even when token is null
+    expect(returnedResult).toEqual(rewriteResult);
+    expect(result.current.sheetState).toBe("idle");
+    // fetch should not have been called because getToken returned null
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/web/test/hooks/use-auto-save.test.ts
+++ b/web/test/hooks/use-auto-save.test.ts
@@ -1,0 +1,520 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+/**
+ * Tests for useAutoSave — the three-tier auto-save hook.
+ *
+ * Tier 1: IndexedDB on every keystroke
+ * Tier 2: API save with 2s debounce
+ * Tier 3: D1 metadata (server-side, not tested here)
+ *
+ * We mock @/lib/indexeddb entirely because IndexedDB's internal async
+ * operations deadlock under vi.useFakeTimers(). The IndexedDB layer
+ * has its own dedicated test suite (test/lib/indexeddb.test.ts).
+ */
+
+// Mock the IndexedDB module before importing the hook
+const mockSaveDraft = vi.fn().mockResolvedValue(undefined);
+const mockLoadDraft = vi.fn().mockResolvedValue(null);
+const mockDeleteDraft = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("@/lib/indexeddb", () => ({
+  saveDraft: (...args: unknown[]) => mockSaveDraft(...args),
+  loadDraft: (...args: unknown[]) => mockLoadDraft(...args),
+  deleteDraft: (...args: unknown[]) => mockDeleteDraft(...args),
+  clearAllDrafts: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { useAutoSave } from "@/hooks/use-auto-save";
+
+function makeOptions(overrides?: Partial<Parameters<typeof useAutoSave>[0]>) {
+  return {
+    chapterId: "ch-1",
+    version: 1,
+    getToken: vi.fn().mockResolvedValue("test-token"),
+    apiUrl: "https://api.test",
+    debounceMs: 2000,
+    maxRetries: 3,
+    ...overrides,
+  };
+}
+
+function mockFetchSuccess(version = 2, wordCount = 10) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () =>
+      Promise.resolve({
+        version,
+        wordCount,
+        updatedAt: new Date().toISOString(),
+      }),
+  });
+}
+
+function mockFetchConflict() {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 409,
+    json: () => Promise.resolve({ error: "Version conflict" }),
+  });
+}
+
+describe("useAutoSave", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockSaveDraft.mockClear().mockResolvedValue(undefined);
+    mockLoadDraft.mockClear().mockResolvedValue(null);
+    mockDeleteDraft.mockClear().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("starts with idle save status", () => {
+    mockFetchSuccess();
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    expect(result.current.saveStatus).toEqual({ state: "idle" });
+    expect(result.current.content).toBe("");
+    expect(result.current.currentVersion).toBe(1);
+  });
+
+  it("does not save when content has not changed (saveNow with no content)", async () => {
+    mockFetchSuccess();
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    // fetch should not be called because content is empty
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(result.current.saveStatus).toEqual({ state: "idle" });
+  });
+
+  it("saves after debounce interval when content changes", async () => {
+    mockFetchSuccess(2, 15);
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    // Simulate a content change (keystroke)
+    act(() => {
+      result.current.handleContentChange("<p>Hello world</p>");
+    });
+
+    // Before debounce fires, fetch should not be called
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    // Advance past the debounce interval (2000ms)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.test/chapters/ch-1/content",
+      expect.objectContaining({
+        method: "PUT",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-token",
+          "Content-Type": "application/json",
+        }),
+        body: JSON.stringify({ content: "<p>Hello world</p>", version: 1 }),
+      }),
+    );
+
+    expect(result.current.saveStatus.state).toBe("saved");
+    expect(result.current.currentVersion).toBe(2);
+  });
+
+  it("writes to IndexedDB immediately on content change (Tier 1)", () => {
+    mockFetchSuccess();
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    act(() => {
+      result.current.handleContentChange("<p>Draft text</p>");
+    });
+
+    // saveDraft should be called synchronously with the content
+    expect(mockSaveDraft).toHaveBeenCalledWith({
+      chapterId: "ch-1",
+      content: "<p>Draft text</p>",
+      updatedAt: expect.any(Number),
+      version: 1,
+    });
+  });
+
+  it("handles version conflict (409) by entering error state", async () => {
+    // On 409, saveToApi sets "Version conflict" status, then executeSave
+    // overwrites with "Save failed — retrying" since success is false.
+    // The final observable state is the error from executeSave.
+    mockFetchConflict();
+    const { result } = renderHook(() => useAutoSave(makeOptions({ maxRetries: 0 })));
+
+    act(() => {
+      result.current.setContent("<p>Some content</p>");
+    });
+
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    expect(result.current.saveStatus.state).toBe("error");
+  });
+
+  it("handles network errors gracefully without crashing", async () => {
+    // fetch rejects entirely (network error)
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network failure"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAutoSave(makeOptions({ maxRetries: 0 })));
+
+    act(() => {
+      result.current.setContent("<p>Content</p>");
+    });
+
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    // The hook should not throw; it should set error status
+    expect(result.current.saveStatus.state).toBe("error");
+  });
+
+  it("updates currentVersion after successful save", async () => {
+    mockFetchSuccess(5, 42);
+    const { result } = renderHook(() => useAutoSave(makeOptions({ version: 1 })));
+
+    expect(result.current.currentVersion).toBe(1);
+
+    act(() => {
+      result.current.setContent("<p>New content</p>");
+    });
+
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    expect(result.current.currentVersion).toBe(5);
+  });
+
+  it("cancels debounce timer on saveNow and saves immediately", async () => {
+    mockFetchSuccess();
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    // Start content change (sets debounce timer)
+    act(() => {
+      result.current.handleContentChange("<p>Typing...</p>");
+    });
+
+    // saveNow should cancel debounce and save immediately
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    // Advancing timers past the debounce should not trigger another save
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets content via setContent without triggering a save", async () => {
+    mockFetchSuccess();
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    act(() => {
+      result.current.setContent("<p>Loaded from server</p>");
+    });
+
+    expect(result.current.content).toBe("<p>Loaded from server</p>");
+
+    // Advance timers — no save should be triggered by setContent alone
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not save when chapterId is null", async () => {
+    mockFetchSuccess();
+    const { result } = renderHook(() => useAutoSave(makeOptions({ chapterId: null })));
+
+    act(() => {
+      result.current.handleContentChange("<p>No chapter</p>");
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    // fetch should not be called when there is no chapterId
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not call fetch when getToken returns null", async () => {
+    mockFetchSuccess();
+    const { result } = renderHook(() =>
+      useAutoSave(
+        makeOptions({
+          getToken: vi.fn().mockResolvedValue(null),
+          maxRetries: 0,
+        }),
+      ),
+    );
+
+    act(() => {
+      result.current.setContent("<p>Content</p>");
+    });
+
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    // fetch should not be called when token is null
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("clears IndexedDB draft after successful remote save", async () => {
+    mockFetchSuccess();
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    act(() => {
+      result.current.setContent("<p>Draft</p>");
+    });
+
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    // After successful remote save, deleteDraft should be called
+    expect(mockDeleteDraft).toHaveBeenCalledWith("ch-1");
+  });
+
+  it("retries on API failure with exponential backoff", async () => {
+    // First two calls fail, third succeeds
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      callCount++;
+      if (callCount <= 2) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          json: () => Promise.resolve({ error: "Server error" }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({
+            version: 2,
+            wordCount: 5,
+            updatedAt: new Date().toISOString(),
+          }),
+      });
+    });
+
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderHook(() => useAutoSave(makeOptions({ maxRetries: 3 })));
+
+    act(() => {
+      result.current.setContent("<p>Retry content</p>");
+    });
+
+    // Start the save — don't await, the retries use setTimeout internally
+    act(() => {
+      result.current.saveNow();
+    });
+
+    // Allow the initial save attempt to complete
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Retry 1 backoff: 1s
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    // Retry 2 backoff: 2s
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    // Allow final microtasks to settle
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Should have called fetch multiple times (initial + retries)
+    expect(callCount).toBeGreaterThanOrEqual(3);
+    expect(result.current.saveStatus.state).toBe("saved");
+  });
+
+  it("debounce resets on rapid content changes", async () => {
+    mockFetchSuccess();
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    // Type rapidly — each call resets the debounce
+    act(() => {
+      result.current.handleContentChange("<p>H</p>");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    act(() => {
+      result.current.handleContentChange("<p>He</p>");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    act(() => {
+      result.current.handleContentChange("<p>Hel</p>");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    act(() => {
+      result.current.handleContentChange("<p>Hell</p>");
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    act(() => {
+      result.current.handleContentChange("<p>Hello</p>");
+    });
+
+    // No save should have happened yet (debounce kept resetting)
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    // Now advance 2 full seconds from last change
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    // Should save only once, with the final content
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      "https://api.test/chapters/ch-1/content",
+      expect.objectContaining({
+        body: JSON.stringify({ content: "<p>Hello</p>", version: 1 }),
+      }),
+    );
+  });
+
+  it("recovery prompt is set when IndexedDB has a draft", async () => {
+    mockFetchSuccess();
+    mockLoadDraft.mockResolvedValue({
+      chapterId: "ch-1",
+      content: "<p>Recovered content</p>",
+      updatedAt: Date.now(),
+      version: 1,
+    });
+
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    // Wait for the recovery check useEffect to run
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.recoveryPrompt).not.toBeNull();
+    expect(result.current.recoveryPrompt!.localContent).toBe("<p>Recovered content</p>");
+    expect(result.current.recoveryPrompt!.remoteVersion).toBe(1);
+  });
+
+  it("dismissRecovery clears the prompt and deletes draft from IndexedDB", async () => {
+    mockFetchSuccess();
+    mockLoadDraft.mockResolvedValue({
+      chapterId: "ch-1",
+      content: "<p>Recovered content</p>",
+      updatedAt: Date.now(),
+      version: 1,
+    });
+
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.recoveryPrompt).not.toBeNull();
+
+    act(() => {
+      result.current.dismissRecovery();
+    });
+
+    expect(result.current.recoveryPrompt).toBeNull();
+    expect(mockDeleteDraft).toHaveBeenCalledWith("ch-1");
+  });
+
+  it("acceptRecovery sets content and triggers a save", async () => {
+    mockFetchSuccess(2, 20);
+    mockLoadDraft.mockResolvedValue({
+      chapterId: "ch-1",
+      content: "<p>Recovered content</p>",
+      updatedAt: Date.now(),
+      version: 1,
+    });
+
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.recoveryPrompt).not.toBeNull();
+
+    await act(async () => {
+      result.current.acceptRecovery();
+    });
+
+    expect(result.current.recoveryPrompt).toBeNull();
+    expect(result.current.content).toBe("<p>Recovered content</p>");
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  it("no recovery prompt when IndexedDB has no draft", async () => {
+    mockFetchSuccess();
+    mockLoadDraft.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useAutoSave(makeOptions()));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.recoveryPrompt).toBeNull();
+  });
+
+  it("sends version in API save body for optimistic concurrency", async () => {
+    mockFetchSuccess(8, 10);
+    const { result } = renderHook(() => useAutoSave(makeOptions({ version: 7 })));
+
+    act(() => {
+      result.current.setContent("<p>Content</p>");
+    });
+
+    await act(async () => {
+      await result.current.saveNow();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: JSON.stringify({ content: "<p>Content</p>", version: 7 }),
+      }),
+    );
+  });
+});

--- a/workers/dc-api/test/ai-interaction.test.ts
+++ b/workers/dc-api/test/ai-interaction.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { AIInteractionService } from "../src/services/ai-interaction.js";
+import { seedUser, seedProject, seedChapter, cleanAll } from "./helpers/seed.js";
+import { ulid } from "ulidx";
+
+/**
+ * Seed an ai_interactions row directly in D1.
+ * Returns the row's id for use in tests.
+ */
+async function seedAIInteraction(
+  userId: string,
+  chapterId: string,
+  overrides?: {
+    id?: string;
+    instruction?: string;
+    accepted?: number | null;
+    parentInteractionId?: string | null;
+    attemptNumber?: number;
+  },
+): Promise<{ id: string }> {
+  const id = overrides?.id ?? ulid();
+  const instruction = overrides?.instruction ?? "Make it concise";
+  const accepted = overrides?.accepted ?? null;
+  const parentInteractionId = overrides?.parentInteractionId ?? null;
+  const attemptNumber = overrides?.attemptNumber ?? 1;
+
+  await env.DB.prepare(
+    `INSERT INTO ai_interactions (id, user_id, chapter_id, action, instruction, input_chars, output_chars, model, latency_ms, accepted, attempt_number, parent_interaction_id, tier, created_at)
+     VALUES (?, ?, ?, 'rewrite', ?, 150, 120, 'gpt-4o', 1200, ?, ?, ?, 'frontier', strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))`,
+  )
+    .bind(id, userId, chapterId, instruction, accepted, attemptNumber, parentInteractionId)
+    .run();
+
+  return { id };
+}
+
+describe("AIInteractionService", () => {
+  let service: AIInteractionService;
+  let userId: string;
+  let chapterId: string;
+  let interactionId: string;
+
+  beforeEach(async () => {
+    // Clean all tables in proper FK order
+    await env.DB.exec(`
+      DELETE FROM ai_interactions;
+      DELETE FROM export_jobs;
+      DELETE FROM chapters;
+      DELETE FROM projects;
+      DELETE FROM users;
+    `);
+
+    service = new AIInteractionService(env.DB);
+
+    // Seed prerequisite data
+    const user = await seedUser();
+    userId = user.id;
+    const project = await seedProject(userId);
+    const chapter = await seedChapter(project.id);
+    chapterId = chapter.id;
+
+    // Seed an ai_interaction row
+    const interaction = await seedAIInteraction(userId, chapterId);
+    interactionId = interaction.id;
+  });
+
+  describe("acceptInteraction", () => {
+    it("sets accepted = true and returns mapped interaction", async () => {
+      const result = await service.acceptInteraction(userId, interactionId);
+
+      expect(result.id).toBe(interactionId);
+      expect(result.accepted).toBe(true);
+      expect(result.userId).toBe(userId);
+      expect(result.chapterId).toBe(chapterId);
+      expect(result.action).toBe("rewrite");
+      expect(result.instruction).toBe("Make it concise");
+      expect(result.inputChars).toBe(150);
+      expect(result.outputChars).toBe(120);
+      expect(result.model).toBe("gpt-4o");
+      expect(result.latencyMs).toBe(1200);
+      expect(result.attemptNumber).toBe(1);
+      expect(result.parentInteractionId).toBeNull();
+      expect(result.tier).toBe("frontier");
+
+      // Verify persisted in D1
+      const row = await env.DB.prepare(`SELECT accepted FROM ai_interactions WHERE id = ?`)
+        .bind(interactionId)
+        .first<{ accepted: number | null }>();
+      expect(row!.accepted).toBe(1);
+    });
+
+    it("can accept an interaction that was previously null", async () => {
+      // Verify it starts as null
+      const before = await env.DB.prepare(`SELECT accepted FROM ai_interactions WHERE id = ?`)
+        .bind(interactionId)
+        .first<{ accepted: number | null }>();
+      expect(before!.accepted).toBeNull();
+
+      const result = await service.acceptInteraction(userId, interactionId);
+      expect(result.accepted).toBe(true);
+    });
+  });
+
+  describe("rejectInteraction", () => {
+    it("sets accepted = false and returns mapped interaction", async () => {
+      const result = await service.rejectInteraction(userId, interactionId);
+
+      expect(result.id).toBe(interactionId);
+      expect(result.accepted).toBe(false);
+      expect(result.userId).toBe(userId);
+      expect(result.chapterId).toBe(chapterId);
+      expect(result.action).toBe("rewrite");
+
+      // Verify persisted in D1
+      const row = await env.DB.prepare(`SELECT accepted FROM ai_interactions WHERE id = ?`)
+        .bind(interactionId)
+        .first<{ accepted: number | null }>();
+      expect(row!.accepted).toBe(0);
+    });
+  });
+
+  describe("ownership check", () => {
+    it("throws NOT_FOUND for another user's interaction", async () => {
+      const other = await seedUser({ id: "other-user" });
+
+      await expect(service.acceptInteraction(other.id, interactionId)).rejects.toThrow(
+        "AI interaction not found",
+      );
+
+      await expect(service.rejectInteraction(other.id, interactionId)).rejects.toThrow(
+        "AI interaction not found",
+      );
+    });
+  });
+
+  describe("NOT_FOUND", () => {
+    it("throws for non-existent interaction ID on accept", async () => {
+      await expect(service.acceptInteraction(userId, "nonexistent-id")).rejects.toThrow(
+        "AI interaction not found",
+      );
+    });
+
+    it("throws for non-existent interaction ID on reject", async () => {
+      await expect(service.rejectInteraction(userId, "nonexistent-id")).rejects.toThrow(
+        "AI interaction not found",
+      );
+    });
+  });
+
+  describe("retry chain mapping", () => {
+    it("correctly maps parentInteractionId for retry interactions", async () => {
+      // Seed a child interaction with parent
+      const child = await seedAIInteraction(userId, chapterId, {
+        parentInteractionId: interactionId,
+        attemptNumber: 2,
+      });
+
+      const result = await service.acceptInteraction(userId, child.id);
+
+      expect(result.parentInteractionId).toBe(interactionId);
+      expect(result.attemptNumber).toBe(2);
+    });
+  });
+});

--- a/workers/dc-api/test/ai-rewrite.test.ts
+++ b/workers/dc-api/test/ai-rewrite.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { AIRewriteService, type RewriteInput } from "../src/services/ai-rewrite.js";
+import type { AIProvider, AIStreamEvent } from "../src/services/ai-provider.js";
+import { seedUser, seedProject, seedChapter, cleanAll } from "./helpers/seed.js";
+
+/**
+ * Mock AIProvider that returns a simple ReadableStream of AIStreamEvents.
+ * Allows tests to verify the service's stream-wrapping and D1 interaction
+ * logging without calling a real AI API.
+ */
+const mockProvider: AIProvider = {
+  model: "test-model",
+  async streamCompletion() {
+    return new ReadableStream<AIStreamEvent>({
+      start(controller) {
+        controller.enqueue({ type: "token", text: "Hello " });
+        controller.enqueue({ type: "token", text: "world" });
+        controller.enqueue({ type: "done" });
+        controller.close();
+      },
+    });
+  },
+};
+
+/**
+ * Helper to build a valid RewriteInput with sensible defaults.
+ */
+function validInput(overrides?: Partial<RewriteInput>): RewriteInput {
+  return {
+    selectedText: "Some text to rewrite",
+    instruction: "Make it better",
+    contextBefore: "Before context",
+    contextAfter: "After context",
+    chapterTitle: "Chapter One",
+    projectDescription: "A test book",
+    chapterId: "test-chapter-id",
+    ...overrides,
+  };
+}
+
+describe("AIRewriteService", () => {
+  let service: AIRewriteService;
+
+  beforeEach(async () => {
+    // Clean all tables including ai_interactions to avoid FK constraint issues
+    await env.DB.exec(`
+      DELETE FROM ai_interactions;
+      DELETE FROM export_jobs;
+      DELETE FROM chapters;
+      DELETE FROM projects;
+      DELETE FROM users;
+    `);
+    service = new AIRewriteService(env.DB, mockProvider);
+  });
+
+  describe("validateInput", () => {
+    it("returns null for valid input", () => {
+      const result = service.validateInput(validInput());
+      expect(result).toBeNull();
+    });
+
+    it("returns error for empty selectedText", () => {
+      const result = service.validateInput(validInput({ selectedText: "" }));
+      expect(result).toBe("Selected text is required");
+    });
+
+    it("returns error for whitespace-only selectedText", () => {
+      const result = service.validateInput(validInput({ selectedText: "   " }));
+      expect(result).toBe("Selected text is required");
+    });
+
+    it("returns error for selectedText over 10000 chars", () => {
+      const result = service.validateInput(validInput({ selectedText: "x".repeat(10001) }));
+      expect(result).toBe("Selected text must be at most 10000 characters");
+    });
+
+    it("returns null for selectedText exactly at 10000 chars", () => {
+      const result = service.validateInput(validInput({ selectedText: "x".repeat(10000) }));
+      expect(result).toBeNull();
+    });
+
+    it("returns error for empty instruction", () => {
+      const result = service.validateInput(validInput({ instruction: "" }));
+      expect(result).toBe("Instruction is required");
+    });
+
+    it("returns error for whitespace-only instruction", () => {
+      const result = service.validateInput(validInput({ instruction: "   " }));
+      expect(result).toBe("Instruction is required");
+    });
+
+    it("returns error for instruction over 500 chars", () => {
+      const result = service.validateInput(validInput({ instruction: "x".repeat(501) }));
+      expect(result).toBe("Instruction must be at most 500 characters");
+    });
+
+    it("returns null for instruction exactly at 500 chars", () => {
+      const result = service.validateInput(validInput({ instruction: "x".repeat(500) }));
+      expect(result).toBeNull();
+    });
+
+    it("returns error for empty chapterId", () => {
+      const result = service.validateInput(validInput({ chapterId: "" }));
+      expect(result).toBe("Chapter ID is required");
+    });
+
+    it("returns error for whitespace-only chapterId", () => {
+      const result = service.validateInput(validInput({ chapterId: "   " }));
+      expect(result).toBe("Chapter ID is required");
+    });
+  });
+
+  describe("streamRewrite", () => {
+    let userId: string;
+    let chapterId: string;
+
+    beforeEach(async () => {
+      const user = await seedUser();
+      userId = user.id;
+      const project = await seedProject(userId);
+      const chapter = await seedChapter(project.id);
+      chapterId = chapter.id;
+    });
+
+    it("creates an interaction record in D1", async () => {
+      const input = validInput({ chapterId });
+
+      const { interactionId } = await service.streamRewrite(userId, input);
+
+      // Verify the row was created
+      const row = await env.DB.prepare(
+        `SELECT id, user_id, chapter_id, action, instruction, input_chars, model, attempt_number, tier
+         FROM ai_interactions WHERE id = ?`,
+      )
+        .bind(interactionId)
+        .first<{
+          id: string;
+          user_id: string;
+          chapter_id: string;
+          action: string;
+          instruction: string;
+          input_chars: number;
+          model: string;
+          attempt_number: number;
+          tier: string;
+        }>();
+
+      expect(row).not.toBeNull();
+      expect(row!.id).toBe(interactionId);
+      expect(row!.user_id).toBe(userId);
+      expect(row!.chapter_id).toBe(chapterId);
+      expect(row!.action).toBe("rewrite");
+      expect(row!.instruction).toBe("Make it better");
+      expect(row!.input_chars).toBe(input.selectedText.length);
+      expect(row!.model).toBe("test-model");
+      expect(row!.attempt_number).toBe(1);
+      expect(row!.tier).toBe("frontier");
+    });
+
+    it("returns a stream with start event containing interactionId", async () => {
+      const input = validInput({ chapterId });
+
+      const { stream, interactionId } = await service.streamRewrite(userId, input);
+
+      // Read the SSE stream into text
+      const reader = stream.getReader();
+      const decoder = new TextDecoder();
+      let fullText = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        fullText += decoder.decode(value, { stream: true });
+      }
+
+      // Parse SSE events — each event is "data: {json}\n\n"
+      const events = fullText
+        .split("\n\n")
+        .filter((line) => line.startsWith("data: "))
+        .map((line) => JSON.parse(line.replace("data: ", "")));
+
+      expect(events.length).toBeGreaterThanOrEqual(3);
+
+      // First event: start with interactionId
+      expect(events[0].type).toBe("start");
+      expect(events[0].interactionId).toBe(interactionId);
+      expect(events[0].attemptNumber).toBe(1);
+      expect(events[0].tier).toBe("frontier");
+
+      // Token events
+      expect(events[1]).toEqual({ type: "token", text: "Hello " });
+      expect(events[2]).toEqual({ type: "token", text: "world" });
+
+      // Done event
+      expect(events[3].type).toBe("done");
+      expect(events[3].interactionId).toBe(interactionId);
+    });
+
+    it("increments attempt_number for retry chains", async () => {
+      const input = validInput({ chapterId });
+
+      // First interaction (the parent)
+      const first = await service.streamRewrite(userId, input);
+      // Consume the stream so the flush runs
+      await consumeStream(first.stream);
+
+      // Second interaction (retry of the first)
+      const retryInput = validInput({
+        chapterId,
+        parentInteractionId: first.interactionId,
+      });
+      const second = await service.streamRewrite(userId, retryInput);
+      await consumeStream(second.stream);
+
+      // Verify attempt numbers
+      const firstRow = await env.DB.prepare(
+        `SELECT attempt_number FROM ai_interactions WHERE id = ?`,
+      )
+        .bind(first.interactionId)
+        .first<{ attempt_number: number }>();
+      expect(firstRow!.attempt_number).toBe(1);
+
+      const secondRow = await env.DB.prepare(
+        `SELECT attempt_number, parent_interaction_id FROM ai_interactions WHERE id = ?`,
+      )
+        .bind(second.interactionId)
+        .first<{ attempt_number: number; parent_interaction_id: string }>();
+      expect(secondRow!.attempt_number).toBe(2);
+      expect(secondRow!.parent_interaction_id).toBe(first.interactionId);
+    });
+
+    it("records output_chars and latency_ms after stream completes", async () => {
+      const input = validInput({ chapterId });
+
+      const { stream, interactionId } = await service.streamRewrite(userId, input);
+
+      // Before consuming — output_chars should be 0
+      const before = await env.DB.prepare(
+        `SELECT output_chars, latency_ms FROM ai_interactions WHERE id = ?`,
+      )
+        .bind(interactionId)
+        .first<{ output_chars: number; latency_ms: number }>();
+      expect(before!.output_chars).toBe(0);
+      expect(before!.latency_ms).toBe(0);
+
+      // Consume stream to trigger the TransformStream flush
+      await consumeStream(stream);
+
+      // After consuming — output_chars should reflect "Hello world" = 11 chars
+      const after = await env.DB.prepare(
+        `SELECT output_chars, latency_ms FROM ai_interactions WHERE id = ?`,
+      )
+        .bind(interactionId)
+        .first<{ output_chars: number; latency_ms: number }>();
+      expect(after!.output_chars).toBe(11); // "Hello " (6) + "world" (5)
+      expect(after!.latency_ms).toBeGreaterThanOrEqual(0);
+    });
+
+    it("sets tier to 'edge' when specified in input", async () => {
+      const input = validInput({ chapterId, tier: "edge" });
+
+      const { interactionId } = await service.streamRewrite(userId, input);
+
+      const row = await env.DB.prepare(`SELECT tier FROM ai_interactions WHERE id = ?`)
+        .bind(interactionId)
+        .first<{ tier: string }>();
+      expect(row!.tier).toBe("edge");
+    });
+  });
+});
+
+/**
+ * Consume a ReadableStream fully, discarding all chunks.
+ * This triggers the TransformStream's flush() callback.
+ */
+async function consumeStream(stream: ReadableStream<Uint8Array>): Promise<void> {
+  const reader = stream.getReader();
+  while (true) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+}

--- a/workers/dc-api/test/export.test.ts
+++ b/workers/dc-api/test/export.test.ts
@@ -1,0 +1,364 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { ExportService } from "../src/services/export.js";
+import { seedUser, seedProject, seedChapter } from "./helpers/seed.js";
+import type { PdfGeneratorConfig } from "../src/services/pdf-generator.js";
+import JSZip from "jszip";
+
+/**
+ * Dummy PDF config — the EPUB path never calls the Browser Rendering API,
+ * so these values are never used in EPUB tests.
+ */
+const dummyPdfConfig: PdfGeneratorConfig = {
+  accountId: "test-account-id",
+  apiToken: "test-api-token",
+};
+
+const apiBaseUrl = "https://api.test.local";
+
+describe("ExportService", () => {
+  let service: ExportService;
+  let userId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    // Clean all tables in proper FK order
+    await env.DB.exec(`
+      DELETE FROM ai_interactions;
+      DELETE FROM export_jobs;
+      DELETE FROM chapters;
+      DELETE FROM projects;
+      DELETE FROM users;
+    `);
+
+    service = new ExportService(env.DB, env.EXPORTS_BUCKET, dummyPdfConfig, apiBaseUrl);
+
+    const user = await seedUser();
+    userId = user.id;
+    const project = await seedProject(userId, { title: "Test Book" });
+    projectId = project.id;
+  });
+
+  describe("exportBook (EPUB)", () => {
+    it("creates an export job record in D1", async () => {
+      const chapter = await seedChapter(projectId, {
+        title: "Chapter 1",
+        sortOrder: 1,
+        wordCount: 10,
+      });
+      // Put chapter content in R2 so fetchChapterContents can find it
+      const r2Key = `chapters/${chapter.id}/content.html`;
+      await env.EXPORTS_BUCKET.put(r2Key, "<p>Some test content for export.</p>");
+      await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
+        .bind(r2Key, chapter.id)
+        .run();
+
+      const result = await service.exportBook(userId, projectId, "epub");
+
+      expect(result.status).toBe("completed");
+      expect(result.jobId).toBeTruthy();
+      expect(result.error).toBeNull();
+
+      // Verify D1 export_jobs row
+      const row = await env.DB.prepare(
+        `SELECT id, project_id, user_id, format, status, chapter_count, total_word_count, r2_key, completed_at
+         FROM export_jobs WHERE id = ?`,
+      )
+        .bind(result.jobId)
+        .first<{
+          id: string;
+          project_id: string;
+          user_id: string;
+          format: string;
+          status: string;
+          chapter_count: number;
+          total_word_count: number;
+          r2_key: string | null;
+          completed_at: string | null;
+        }>();
+
+      expect(row).not.toBeNull();
+      expect(row!.project_id).toBe(projectId);
+      expect(row!.user_id).toBe(userId);
+      expect(row!.format).toBe("epub");
+      expect(row!.status).toBe("completed");
+      expect(row!.chapter_count).toBe(1);
+      expect(row!.total_word_count).toBe(10);
+      expect(row!.r2_key).toBe(`exports/${result.jobId}.epub`);
+      expect(row!.completed_at).not.toBeNull();
+    });
+
+    it("generates valid EPUB content from chapters", async () => {
+      const ch1 = await seedChapter(projectId, {
+        title: "Introduction",
+        sortOrder: 1,
+        wordCount: 5,
+      });
+      const ch2 = await seedChapter(projectId, {
+        title: "Main Story",
+        sortOrder: 2,
+        wordCount: 8,
+      });
+
+      // Store chapter content in R2
+      const r2Key1 = `chapters/${ch1.id}/content.html`;
+      const r2Key2 = `chapters/${ch2.id}/content.html`;
+      await env.EXPORTS_BUCKET.put(r2Key1, "<p>This is the introduction.</p>");
+      await env.EXPORTS_BUCKET.put(r2Key2, "<p>This is the main story content.</p>");
+      await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
+        .bind(r2Key1, ch1.id)
+        .run();
+      await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
+        .bind(r2Key2, ch2.id)
+        .run();
+
+      const result = await service.exportBook(userId, projectId, "epub");
+
+      expect(result.status).toBe("completed");
+      expect(result.fileName).toContain("Test Book");
+      expect(result.fileName).toContain(".epub");
+      expect(result.downloadUrl).toBe(`${apiBaseUrl}/exports/${result.jobId}/download`);
+
+      // Verify EPUB was stored in R2 and is a valid ZIP
+      const r2Object = await env.EXPORTS_BUCKET.get(`exports/${result.jobId}.epub`);
+      expect(r2Object).not.toBeNull();
+
+      const epubBuffer = await r2Object!.arrayBuffer();
+      expect(epubBuffer.byteLength).toBeGreaterThan(0);
+
+      // Verify the EPUB is a valid ZIP containing the expected files
+      const zip = await JSZip.loadAsync(epubBuffer);
+      expect(zip.file("mimetype")).not.toBeNull();
+      expect(zip.file("META-INF/container.xml")).not.toBeNull();
+      expect(zip.file("OEBPS/content.opf")).not.toBeNull();
+      expect(zip.file("OEBPS/toc.xhtml")).not.toBeNull();
+      expect(zip.file("OEBPS/title.xhtml")).not.toBeNull();
+      expect(zip.file("OEBPS/chapter-1.xhtml")).not.toBeNull();
+      expect(zip.file("OEBPS/chapter-2.xhtml")).not.toBeNull();
+      expect(zip.file("OEBPS/style.css")).not.toBeNull();
+
+      // Verify chapter content is in the EPUB
+      const ch1Xhtml = await zip.file("OEBPS/chapter-1.xhtml")!.async("string");
+      expect(ch1Xhtml).toContain("Introduction");
+      expect(ch1Xhtml).toContain("This is the introduction.");
+
+      const ch2Xhtml = await zip.file("OEBPS/chapter-2.xhtml")!.async("string");
+      expect(ch2Xhtml).toContain("Main Story");
+      expect(ch2Xhtml).toContain("This is the main story content.");
+
+      // Verify title page contains book title and author name
+      const titleXhtml = await zip.file("OEBPS/title.xhtml")!.async("string");
+      expect(titleXhtml).toContain("Test Book");
+      expect(titleXhtml).toContain("Test User");
+    });
+
+    it("marks job as completed with proper metadata", async () => {
+      await seedChapter(projectId, { title: "Only Chapter", sortOrder: 1, wordCount: 42 });
+
+      const result = await service.exportBook(userId, projectId, "epub");
+
+      expect(result.status).toBe("completed");
+
+      // Verify R2 custom metadata
+      const r2Object = await env.EXPORTS_BUCKET.head(`exports/${result.jobId}.epub`);
+      expect(r2Object).not.toBeNull();
+      expect(r2Object!.customMetadata?.jobId).toBe(result.jobId);
+      expect(r2Object!.customMetadata?.projectId).toBe(projectId);
+      expect(r2Object!.customMetadata?.userId).toBe(userId);
+    });
+
+    it("throws NOT_FOUND for wrong user's project", async () => {
+      await seedChapter(projectId, { sortOrder: 1 });
+      const other = await seedUser({ id: "other-user" });
+
+      await expect(service.exportBook(other.id, projectId, "epub")).rejects.toThrow(
+        "Project not found",
+      );
+    });
+
+    it("throws NOT_FOUND for non-existent project", async () => {
+      await expect(service.exportBook(userId, "nonexistent-project", "epub")).rejects.toThrow(
+        "Project not found",
+      );
+    });
+
+    it("handles chapters without R2 content gracefully", async () => {
+      // Chapter with no r2_key — should still be included with empty HTML
+      await seedChapter(projectId, {
+        title: "Empty Chapter",
+        sortOrder: 1,
+        wordCount: 0,
+      });
+
+      const result = await service.exportBook(userId, projectId, "epub");
+
+      expect(result.status).toBe("completed");
+
+      // Verify the EPUB still contains the chapter heading
+      const r2Object = await env.EXPORTS_BUCKET.get(`exports/${result.jobId}.epub`);
+      const zip = await JSZip.loadAsync(await r2Object!.arrayBuffer());
+      const chXhtml = await zip.file("OEBPS/chapter-1.xhtml")!.async("string");
+      expect(chXhtml).toContain("Empty Chapter");
+    });
+
+    it("includes multiple chapters in correct sort order", async () => {
+      // Seed chapters in reverse order to verify sorting
+      const ch3 = await seedChapter(projectId, { title: "Epilogue", sortOrder: 3, wordCount: 3 });
+      const ch1 = await seedChapter(projectId, { title: "Prologue", sortOrder: 1, wordCount: 5 });
+      const ch2 = await seedChapter(projectId, { title: "Body", sortOrder: 2, wordCount: 7 });
+
+      const r2Key1 = `chapters/${ch1.id}/content.html`;
+      const r2Key2 = `chapters/${ch2.id}/content.html`;
+      const r2Key3 = `chapters/${ch3.id}/content.html`;
+      await env.EXPORTS_BUCKET.put(r2Key1, "<p>Prologue content</p>");
+      await env.EXPORTS_BUCKET.put(r2Key2, "<p>Body content</p>");
+      await env.EXPORTS_BUCKET.put(r2Key3, "<p>Epilogue content</p>");
+      await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
+        .bind(r2Key1, ch1.id)
+        .run();
+      await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
+        .bind(r2Key2, ch2.id)
+        .run();
+      await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
+        .bind(r2Key3, ch3.id)
+        .run();
+
+      const result = await service.exportBook(userId, projectId, "epub");
+      expect(result.status).toBe("completed");
+
+      const row = await env.DB.prepare(
+        `SELECT chapter_count, total_word_count FROM export_jobs WHERE id = ?`,
+      )
+        .bind(result.jobId)
+        .first<{ chapter_count: number; total_word_count: number }>();
+      expect(row!.chapter_count).toBe(3);
+      expect(row!.total_word_count).toBe(15);
+
+      // Verify chapter order in the OPF manifest
+      const r2Object = await env.EXPORTS_BUCKET.get(`exports/${result.jobId}.epub`);
+      const zip = await JSZip.loadAsync(await r2Object!.arrayBuffer());
+      const opf = await zip.file("OEBPS/content.opf")!.async("string");
+      const ch1Pos = opf.indexOf("chapter-1");
+      const ch2Pos = opf.indexOf("chapter-2");
+      const ch3Pos = opf.indexOf("chapter-3");
+      expect(ch1Pos).toBeLessThan(ch2Pos);
+      expect(ch2Pos).toBeLessThan(ch3Pos);
+    });
+  });
+
+  describe("exportChapter (EPUB)", () => {
+    it("exports a single chapter as EPUB", async () => {
+      const chapter = await seedChapter(projectId, {
+        title: "Standalone Chapter",
+        sortOrder: 1,
+        wordCount: 20,
+      });
+      const r2Key = `chapters/${chapter.id}/content.html`;
+      await env.EXPORTS_BUCKET.put(r2Key, "<p>Standalone chapter content here.</p>");
+      await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
+        .bind(r2Key, chapter.id)
+        .run();
+
+      const result = await service.exportChapter(userId, projectId, chapter.id, "epub");
+
+      expect(result.status).toBe("completed");
+      expect(result.fileName).toContain("Test Book");
+      expect(result.fileName).toContain("Standalone Chapter");
+      expect(result.fileName).toContain(".epub");
+      expect(result.downloadUrl).toBe(`${apiBaseUrl}/exports/${result.jobId}/download`);
+      expect(result.error).toBeNull();
+
+      // Verify D1 export_jobs row has chapter_id set
+      const row = await env.DB.prepare(
+        `SELECT chapter_id, chapter_count, total_word_count FROM export_jobs WHERE id = ?`,
+      )
+        .bind(result.jobId)
+        .first<{ chapter_id: string; chapter_count: number; total_word_count: number }>();
+      expect(row!.chapter_id).toBe(chapter.id);
+      expect(row!.chapter_count).toBe(1);
+      expect(row!.total_word_count).toBe(20);
+
+      // Verify EPUB content
+      const r2Object = await env.EXPORTS_BUCKET.get(`exports/${result.jobId}.epub`);
+      const zip = await JSZip.loadAsync(await r2Object!.arrayBuffer());
+      const chXhtml = await zip.file("OEBPS/chapter-1.xhtml")!.async("string");
+      expect(chXhtml).toContain("Standalone Chapter");
+      expect(chXhtml).toContain("Standalone chapter content here.");
+    });
+
+    it("throws NOT_FOUND for wrong user's project", async () => {
+      const chapter = await seedChapter(projectId, { sortOrder: 1 });
+      const other = await seedUser({ id: "other-user-export" });
+
+      await expect(service.exportChapter(other.id, projectId, chapter.id, "epub")).rejects.toThrow(
+        "Project not found",
+      );
+    });
+
+    it("throws NOT_FOUND for chapter not in the specified project", async () => {
+      const otherProject = await seedProject(userId, { title: "Other Book" });
+      const chapterInOtherProject = await seedChapter(otherProject.id, { sortOrder: 1 });
+
+      await expect(
+        service.exportChapter(userId, projectId, chapterInOtherProject.id, "epub"),
+      ).rejects.toThrow("Chapter not found");
+    });
+
+    it("throws NOT_FOUND for non-existent chapter", async () => {
+      await expect(
+        service.exportChapter(userId, projectId, "nonexistent-chapter", "epub"),
+      ).rejects.toThrow("Chapter not found");
+    });
+  });
+
+  describe("getExportStatus", () => {
+    it("returns status for a completed export job", async () => {
+      const chapter = await seedChapter(projectId, {
+        title: "Status Test",
+        sortOrder: 1,
+        wordCount: 5,
+      });
+      const r2Key = `chapters/${chapter.id}/content.html`;
+      await env.EXPORTS_BUCKET.put(r2Key, "<p>Status test content.</p>");
+      await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
+        .bind(r2Key, chapter.id)
+        .run();
+
+      const exportResult = await service.exportBook(userId, projectId, "epub");
+
+      const status = await service.getExportStatus(userId, exportResult.jobId);
+
+      expect(status.jobId).toBe(exportResult.jobId);
+      expect(status.status).toBe("completed");
+      expect(status.format).toBe("epub");
+      expect(status.chapterCount).toBe(1);
+      expect(status.totalWordCount).toBe(5);
+      expect(status.error).toBeNull();
+      expect(status.fileName).toContain("Test Book");
+      expect(status.downloadUrl).toBe(`${apiBaseUrl}/exports/${exportResult.jobId}/download`);
+      expect(status.completedAt).not.toBeNull();
+    });
+
+    it("throws NOT_FOUND for another user's export job", async () => {
+      const chapter = await seedChapter(projectId, { sortOrder: 1 });
+      const r2Key = `chapters/${chapter.id}/content.html`;
+      await env.EXPORTS_BUCKET.put(r2Key, "<p>Content</p>");
+      await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
+        .bind(r2Key, chapter.id)
+        .run();
+
+      const exportResult = await service.exportBook(userId, projectId, "epub");
+      const other = await seedUser({ id: "other-user-status" });
+
+      await expect(service.getExportStatus(other.id, exportResult.jobId)).rejects.toThrow(
+        "Export not found",
+      );
+    });
+
+    it("throws NOT_FOUND for non-existent export job", async () => {
+      await expect(service.getExportStatus(userId, "nonexistent-job")).rejects.toThrow(
+        "Export not found",
+      );
+    });
+  });
+});

--- a/workers/dc-api/test/helpers/seed.ts
+++ b/workers/dc-api/test/helpers/seed.ts
@@ -71,9 +71,12 @@ export async function seedChapter(
  * Remove all rows from test tables in reverse FK order.
  */
 export async function cleanAll() {
-  await env.DB.exec(`
-    DELETE FROM chapters;
-    DELETE FROM projects;
-    DELETE FROM users;
-  `);
+  await env.DB.batch([
+    env.DB.prepare("DELETE FROM ai_interactions"),
+    env.DB.prepare("DELETE FROM export_jobs"),
+    env.DB.prepare("DELETE FROM chapters"),
+    env.DB.prepare("DELETE FROM projects"),
+    env.DB.prepare("DELETE FROM drive_connections"),
+    env.DB.prepare("DELETE FROM users"),
+  ]);
 }


### PR DESCRIPTION
## Summary

- Extract 200-line inline settings dropdown from editor page.tsx into `SettingsMenu` component (page.tsx: 1019 → 830 lines)
- Fix `countWords` to strip `&nbsp;` entities, aligning frontend/backend word counting
- Expand `cleanAll()` test helper to cover all 6 tables via `db.batch()`
- Add 68 new tests across 5 files: AI rewrite hook (22), auto-save hook (19), AI interactions service (7), AI rewrite service (16), export service (14)
- Add comprehensive API reference documentation (33 endpoints)
- Add code review report (overall grade: B)

## Test plan

- [x] `npm run typecheck` — zero errors (both workspaces)
- [x] Backend: 108 tests pass (12 files)
- [x] Frontend: 71 tests pass (5 files)
- [x] `npm run lint` — clean
- [x] Prettier formatting — clean
- [ ] Manual: verify editor loads, settings menu works, AI rewrite flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)