### PR TITLE
Fix source linking: CSP blocking Picker + 4 backend bugs

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -4,18 +4,23 @@ import { withSerwist } from "@serwist/turbopack";
 /**
  * Security headers applied to all routes.
  *
- * CSP allows Clerk (auth UI, API), the DC API worker, and Next.js runtime.
+ * CSP allows Clerk (auth UI, API), the DC API worker, Google Picker, and Next.js runtime.
  * Fonts are self-hosted via next/font so no external font-src is needed.
+ *
+ * Google Picker requires:
+ * - script-src: apis.google.com (gapi loader)
+ * - frame-src: docs.google.com (Picker iframe)
+ * - connect-src: *.googleapis.com (Drive API calls from Picker)
  */
 
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.accounts.dev https://*.clerk.com;
+  script-src 'self' 'unsafe-inline' 'unsafe-eval' https://*.clerk.accounts.dev https://*.clerk.com https://apis.google.com;
   style-src 'self' 'unsafe-inline';
   img-src 'self' blob: data: https://*.clerk.com https://img.clerk.com;
   font-src 'self';
-  connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://api.draftcrane.app;
-  frame-src 'self' https://*.clerk.accounts.dev https://*.clerk.com;
+  connect-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://api.draftcrane.app https://*.googleapis.com;
+  frame-src 'self' https://*.clerk.accounts.dev https://*.clerk.com https://docs.google.com;
   worker-src 'self' blob:;
   object-src 'none';
   base-uri 'self';

--- a/web/src/app/(protected)/drive/success/page.tsx
+++ b/web/src/app/(protected)/drive/success/page.tsx
@@ -57,8 +57,6 @@ export default function DriveSuccessPage() {
     getServerSnapshot,
   );
 
-
-
   // Auto-redirect after successful connection
   useEffect(() => {
     const shouldRedirect = !isLoadingDrive && status?.connected;
@@ -71,8 +69,6 @@ export default function DriveSuccessPage() {
       router.push(destination);
     }, 3000); // 3-second delay to show success message
   }, [isLoadingDrive, status?.connected, projectId, router]);
-
-
 
   const handleContinue = useCallback(() => {
     const destination = projectId ? `/editor/${projectId}` : "/dashboard";
@@ -107,8 +103,6 @@ export default function DriveSuccessPage() {
         ) : (
           <p className="text-muted-foreground">Your Google Drive is now connected.</p>
         )}
-
-
       </div>
     </div>
   );

--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -316,6 +316,7 @@ export default function EditorPage() {
     openAddSourceSheet,
     closeAddSourceSheet,
     error: sourcesError,
+    contentError,
   } = useSourceActions(projectId);
 
   // Chapter-source linking
@@ -775,7 +776,7 @@ export default function EditorPage() {
         content={viewerContent}
         wordCount={viewerWordCount}
         isLoading={isContentLoading}
-        error={sourcesError}
+        error={contentError}
         onClose={closeSourceViewer}
         onImportAsChapter={async () => {
           if (!activeSource) return;

--- a/web/src/app/(protected)/setup/page.tsx
+++ b/web/src/app/(protected)/setup/page.tsx
@@ -95,8 +95,6 @@ export default function SetupPage() {
     setIsConnecting(false);
   }, [createdProjectId, connectDrive]);
 
-
-
   // Step 2: Drive connection (shown after project creation)
   if (createdProjectId) {
     return (
@@ -145,7 +143,6 @@ export default function SetupPage() {
                 </>
               )}
             </button>
-
           </div>
 
           {/* Maybe later / skip to editor */}

--- a/web/src/components/drive-files-sheet.tsx
+++ b/web/src/components/drive-files-sheet.tsx
@@ -287,7 +287,12 @@ export function DriveFilesSheet({
                       viewBox="0 0 24 24"
                       aria-hidden="true"
                     >
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 4v16m8-8H4"
+                      />
                     </svg>
                     Add Source Documents
                   </button>

--- a/web/src/hooks/use-source-actions.ts
+++ b/web/src/hooks/use-source-actions.ts
@@ -151,7 +151,9 @@ export function useSourceActions(projectId: string) {
     removeSource,
     importSourceAsChapter,
 
-    // Error
+    // Error (aggregated for panels that show any source-related error)
     error,
+    // Content-specific error (isolated for the viewer so stale panel errors don't suppress content)
+    contentError,
   };
 }

--- a/workers/dc-api/src/services/chapter-source.ts
+++ b/workers/dc-api/src/services/chapter-source.ts
@@ -55,6 +55,7 @@ function rowToSource(row: SourceRow): SourceMaterial {
     originalFilename: row.original_filename,
     driveModifiedTime: row.drive_modified_time,
     wordCount: row.word_count,
+    r2Key: row.r2_key,
     cachedAt: row.cached_at,
     status: row.status as SourceMaterial["status"],
     sortOrder: row.sort_order,

--- a/workers/dc-api/src/services/drive.ts
+++ b/workers/dc-api/src/services/drive.ts
@@ -181,7 +181,12 @@ export class DriveService {
   ): Promise<string> {
     const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
     const encryptedAccess = await encrypt(tokens.access_token, this.env.ENCRYPTION_KEY);
-    const encryptedRefresh = await encrypt(tokens.refresh_token || "", this.env.ENCRYPTION_KEY);
+    // Only encrypt refresh_token when Google provides one. Passing literal ''
+    // allows the SQL CASE to correctly preserve the existing stored refresh token
+    // on re-auth flows where Google omits the refresh_token.
+    const encryptedRefresh = tokens.refresh_token
+      ? await encrypt(tokens.refresh_token, this.env.ENCRYPTION_KEY)
+      : "";
 
     await this.env.DB.prepare(
       `INSERT INTO drive_connections (id, user_id, access_token, refresh_token, token_expires_at, drive_email, updated_at)

--- a/workers/dc-api/src/services/project.ts
+++ b/workers/dc-api/src/services/project.ts
@@ -295,7 +295,7 @@ export class ProjectService {
     // Fetch updated project
     const project = await this.db
       .prepare(
-        `SELECT id, user_id, title, description, drive_folder_id, status, created_at, updated_at
+        `SELECT id, user_id, title, description, drive_folder_id, drive_connection_id, status, created_at, updated_at
          FROM projects
          WHERE id = ? AND user_id = ?`,
       )

--- a/workers/dc-api/src/services/source-material.ts
+++ b/workers/dc-api/src/services/source-material.ts
@@ -45,6 +45,7 @@ export interface SourceMaterial {
   originalFilename: string | null;
   driveModifiedTime: string | null;
   wordCount: number;
+  r2Key: string | null;
   cachedAt: string | null;
   status: "active" | "archived" | "error";
   sortOrder: number;
@@ -106,6 +107,7 @@ function rowToSource(row: SourceRow): SourceMaterial {
     originalFilename: row.original_filename,
     driveModifiedTime: row.drive_modified_time,
     wordCount: row.word_count,
+    r2Key: row.r2_key,
     cachedAt: row.cached_at,
     status: row.status as SourceMaterial["status"],
     sortOrder: row.sort_order,
@@ -320,6 +322,7 @@ export class SourceMaterialService {
         originalFilename: null,
         driveModifiedTime: null,
         wordCount: 0,
+        r2Key: null,
         cachedAt: null,
         status: "active",
         sortOrder,
@@ -479,6 +482,7 @@ export class SourceMaterialService {
       originalFilename: file.name,
       driveModifiedTime: null,
       wordCount,
+      r2Key: r2Key,
       cachedAt: now,
       status: "active",
       sortOrder,
@@ -547,7 +551,7 @@ export class SourceMaterialService {
 
     // If already cached, read from R2 (both drive and local sources)
     if (source.cachedAt && source.status === "active") {
-      const r2Key = `sources/${sourceId}/content.html`;
+      const r2Key = source.r2Key || `sources/${sourceId}/content.html`;
       const object = await this.bucket.get(r2Key);
       if (object) {
         const content = await object.text();


### PR DESCRIPTION
## Summary

Source linking was completely broken in production. Root cause: **CSP `script-src` was missing `apis.google.com`**, so the Google Picker script could never load — the browser silently blocked it. This explains "can't link to a source and can't see any source doc."

Additionally, code review found 4 targeted bugs that would surface once the Picker unblocks:

- **CSP** (`next.config.ts`): Add `apis.google.com` to `script-src`, `docs.google.com` to `frame-src`, `*.googleapis.com` to `connect-src`
- **Refresh token preservation** (`drive.ts`): `encrypt("")` produced ciphertext that never matched `''` in the SQL CASE, silently overwriting valid refresh tokens on re-auth
- **updateProject SELECT** (`project.ts`): Missing `drive_connection_id` column — returned `undefined` after project updates
- **R2 key lookup** (`source-material.ts`): `getContent()` hardcoded the R2 key pattern instead of using the stored `r2_key`; added `r2Key` to `SourceMaterial` interface
- **Error wiring** (`use-source-actions.ts` + editor page): `SourceViewerSheet` received aggregated `sourcesError` — a stale error from a failed add-source suppressed content rendering. Now receives isolated `contentError`

## Test plan

- [ ] All 155 backend tests pass (`npm test`)
- [ ] Frontend typecheck clean (`npm run typecheck`)
- [ ] Lint clean (0 errors, 4 pre-existing warnings in out-of-scope files)
- [ ] Verify Picker loads on iPad Safari (no more "Failed to load Google Picker API script")
- [ ] Test full flow: add source → view source → link source → view linked source
- [ ] Verify re-auth flow preserves refresh token (connect Drive, wait for token expiry, re-auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)