### PR TITLE
test: add regression tests for EditorPage TDZ initialization order

### DIFF
--- a/web/test/hooks/editor-page-init-order.test.ts
+++ b/web/test/hooks/editor-page-init-order.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import path from "path";
+
+/**
+ * Regression test for issue #119: EditorPage TDZ crash
+ *
+ * The EditorPage component previously crashed with a temporal dead zone (TDZ)
+ * error when `useProjectActions` attempted to access `fetchProjectData` before
+ * it was initialized. The fix was to reorder the hook declarations so that
+ * `fetchProjectData` and its `useEffect` are defined before `useProjectActions`.
+ *
+ * This test statically validates that initialization order is maintained,
+ * preventing future regressions from code reordering.
+ */
+describe("EditorPage initialization order (#119 TDZ regression)", () => {
+  const editorPagePath = path.resolve(
+    __dirname,
+    "../../src/app/(protected)/editor/[projectId]/page.tsx",
+  );
+  const source = fs.readFileSync(editorPagePath, "utf-8");
+
+  it("fetchProjectData is defined before useProjectActions is called", () => {
+    // Find the position of the fetchProjectData useCallback definition
+    const fetchProjectDataDef = source.indexOf("const fetchProjectData = useCallback");
+    expect(fetchProjectDataDef).toBeGreaterThan(-1);
+
+    // Find the position of the useProjectActions call
+    const useProjectActionsCall = source.indexOf("useProjectActions(");
+    expect(useProjectActionsCall).toBeGreaterThan(-1);
+
+    // fetchProjectData must be defined BEFORE useProjectActions is called
+    expect(fetchProjectDataDef).toBeLessThan(useProjectActionsCall);
+  });
+
+  it("fetchProjectData useEffect runs before useProjectActions is called", () => {
+    // The useEffect that invokes fetchProjectData
+    const fetchEffectPattern = /useEffect\(\s*\(\)\s*=>\s*\{\s*\n?\s*fetchProjectData\(\)/;
+    const fetchEffectMatch = source.match(fetchEffectPattern);
+    expect(fetchEffectMatch).not.toBeNull();
+
+    const fetchEffectPos = source.indexOf(fetchEffectMatch![0]);
+    const useProjectActionsPos = source.indexOf("useProjectActions(");
+
+    // The useEffect calling fetchProjectData must appear before useProjectActions
+    expect(fetchEffectPos).toBeLessThan(useProjectActionsPos);
+  });
+
+  it("handleProjectConnected is defined before useProjectActions and depends on fetchProjectData", () => {
+    const handleProjectConnectedDef = source.indexOf("const handleProjectConnected = useCallback");
+    expect(handleProjectConnectedDef).toBeGreaterThan(-1);
+
+    const useProjectActionsPos = source.indexOf("useProjectActions(");
+
+    // handleProjectConnected must be defined before useProjectActions
+    expect(handleProjectConnectedDef).toBeLessThan(useProjectActionsPos);
+
+    // handleProjectConnected's definition should reference fetchProjectData
+    // (it calls fetchProjectData to refresh server state after Drive connect)
+    const handleProjectConnectedBlock = source.slice(
+      handleProjectConnectedDef,
+      source.indexOf("const handleProjectDisconnected", handleProjectConnectedDef),
+    );
+    expect(handleProjectConnectedBlock).toContain("fetchProjectData");
+  });
+
+  it("handleProjectDisconnected is defined before useProjectActions and depends on fetchProjectData", () => {
+    const handleProjectDisconnectedDef = source.indexOf(
+      "const handleProjectDisconnected = useCallback",
+    );
+    expect(handleProjectDisconnectedDef).toBeGreaterThan(-1);
+
+    const useProjectActionsPos = source.indexOf("useProjectActions(");
+
+    // handleProjectDisconnected must be defined before useProjectActions
+    expect(handleProjectDisconnectedDef).toBeLessThan(useProjectActionsPos);
+
+    // handleProjectDisconnected's definition should reference fetchProjectData
+    const handleProjectDisconnectedBlock = source.slice(
+      handleProjectDisconnectedDef,
+      useProjectActionsPos,
+    );
+    expect(handleProjectDisconnectedBlock).toContain("fetchProjectData");
+  });
+
+  it("useProjectActions receives onProjectConnected and onProjectDisconnected callbacks", () => {
+    // Extract the useProjectActions call block
+    const callStart = source.indexOf("useProjectActions({");
+    expect(callStart).toBeGreaterThan(-1);
+
+    // Find the closing of the options object (matching brace)
+    const callBlock = source.slice(callStart, source.indexOf("});", callStart) + 3);
+
+    expect(callBlock).toContain("onProjectConnected: handleProjectConnected");
+    expect(callBlock).toContain("onProjectDisconnected: handleProjectDisconnected");
+  });
+});

--- a/web/test/hooks/use-project-actions.test.ts
+++ b/web/test/hooks/use-project-actions.test.ts
@@ -1,0 +1,284 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useProjectActions } from "@/hooks/use-project-actions";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+}));
+
+describe("useProjectActions", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockPush.mockClear();
+    // Default: every fetch call returns empty projects list
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ projects: [] }),
+    });
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  /**
+   * Renders the hook with stable option references to avoid infinite
+   * re-render loops from unstable `getToken` identity.
+   */
+  function renderProjectActions(overrides?: Record<string, unknown>) {
+    const stableGetToken = vi.fn().mockResolvedValue("test-token");
+    const stableFetchDriveFiles = vi.fn();
+    const stableResetDriveFiles = vi.fn();
+    const stableConnectDrive = vi.fn();
+    const stableOnProjectConnected = vi.fn();
+    const stableOnProjectDisconnected = vi.fn();
+
+    const opts = {
+      getToken: stableGetToken,
+      projectId: "proj-1" as string | undefined,
+      fetchDriveFiles: stableFetchDriveFiles,
+      resetDriveFiles: stableResetDriveFiles,
+      connectDrive: stableConnectDrive,
+      driveFolderId: "drive-folder-123" as string | null | undefined,
+      onProjectConnected: stableOnProjectConnected,
+      onProjectDisconnected: stableOnProjectDisconnected,
+      ...overrides,
+    };
+
+    const hookResult = renderHook(() => useProjectActions(opts));
+
+    return {
+      ...hookResult,
+      mocks: {
+        getToken: stableGetToken,
+        fetchDriveFiles: stableFetchDriveFiles,
+        resetDriveFiles: stableResetDriveFiles,
+        connectDrive: stableConnectDrive,
+        onProjectConnected: stableOnProjectConnected,
+        onProjectDisconnected: stableOnProjectDisconnected,
+      },
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // TDZ regression coverage (#119)
+  //
+  // The EditorPage previously crashed with a TDZ error because
+  // `useProjectActions` accessed `fetchProjectData` before its
+  // `useCallback` declaration ran. The fix reordered hook declarations
+  // so `fetchProjectData` is defined before `useProjectActions`.
+  //
+  // These tests exercise the `onProjectConnected` and
+  // `onProjectDisconnected` callbacks (which in EditorPage close over
+  // `fetchProjectData`) to ensure they fire correctly during Drive
+  // connect and disconnect flows.
+  // ------------------------------------------------------------------
+
+  describe("Drive connect flow (onProjectConnected callback)", () => {
+    it("calls onProjectConnected with driveFolderId after successful connect", async () => {
+      const onProjectConnected = vi.fn();
+      const fetchDriveFiles = vi.fn();
+
+      const { result } = renderProjectActions({
+        onProjectConnected,
+        fetchDriveFiles,
+      });
+
+      // Wait for mount effect (fetchProjects) to settle
+      await waitFor(() => {
+        expect(result.current.isLoadingProjects).toBe(false);
+      });
+
+      // Override fetch for the connect-drive call
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ driveFolderId: "new-folder-456" }),
+      });
+
+      await act(async () => {
+        await result.current.onConnectProjectToDrive();
+      });
+
+      expect(onProjectConnected).toHaveBeenCalledWith("new-folder-456");
+      expect(fetchDriveFiles).toHaveBeenCalledWith("new-folder-456");
+    });
+
+    it("does not call onProjectConnected when API returns error", async () => {
+      const onProjectConnected = vi.fn();
+
+      const { result } = renderProjectActions({ onProjectConnected });
+
+      await waitFor(() => {
+        expect(result.current.isLoadingProjects).toBe(false);
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      await act(async () => {
+        await result.current.onConnectProjectToDrive();
+      });
+
+      expect(onProjectConnected).not.toHaveBeenCalled();
+    });
+
+    it("resets isConnectingDrive to false after connect completes", async () => {
+      const { result } = renderProjectActions();
+
+      await waitFor(() => {
+        expect(result.current.isLoadingProjects).toBe(false);
+      });
+
+      expect(result.current.isConnectingDrive).toBe(false);
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ driveFolderId: "folder-1" }),
+      });
+
+      await act(async () => {
+        await result.current.onConnectProjectToDrive();
+      });
+
+      expect(result.current.isConnectingDrive).toBe(false);
+    });
+  });
+
+  describe("Drive disconnect flow (onProjectDisconnected callback)", () => {
+    it("calls onProjectDisconnected after successful disconnect", async () => {
+      const onProjectDisconnected = vi.fn();
+      const resetDriveFiles = vi.fn();
+
+      const { result } = renderProjectActions({
+        onProjectDisconnected,
+        resetDriveFiles,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoadingProjects).toBe(false);
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+
+      let success: boolean | undefined;
+      await act(async () => {
+        success = await result.current.disconnectProjectFromDrive();
+      });
+
+      expect(success).toBe(true);
+      expect(resetDriveFiles).toHaveBeenCalled();
+      expect(onProjectDisconnected).toHaveBeenCalled();
+    });
+
+    it("does not call onProjectDisconnected when API returns error", async () => {
+      const onProjectDisconnected = vi.fn();
+
+      const { result } = renderProjectActions({ onProjectDisconnected });
+
+      await waitFor(() => {
+        expect(result.current.isLoadingProjects).toBe(false);
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      let success: boolean | undefined;
+      await act(async () => {
+        success = await result.current.disconnectProjectFromDrive();
+      });
+
+      expect(success).toBe(false);
+      expect(onProjectDisconnected).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Project save flow (rename and duplicate)", () => {
+    it("renameProject sends PATCH and returns true on success", async () => {
+      const { result } = renderProjectActions();
+
+      await waitFor(() => {
+        expect(result.current.isLoadingProjects).toBe(false);
+      });
+
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ ok: true });
+
+      let success: boolean | undefined;
+      await act(async () => {
+        success = await result.current.renameProject("proj-1", "New Title");
+      });
+
+      expect(success).toBe(true);
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/projects/proj-1"),
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ title: "New Title" }),
+        }),
+      );
+    });
+
+    it("duplicateProject returns new project ID on success", async () => {
+      const { result } = renderProjectActions();
+
+      await waitFor(() => {
+        expect(result.current.isLoadingProjects).toBe(false);
+      });
+
+      // duplicate POST + refresh fetchProjects
+      (global.fetch as ReturnType<typeof vi.fn>)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ id: "proj-copy-1" }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: () => Promise.resolve({ projects: [] }),
+        });
+
+      let newId: string | null | undefined;
+      await act(async () => {
+        newId = await result.current.duplicateProject("proj-1");
+      });
+
+      expect(newId).toBe("proj-copy-1");
+    });
+  });
+
+  describe("connectDriveWithProject stores project context", () => {
+    it("stores projectId in sessionStorage before calling connectDrive", async () => {
+      const connectDrive = vi.fn();
+      const setItemSpy = vi.spyOn(Storage.prototype, "setItem");
+
+      const { result } = renderProjectActions({ connectDrive });
+
+      await waitFor(() => {
+        expect(result.current.isLoadingProjects).toBe(false);
+      });
+
+      act(() => {
+        result.current.connectDriveWithProject();
+      });
+
+      expect(setItemSpy).toHaveBeenCalledWith("dc_pending_drive_project", "proj-1");
+      expect(connectDrive).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add static analysis tests that verify `fetchProjectData` and related callbacks are declared before `useProjectActions` in the EditorPage source, preventing future TDZ regressions from code reordering
- Add functional tests for `useProjectActions` covering the Drive connect/disconnect flows (the TDZ-sensitive `onProjectConnected`/`onProjectDisconnected` callbacks), plus rename, duplicate, and `connectDriveWithProject`

## Changes
- `web/test/hooks/editor-page-init-order.test.ts` - 5 static analysis tests validating hook initialization order in `EditorPage`
- `web/test/hooks/use-project-actions.test.ts` - 8 functional tests for `useProjectActions` covering Drive connect, disconnect, rename, duplicate, and session storage flows

## Test Plan
- [x] Regression tests verify fetchProjectData initializes before useProjectActions (5 static analysis tests)
- [x] Drive connect flow correctly invokes onProjectConnected callback (3 tests)
- [x] Drive disconnect flow correctly invokes onProjectDisconnected callback (2 tests)
- [x] Project save flows (rename, duplicate) work correctly (2 tests)
- [x] connectDriveWithProject stores project context in sessionStorage (1 test)
- [x] All 84 web tests pass, all 152 dc-api tests pass (236 total)
- [x] No side effects in project save or drive connect flows

Closes #119

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>