### PR TITLE
security: enforce global authentication on backend API

### DIFF
--- a/workers/dc-api/src/routes/ai.ts
+++ b/workers/dc-api/src/routes/ai.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import type { Env } from "../types/index.js";
-import { requireAuth } from "../middleware/auth.js";
 import { validationError } from "../middleware/error-handler.js";
 import { aiRateLimit } from "../middleware/rate-limit.js";
 import { AIRewriteService, type RewriteInput } from "../services/ai-rewrite.js";
@@ -9,9 +8,7 @@ import { OpenAIProvider, WorkersAIProvider } from "../services/ai-provider.js";
 
 const ai = new Hono<{ Bindings: Env }>();
 
-// All AI routes require authentication
-ai.use("*", requireAuth);
-
+// Auth is enforced globally in index.ts
 // Rate limit: 10 req/min for AI rewrite (applied after auth)
 ai.use("/rewrite", aiRateLimit);
 

--- a/workers/dc-api/src/routes/chapters.ts
+++ b/workers/dc-api/src/routes/chapters.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import type { Env } from "../types/index.js";
-import { requireAuth } from "../middleware/auth.js";
 import { standardRateLimit } from "../middleware/rate-limit.js";
 import { validationError } from "../middleware/error-handler.js";
 import { ChapterService } from "../services/chapter.js";
@@ -21,13 +20,12 @@ import { DriveService } from "../services/drive.js";
  * - PUT /chapters/:chapterId/content - Save content to R2, update D1 metadata
  * - GET /chapters/:chapterId/content - Load content from R2
  *
- * All routes require authentication.
+ * All routes require authentication (enforced globally in index.ts).
  * Authorization: All queries include WHERE user_id = ? via project ownership
  */
 const chapters = new Hono<{ Bindings: Env }>();
 
-// All chapter routes require authentication
-chapters.use("*", requireAuth);
+// Auth is enforced globally in index.ts
 chapters.use("*", standardRateLimit);
 
 /**

--- a/workers/dc-api/src/routes/export.ts
+++ b/workers/dc-api/src/routes/export.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import type { Env } from "../types/index.js";
-import { requireAuth } from "../middleware/auth.js";
 import { exportRateLimit, standardRateLimit } from "../middleware/rate-limit.js";
 import { validationError } from "../middleware/error-handler.js";
 import { ExportService } from "../services/export.js";
@@ -16,13 +15,11 @@ import { DriveService } from "../services/drive.js";
  * - GET /exports/:jobId/download - Download a completed export
  *
  * Rate limit: 5 req/min per user (exportRateLimit middleware).
- * All routes require authentication.
+ * All routes require authentication (enforced globally in index.ts).
  */
 const exportRoutes = new Hono<{ Bindings: Env }>();
 
-// All export routes require authentication
-exportRoutes.use("*", requireAuth);
-
+// Auth is enforced globally in index.ts
 // Rate limit export generation endpoints (not downloads)
 exportRoutes.use("/projects/*", exportRateLimit);
 

--- a/workers/dc-api/src/routes/projects.ts
+++ b/workers/dc-api/src/routes/projects.ts
@@ -1,6 +1,5 @@
 import { Hono } from "hono";
 import type { Env } from "../types/index.js";
-import { requireAuth } from "../middleware/auth.js";
 import { standardRateLimit, exportRateLimit } from "../middleware/rate-limit.js";
 import { validationError } from "../middleware/error-handler.js";
 import { ProjectService } from "../services/project.js";
@@ -18,13 +17,12 @@ import { safeContentDisposition } from "../utils/file-names.js";
  * - PATCH /projects/:projectId - Updates title, description, settings
  * - DELETE /projects/:projectId - Soft-delete (status='archived')
  *
- * All routes require authentication.
+ * All routes require authentication (enforced globally in index.ts).
  * Authorization: All queries include WHERE user_id = ?
  */
 const projects = new Hono<{ Bindings: Env }>();
 
-// All project routes require authentication
-projects.use("*", requireAuth);
+// Auth is enforced globally in index.ts
 projects.use("*", standardRateLimit);
 
 /**

--- a/workers/dc-api/src/routes/sources.ts
+++ b/workers/dc-api/src/routes/sources.ts
@@ -17,7 +17,6 @@
 
 import { Hono } from "hono";
 import type { Env } from "../types/index.js";
-import { requireAuth } from "../middleware/auth.js";
 import { standardRateLimit } from "../middleware/rate-limit.js";
 import { validationError } from "../middleware/error-handler.js";
 import { SourceMaterialService, type AddSourceInput } from "../services/source-material.js";
@@ -27,8 +26,7 @@ import { validateDriveId } from "../utils/drive-query.js";
 
 const sources = new Hono<{ Bindings: Env }>();
 
-// All source routes require authentication
-sources.use("*", requireAuth);
+// Auth is enforced globally in index.ts
 sources.use("*", standardRateLimit);
 
 /**

--- a/workers/dc-api/src/routes/users.ts
+++ b/workers/dc-api/src/routes/users.ts
@@ -1,12 +1,11 @@
 import { Hono } from "hono";
 import type { Env } from "../types/index.js";
-import { requireAuth } from "../middleware/auth.js";
 import { standardRateLimit } from "../middleware/rate-limit.js";
 import { notFound } from "../middleware/index.js";
 
 const users = new Hono<{ Bindings: Env }>();
 
-users.use("*", requireAuth);
+// Auth is enforced globally in index.ts
 users.use("*", standardRateLimit);
 
 /**


### PR DESCRIPTION
## Summary
- Apply `requireAuth` middleware globally in `index.ts` so new routes are authenticated by default
- Mount public routes (health, Clerk webhook, Drive OAuth callback) before the auth barrier with clear documentation
- Extract Drive OAuth callback into a separate `driveCallback` Hono sub-app for clean separation
- Remove redundant per-route `requireAuth` calls from all 7 route files (users, projects, chapters, ai, export, sources, drive)

## Public Route Exceptions
| Route | Reason |
|---|---|
| `GET /health` | Health check, no auth needed |
| `POST /auth/webhook` | Clerk webhook uses Svix signature verification |
| `GET /drive/callback` | Google OAuth redirect uses CSRF state token |

## Test Plan
- [x] Health endpoint still accessible without auth (verified: `health.test.ts` passes)
- [x] Auth middleware still rejects invalid tokens (verified: `auth.test.ts` passes, 4 tests)
- [x] All 152 dc-api tests pass
- [x] All 84 web tests pass
- [x] Lint, typecheck, and format checks pass
- [ ] Clerk webhook still accessible without auth (manual verification recommended)
- [ ] Drive OAuth callback still works end-to-end (manual verification recommended)
- [ ] All authenticated routes still work with valid tokens (manual verification recommended)

Closes #141

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>