### PR TITLE
refactor: decompose large backend service files

### DIFF
--- a/workers/dc-api/src/services/drive-files.ts
+++ b/workers/dc-api/src/services/drive-files.ts
@@ -1,0 +1,541 @@
+/**
+ * Drive file operations -- folder CRUD, file listing, upload, update, rename, trash, download, export.
+ *
+ * Split from drive.ts per Single Responsibility Principle.
+ * All Google Drive API calls for file/folder manipulation live here.
+ * Token management lives in drive-token.ts.
+ *
+ * Key responsibilities:
+ * - Folder creation and subfolder find-or-create
+ * - File listing (flat and recursive)
+ * - File upload (multipart), update, rename, trash
+ * - File metadata retrieval, export, download
+ */
+
+import { validateDriveId, escapeDriveQuery } from "../utils/drive-query.js";
+
+/** Google Drive file metadata */
+export interface DriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  webViewLink?: string;
+  createdTime?: string;
+  modifiedTime?: string;
+  size?: string;
+}
+
+/** Google Drive folder create response */
+interface DriveFolderResponse {
+  id: string;
+  name: string;
+  mimeType: string;
+  webViewLink: string;
+}
+
+interface DriveListResponse {
+  files?: DriveFile[];
+  nextPageToken?: string;
+}
+
+const GOOGLE_DRIVE_API = "https://www.googleapis.com/drive/v3";
+const GOOGLE_DOC_MIME_TYPE = "application/vnd.google-apps.document";
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
+
+/**
+ * DriveFileService handles all Google Drive file and folder operations.
+ * Requires a valid access token for every call (obtained via DriveTokenService).
+ */
+export class DriveFileService {
+  /**
+   * Creates a folder in Google Drive.
+   * Per PRD Section 8 (US-006): Auto-creates folder named after project title.
+   *
+   * @param accessToken - Valid access token
+   * @param folderName - Name for the folder
+   * @returns The created folder metadata
+   */
+  async createFolder(accessToken: string, folderName: string): Promise<DriveFolderResponse> {
+    const response = await fetch(`${GOOGLE_DRIVE_API}/files`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: folderName,
+        mimeType: "application/vnd.google-apps.folder",
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("Folder creation failed:", error);
+      throw new Error("Failed to create Drive folder");
+    }
+
+    const folder = (await response.json()) as DriveFile;
+
+    // Get the webViewLink by fetching with fields
+    const detailResponse = await fetch(
+      `${GOOGLE_DRIVE_API}/files/${folder.id}?fields=id,name,mimeType,webViewLink`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    if (!detailResponse.ok) {
+      // Return basic info if detail fetch fails
+      return {
+        id: folder.id,
+        name: folder.name,
+        mimeType: folder.mimeType,
+        webViewLink: `https://drive.google.com/drive/folders/${folder.id}`,
+      };
+    }
+
+    return detailResponse.json() as Promise<DriveFolderResponse>;
+  }
+
+  /**
+   * Lists files in a folder.
+   * Per PRD Section 8 (US-007): Read-only listing of DraftCrane-created files.
+   *
+   * @param accessToken - Valid access token
+   * @param folderId - The folder ID to list
+   * @returns Array of file metadata
+   */
+  async listFolderChildren(accessToken: string, folderId: string): Promise<DriveFile[]> {
+    const result = await this.listFolderChildrenPage(accessToken, folderId);
+    return result.files;
+  }
+
+  /**
+   * Lists files in a folder with pagination support.
+   */
+  async listFolderChildrenPage(
+    accessToken: string,
+    folderId: string,
+    options: { pageSize?: number; pageToken?: string } = {},
+  ): Promise<{ files: DriveFile[]; nextPageToken?: string }> {
+    const params = new URLSearchParams({
+      q: `'${validateDriveId(folderId)}' in parents and trashed = false`,
+      fields: "files(id,name,mimeType,webViewLink,createdTime,modifiedTime)",
+      orderBy: "modifiedTime desc",
+    });
+    if (options.pageSize) {
+      params.set("pageSize", String(options.pageSize));
+    }
+    if (options.pageToken) {
+      params.set("pageToken", options.pageToken);
+    }
+
+    const response = await fetch(`${GOOGLE_DRIVE_API}/files?${params.toString()}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.text();
+      console.error(
+        `List folder failed: Status ${response.status} ${response.statusText || ""}, Body: ${errorBody}`,
+      );
+      if (response.status === 403 && errorBody.includes("insufficientPermissions")) {
+        throw new Error("Google Drive permission update required. Reconnect Drive.");
+      }
+      throw new Error(
+        `Failed to list folder contents: ${response.status} ${response.statusText || ""}`,
+      );
+    }
+
+    const data = (await response.json()) as { files: DriveFile[]; nextPageToken?: string };
+    return { files: data.files || [], nextPageToken: data.nextPageToken };
+  }
+
+  /**
+   * Recursively lists Google Docs contained in one or more Drive folders.
+   * Includes docs in nested subfolders. Stops at maxDocs to avoid expensive traversals.
+   */
+  async listDocsInFoldersRecursive(
+    accessToken: string,
+    folderIds: string[],
+    maxDocs: number,
+  ): Promise<DriveFile[]> {
+    const pending = [...new Set(folderIds.map((id) => validateDriveId(id)))];
+    const visitedFolders = new Set<string>();
+    const seenDocs = new Set<string>();
+    const docs: DriveFile[] = [];
+
+    while (pending.length > 0) {
+      const folderId = pending.shift();
+      if (!folderId || visitedFolders.has(folderId)) {
+        continue;
+      }
+      visitedFolders.add(folderId);
+
+      let pageToken: string | undefined;
+      do {
+        const params = new URLSearchParams({
+          q: `'${folderId}' in parents and trashed = false and (mimeType = '${GOOGLE_DOC_MIME_TYPE}' or mimeType = '${GOOGLE_FOLDER_MIME_TYPE}')`,
+          fields: "nextPageToken,files(id,name,mimeType)",
+          pageSize: "1000",
+        });
+        if (pageToken) {
+          params.set("pageToken", pageToken);
+        }
+
+        const response = await fetch(`${GOOGLE_DRIVE_API}/files?${params.toString()}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+
+        if (!response.ok) {
+          const errorBody = await response.text();
+          console.error(
+            `Recursive folder list failed: Status ${response.status} ${response.statusText || ""}, Body: ${errorBody}`,
+          );
+          throw new Error("Failed to list selected folder contents from Drive");
+        }
+
+        const data = (await response.json()) as DriveListResponse;
+        const files = data.files || [];
+        for (const file of files) {
+          if (!file.id || !file.mimeType) continue;
+
+          if (file.mimeType === GOOGLE_FOLDER_MIME_TYPE) {
+            if (!visitedFolders.has(file.id)) {
+              pending.push(file.id);
+            }
+            continue;
+          }
+
+          if (file.mimeType !== GOOGLE_DOC_MIME_TYPE || seenDocs.has(file.id)) {
+            continue;
+          }
+
+          docs.push(file);
+          seenDocs.add(file.id);
+
+          if (docs.length > maxDocs) {
+            throw new Error("MAX_DOCS_EXCEEDED");
+          }
+        }
+
+        pageToken = data.nextPageToken;
+      } while (pageToken);
+    }
+
+    return docs;
+  }
+
+  /**
+   * Finds an existing subfolder by name within a parent folder, or creates it.
+   * Per PRD Section 11: _exports/ subfolder in the Book Folder.
+   *
+   * @param accessToken - Valid access token
+   * @param parentFolderId - The parent folder ID
+   * @param folderName - Name for the subfolder (e.g. "_exports")
+   * @returns The subfolder ID
+   */
+  async findOrCreateSubfolder(
+    accessToken: string,
+    parentFolderId: string,
+    folderName: string,
+  ): Promise<string> {
+    // Search for existing subfolder
+    const searchParams = new URLSearchParams({
+      q: `'${validateDriveId(parentFolderId)}' in parents and name = '${escapeDriveQuery(folderName)}' and mimeType = 'application/vnd.google-apps.folder' and trashed = false`,
+      fields: "files(id,name)",
+    });
+
+    const searchResponse = await fetch(`${GOOGLE_DRIVE_API}/files?${searchParams.toString()}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (searchResponse.ok) {
+      const data = (await searchResponse.json()) as { files: DriveFile[] };
+      if (data.files && data.files.length > 0) {
+        return data.files[0].id;
+      }
+    }
+
+    // Create the subfolder
+    const createResponse = await fetch(`${GOOGLE_DRIVE_API}/files`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: folderName,
+        mimeType: "application/vnd.google-apps.folder",
+        parents: [parentFolderId],
+      }),
+    });
+
+    if (!createResponse.ok) {
+      const error = await createResponse.text();
+      console.error("Subfolder creation failed:", error);
+      throw new Error(`Failed to create ${folderName} subfolder in Drive`);
+    }
+
+    const folder = (await createResponse.json()) as DriveFile;
+    return folder.id;
+  }
+
+  /**
+   * Uploads a file to Google Drive using multipart upload.
+   * Per PRD Section 8 (US-021): Upload export artifacts to _exports/ subfolder.
+   *
+   * @param accessToken - Valid access token
+   * @param parentFolderId - The folder to upload into
+   * @param fileName - Name for the file in Drive
+   * @param mimeType - MIME type of the file content
+   * @param data - The file content as ArrayBuffer
+   * @returns The uploaded file metadata including webViewLink
+   */
+  async uploadFile(
+    accessToken: string,
+    parentFolderId: string,
+    fileName: string,
+    mimeType: string,
+    data: ArrayBuffer,
+  ): Promise<DriveFile> {
+    // Use multipart upload for files with metadata
+    const boundary = "---DraftCraneUploadBoundary";
+    const metadata = JSON.stringify({
+      name: fileName,
+      parents: [parentFolderId],
+    });
+
+    // Build multipart body
+    const encoder = new TextEncoder();
+    const metadataPart = encoder.encode(
+      `--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${metadata}\r\n`,
+    );
+    const filePart = encoder.encode(`--${boundary}\r\nContent-Type: ${mimeType}\r\n\r\n`);
+    const fileData = new Uint8Array(data);
+    const closingBoundary = encoder.encode(`\r\n--${boundary}--`);
+
+    // Concatenate all parts
+    const bodyLength =
+      metadataPart.length + filePart.length + fileData.length + closingBoundary.length;
+    const body = new Uint8Array(bodyLength);
+    let offset = 0;
+    body.set(metadataPart, offset);
+    offset += metadataPart.length;
+    body.set(filePart, offset);
+    offset += filePart.length;
+    body.set(fileData, offset);
+    offset += fileData.length;
+    body.set(closingBoundary, offset);
+
+    const uploadResponse = await fetch(
+      "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&fields=id,name,mimeType,webViewLink",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": `multipart/related; boundary=${boundary}`,
+        },
+        body: body,
+      },
+    );
+
+    if (!uploadResponse.ok) {
+      const error = await uploadResponse.text();
+      console.error("Drive file upload failed:", error);
+      throw new Error("Failed to upload file to Google Drive");
+    }
+
+    return uploadResponse.json() as Promise<DriveFile>;
+  }
+
+  /**
+   * Moves a file to Google Drive trash.
+   * Per PRD US-014: When deleting a chapter, trash the Drive file (30-day retention by Google).
+   *
+   * @param accessToken - Valid access token
+   * @param fileId - The Drive file ID to trash
+   */
+  async trashFile(accessToken: string, fileId: string): Promise<void> {
+    validateDriveId(fileId);
+    const response = await fetch(`${GOOGLE_DRIVE_API}/files/${fileId}`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ trashed: true }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("Drive file trash failed:", error);
+      throw new Error("Failed to trash Drive file");
+    }
+  }
+
+  /**
+   * Renames a file in Google Drive.
+   * Per PRD US-013: When a chapter is renamed, the Drive file name should match.
+   *
+   * @param accessToken - Valid access token
+   * @param fileId - The Drive file ID to rename
+   * @param newName - The new file name
+   */
+  async renameFile(accessToken: string, fileId: string, newName: string): Promise<void> {
+    validateDriveId(fileId);
+    const response = await fetch(`${GOOGLE_DRIVE_API}/files/${fileId}`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ name: newName }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("Drive file rename failed:", error);
+      throw new Error("Failed to rename Drive file");
+    }
+  }
+
+  /**
+   * Updates an existing file's content in Google Drive.
+   * Used for Drive write-through: syncing chapter content from R2 to Drive.
+   *
+   * @param accessToken - Valid access token
+   * @param fileId - The Drive file ID to update
+   * @param mimeType - MIME type of the content
+   * @param data - The file content as string or ArrayBuffer
+   */
+  async updateFile(
+    accessToken: string,
+    fileId: string,
+    mimeType: string,
+    data: string | ArrayBuffer,
+  ): Promise<void> {
+    validateDriveId(fileId);
+    const body = typeof data === "string" ? new TextEncoder().encode(data) : data;
+
+    const response = await fetch(
+      `https://www.googleapis.com/upload/drive/v3/files/${fileId}?uploadType=media`,
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": mimeType,
+        },
+        body,
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("Drive file update failed:", error);
+      throw new Error("Failed to update file in Google Drive");
+    }
+  }
+
+  /**
+   * Gets metadata for a file in Google Drive.
+   *
+   * @param accessToken - Valid access token
+   * @param fileId - The Drive file ID
+   * @returns File metadata (id, name, mimeType, size, modifiedTime)
+   */
+  async getFileMetadata(accessToken: string, fileId: string): Promise<DriveFile> {
+    validateDriveId(fileId);
+    const fields = "id,name,mimeType,size,modifiedTime";
+    const response = await fetch(`${GOOGLE_DRIVE_API}/files/${fileId}?fields=${fields}`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("Get file metadata failed:", error);
+      throw new Error("Failed to get file metadata from Drive");
+    }
+
+    return response.json() as Promise<DriveFile>;
+  }
+
+  /**
+   * Exports a Google Workspace file (Docs, Sheets, etc.) to a specified MIME type.
+   * Used for importing Google Docs as HTML.
+   *
+   * @param accessToken - Valid access token
+   * @param fileId - The Drive file ID (must be a Google Workspace file)
+   * @param mimeType - Target export MIME type (e.g. "text/html")
+   * @returns The exported content as a string
+   * @throws Error if the exported file exceeds 5MB
+   */
+  async exportFile(accessToken: string, fileId: string, mimeType: string): Promise<string> {
+    validateDriveId(fileId);
+    const params = new URLSearchParams({ mimeType });
+    const response = await fetch(
+      `${GOOGLE_DRIVE_API}/files/${fileId}/export?${params.toString()}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("File export failed:", error);
+      throw new Error("Failed to export file from Drive");
+    }
+
+    // Reject files larger than 5MB to prevent memory issues
+    const contentLength = response.headers.get("Content-Length");
+    if (contentLength && parseInt(contentLength, 10) > 5 * 1024 * 1024) {
+      throw new Error("FILE_TOO_LARGE");
+    }
+
+    const text = await response.text();
+
+    // Double-check after reading (Content-Length may not always be present)
+    if (text.length > 5 * 1024 * 1024) {
+      throw new Error("FILE_TOO_LARGE");
+    }
+
+    return text;
+  }
+
+  /**
+   * Downloads a binary file from Google Drive.
+   * Used for non-Workspace files (images, PDFs, etc.).
+   *
+   * @param accessToken - Valid access token
+   * @param fileId - The Drive file ID
+   * @returns The file content as an ArrayBuffer
+   */
+  async downloadFile(accessToken: string, fileId: string): Promise<ArrayBuffer> {
+    validateDriveId(fileId);
+    const response = await fetch(`${GOOGLE_DRIVE_API}/files/${fileId}?alt=media`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("File download failed:", error);
+      throw new Error("Failed to download file from Drive");
+    }
+
+    return response.arrayBuffer();
+  }
+}

--- a/workers/dc-api/src/services/drive-token.ts
+++ b/workers/dc-api/src/services/drive-token.ts
@@ -1,0 +1,404 @@
+/**
+ * Drive token management -- OAuth flow, token storage/retrieval/refresh, connections.
+ *
+ * Split from drive.ts per Single Responsibility Principle.
+ * All token encryption/decryption, Google OAuth, and D1 connection management lives here.
+ *
+ * Key responsibilities:
+ * - OAuth authorization URL generation
+ * - Code-for-tokens exchange
+ * - Token encryption/decryption via AES-256-GCM (crypto service)
+ * - Token refresh (5 min before expiry per PRD Section 13)
+ * - Multi-account connection management
+ */
+
+import { encrypt, decrypt } from "./crypto.js";
+import type { Env } from "../types/index.js";
+
+/** Google OAuth token response */
+export interface GoogleTokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+  token_type: string;
+  scope: string;
+}
+
+/** Stored token data from D1 */
+export interface StoredTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: Date;
+}
+
+/** Result of getting valid tokens (may have been refreshed) */
+export interface ValidTokens {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: Date;
+  wasRefreshed: boolean;
+}
+
+/** Drive connection metadata (no tokens) */
+export interface DriveConnection {
+  id: string;
+  email: string;
+  connectedAt: string;
+}
+
+const GOOGLE_OAUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+
+// Refresh tokens 5 minutes before expiry per PRD Section 13
+const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+/**
+ * DriveTokenService handles OAuth flow, token management, and connection CRUD.
+ */
+export class DriveTokenService {
+  constructor(private readonly env: Env) {}
+
+  /**
+   * Generates the Google OAuth authorization URL.
+   * Uses drive.file scope only per PRD Section 8.
+   *
+   * @param state - CSRF protection state parameter
+   * @param loginHint - Optional email to pre-select Google account (for multi-account)
+   * @returns The authorization URL to redirect the user to
+   */
+  getAuthorizationUrl(state: string, loginHint?: string): string {
+    const params = new URLSearchParams({
+      client_id: this.env.GOOGLE_CLIENT_ID,
+      redirect_uri: this.env.GOOGLE_REDIRECT_URI,
+      response_type: "code",
+      scope:
+        "https://www.googleapis.com/auth/drive.file https://www.googleapis.com/auth/drive.readonly email",
+      access_type: "offline",
+      prompt: "consent", // Always get refresh token
+      state,
+    });
+
+    if (loginHint) {
+      params.set("login_hint", loginHint);
+    }
+
+    return `${GOOGLE_OAUTH_URL}?${params.toString()}`;
+  }
+
+  /**
+   * Exchanges an authorization code for tokens.
+   *
+   * @param code - The authorization code from Google OAuth callback
+   * @returns Token response from Google
+   */
+  async exchangeCodeForTokens(code: string): Promise<GoogleTokenResponse> {
+    const response = await fetch(GOOGLE_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: this.env.GOOGLE_CLIENT_ID,
+        client_secret: this.env.GOOGLE_CLIENT_SECRET,
+        code,
+        grant_type: "authorization_code",
+        redirect_uri: this.env.GOOGLE_REDIRECT_URI,
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("Token exchange failed:", error);
+      throw new Error("Failed to exchange code for tokens");
+    }
+
+    return response.json() as Promise<GoogleTokenResponse>;
+  }
+
+  /**
+   * Gets the Google user's email address.
+   *
+   * @param accessToken - Valid access token
+   * @returns The user's email address
+   */
+  async getUserEmail(accessToken: string): Promise<string> {
+    const response = await fetch(GOOGLE_USERINFO_URL, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to get user info");
+    }
+
+    const data = (await response.json()) as { email: string };
+    return data.email;
+  }
+
+  /**
+   * Stores encrypted tokens in D1.
+   * Upserts on (user_id, drive_email) to preserve existing connection ID on re-auth.
+   * This is critical: other tables (source_materials, projects) reference the connection ID as FK.
+   *
+   * @param userId - The user ID
+   * @param connectionId - The connection ID (ULID) - used only for new connections
+   * @param tokens - Token response from Google
+   * @param email - The Google account email
+   * @returns The connection ID (existing or new)
+   */
+  async storeTokens(
+    userId: string,
+    connectionId: string,
+    tokens: GoogleTokenResponse,
+    email: string,
+  ): Promise<string> {
+    const expiresAt = new Date(Date.now() + tokens.expires_in * 1000);
+    const encryptedAccess = await encrypt(tokens.access_token, this.env.ENCRYPTION_KEY);
+    // Only encrypt refresh_token when Google provides one. Passing literal ''
+    // allows the SQL CASE to correctly preserve the existing stored refresh token
+    // on re-auth flows where Google omits the refresh_token.
+    const encryptedRefresh = tokens.refresh_token
+      ? await encrypt(tokens.refresh_token, this.env.ENCRYPTION_KEY)
+      : "";
+
+    await this.env.DB.prepare(
+      `INSERT INTO drive_connections (id, user_id, access_token, refresh_token, token_expires_at, drive_email, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+       ON CONFLICT (user_id, drive_email) DO UPDATE SET
+         access_token = excluded.access_token,
+         refresh_token = CASE WHEN excluded.refresh_token != '' THEN excluded.refresh_token ELSE drive_connections.refresh_token END,
+         token_expires_at = excluded.token_expires_at,
+         updated_at = excluded.updated_at`,
+    )
+      .bind(connectionId, userId, encryptedAccess, encryptedRefresh, expiresAt.toISOString(), email)
+      .run();
+
+    // Return the actual connection ID (may differ from input if re-auth of same account)
+    const row = await this.env.DB.prepare(
+      `SELECT id FROM drive_connections WHERE user_id = ? AND drive_email = ?`,
+    )
+      .bind(userId, email)
+      .first<{ id: string }>();
+
+    return row?.id ?? connectionId;
+  }
+
+  /**
+   * Gets stored tokens for a specific connection, decrypting them.
+   *
+   * @param connectionId - The drive connection ID
+   * @returns Decrypted tokens or null if not found
+   */
+  async getStoredTokens(connectionId: string): Promise<StoredTokens | null> {
+    const row = await this.env.DB.prepare(
+      `SELECT access_token, refresh_token, token_expires_at FROM drive_connections WHERE id = ?`,
+    )
+      .bind(connectionId)
+      .first<{ access_token: string; refresh_token: string; token_expires_at: string }>();
+
+    if (!row) {
+      return null;
+    }
+
+    const accessToken = await decrypt(row.access_token, this.env.ENCRYPTION_KEY);
+    const refreshToken = await decrypt(row.refresh_token, this.env.ENCRYPTION_KEY);
+    const expiresAt = new Date(row.token_expires_at);
+
+    return { accessToken, refreshToken, expiresAt };
+  }
+
+  /**
+   * Gets stored tokens for a user's first connection (legacy fallback).
+   * Used when we only have userId, not a specific connectionId.
+   *
+   * @param userId - The user ID
+   * @returns Decrypted tokens or null if not connected
+   */
+  async getStoredTokensByUser(
+    userId: string,
+  ): Promise<(StoredTokens & { connectionId: string }) | null> {
+    const row = await this.env.DB.prepare(
+      `SELECT id, access_token, refresh_token, token_expires_at FROM drive_connections WHERE user_id = ? LIMIT 1`,
+    )
+      .bind(userId)
+      .first<{
+        id: string;
+        access_token: string;
+        refresh_token: string;
+        token_expires_at: string;
+      }>();
+
+    if (!row) {
+      return null;
+    }
+
+    const accessToken = await decrypt(row.access_token, this.env.ENCRYPTION_KEY);
+    const refreshToken = await decrypt(row.refresh_token, this.env.ENCRYPTION_KEY);
+    const expiresAt = new Date(row.token_expires_at);
+
+    return { connectionId: row.id, accessToken, refreshToken, expiresAt };
+  }
+
+  /**
+   * Refreshes the access token using the refresh token.
+   *
+   * @param refreshToken - The refresh token
+   * @returns New token response
+   */
+  async refreshAccessToken(refreshToken: string): Promise<GoogleTokenResponse> {
+    const response = await fetch(GOOGLE_TOKEN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({
+        client_id: this.env.GOOGLE_CLIENT_ID,
+        client_secret: this.env.GOOGLE_CLIENT_SECRET,
+        refresh_token: refreshToken,
+        grant_type: "refresh_token",
+      }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      console.error("Token refresh failed:", error);
+      throw new Error("Failed to refresh access token");
+    }
+
+    return response.json() as Promise<GoogleTokenResponse>;
+  }
+
+  /**
+   * Gets valid tokens for a specific connection, refreshing if needed.
+   * Per PRD Section 13: Automatic token refresh, 5 min before expiry.
+   *
+   * @param connectionId - The drive connection ID
+   * @returns Valid tokens, or null if connection not found
+   */
+  async getValidTokensByConnection(connectionId: string): Promise<ValidTokens | null> {
+    const stored = await this.getStoredTokens(connectionId);
+    if (!stored) {
+      return null;
+    }
+
+    return this.ensureTokensFresh(connectionId, stored);
+  }
+
+  /**
+   * Gets valid tokens for a user's first connection (legacy fallback).
+   * Used by fire-and-forget write-through code that only has userId.
+   *
+   * @param userId - The user ID
+   * @returns Valid tokens with connectionId, or null if not connected
+   */
+  async getValidTokens(userId: string): Promise<(ValidTokens & { connectionId: string }) | null> {
+    const stored = await this.getStoredTokensByUser(userId);
+    if (!stored) {
+      return null;
+    }
+
+    const result = await this.ensureTokensFresh(stored.connectionId, stored);
+    if (!result) return null;
+
+    return { ...result, connectionId: stored.connectionId };
+  }
+
+  /**
+   * Internal: refresh tokens if within 5min of expiry.
+   */
+  private async ensureTokensFresh(
+    connectionId: string,
+    stored: StoredTokens,
+  ): Promise<ValidTokens | null> {
+    const now = Date.now();
+    const expiresAt = stored.expiresAt.getTime();
+
+    // Check if token needs refresh (expires within 5 minutes)
+    if (expiresAt - now < REFRESH_BUFFER_MS) {
+      try {
+        const newTokens = await this.refreshAccessToken(stored.refreshToken);
+        const newExpiresAt = new Date(now + newTokens.expires_in * 1000);
+
+        // Update stored tokens
+        const encryptedAccess = await encrypt(newTokens.access_token, this.env.ENCRYPTION_KEY);
+        await this.env.DB.prepare(
+          `UPDATE drive_connections
+           SET access_token = ?, token_expires_at = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now')
+           WHERE id = ?`,
+        )
+          .bind(encryptedAccess, newExpiresAt.toISOString(), connectionId)
+          .run();
+
+        return {
+          accessToken: newTokens.access_token,
+          refreshToken: newTokens.refresh_token || stored.refreshToken,
+          expiresAt: newExpiresAt,
+          wasRefreshed: true,
+        };
+      } catch (err) {
+        console.error("Token refresh failed, using existing token:", err);
+        // Fall through to use existing token
+      }
+    }
+
+    return {
+      ...stored,
+      wasRefreshed: false,
+    };
+  }
+
+  /**
+   * Returns all Drive connections for a user (metadata only, no tokens).
+   *
+   * @param userId - The user ID
+   * @returns Array of connection metadata
+   */
+  async getConnectionsForUser(userId: string): Promise<DriveConnection[]> {
+    const result = await this.env.DB.prepare(
+      `SELECT id, drive_email, created_at FROM drive_connections WHERE user_id = ? ORDER BY created_at ASC`,
+    )
+      .bind(userId)
+      .all<{ id: string; drive_email: string; created_at: string }>();
+
+    return (result.results ?? []).map((row) => ({
+      id: row.id,
+      email: row.drive_email,
+      connectedAt: row.created_at,
+    }));
+  }
+
+  /**
+   * Revokes the OAuth token with Google.
+   * Per PRD Section 8 (US-008): Disconnects Drive, revokes token.
+   *
+   * @param accessToken - The access token to revoke
+   */
+  async revokeToken(accessToken: string): Promise<void> {
+    const response = await fetch(`${GOOGLE_REVOKE_URL}?token=${accessToken}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+    });
+
+    if (!response.ok) {
+      // Log but don't throw - token might already be invalid
+      console.warn("Token revocation returned non-200:", response.status);
+    }
+  }
+
+  /**
+   * Deletes a specific drive connection from D1.
+   *
+   * @param connectionId - The connection ID
+   * @param userId - The user ID (for ownership verification)
+   */
+  async deleteConnectionById(connectionId: string, userId: string): Promise<void> {
+    await this.env.DB.prepare(`DELETE FROM drive_connections WHERE id = ? AND user_id = ?`)
+      .bind(connectionId, userId)
+      .run();
+  }
+}

--- a/workers/dc-api/src/services/export-delivery.ts
+++ b/workers/dc-api/src/services/export-delivery.ts
@@ -1,0 +1,262 @@
+/**
+ * Export delivery -- status queries, download streaming, and Drive upload.
+ *
+ * Split from export.ts per Single Responsibility Principle.
+ * Handles the "read" side of exports: checking job status, streaming downloads
+ * from R2, and saving completed exports to Google Drive.
+ */
+
+import { notFound, validationError } from "../middleware/error-handler.js";
+import type { DriveService } from "./drive.js";
+
+export interface ExportToDriveResult {
+  driveFileId: string;
+  fileName: string;
+  webViewLink: string;
+}
+
+export interface ExportJobStatus {
+  jobId: string;
+  status: "pending" | "processing" | "completed" | "failed";
+  format: string;
+  fileName: string | null;
+  downloadUrl: string | null;
+  chapterCount: number;
+  totalWordCount: number;
+  error: string | null;
+  createdAt: string;
+  completedAt: string | null;
+}
+
+interface ExportJobRow {
+  id: string;
+  project_id: string;
+  user_id: string;
+  chapter_id: string | null;
+  format: string;
+  status: string;
+  r2_key: string | null;
+  drive_file_id: string | null;
+  error_message: string | null;
+  chapter_count: number;
+  total_word_count: number;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export class ExportDeliveryService {
+  constructor(
+    private readonly db: D1Database,
+    private readonly bucket: R2Bucket,
+    private readonly apiBaseUrl: string,
+  ) {}
+
+  /**
+   * Get the status of an export job.
+   *
+   * Per US-022: GET /exports/:jobId returns job status + signed download URL.
+   * Download URL is only included for completed jobs (1-hour cache via download endpoint).
+   */
+  async getExportStatus(userId: string, jobId: string): Promise<ExportJobStatus> {
+    const job = await this.db
+      .prepare(
+        `SELECT id, user_id, format, status, r2_key, error_message, chapter_count,
+                total_word_count, created_at, completed_at
+         FROM export_jobs WHERE id = ? AND user_id = ?`,
+      )
+      .bind(jobId, userId)
+      .first<ExportJobRow>();
+
+    if (!job) {
+      notFound("Export not found");
+    }
+
+    let fileName: string | null = null;
+    let downloadUrl: string | null = null;
+
+    if (job.status === "completed" && job.r2_key) {
+      // Retrieve the file name from R2 custom metadata
+      const head = await this.bucket.head(job.r2_key);
+      fileName = head?.customMetadata?.fileName || `export-${jobId}.${job.format}`;
+      downloadUrl = `${this.apiBaseUrl}/exports/${jobId}/download`;
+    }
+
+    return {
+      jobId: job.id,
+      status: job.status as ExportJobStatus["status"],
+      format: job.format,
+      fileName,
+      downloadUrl,
+      chapterCount: job.chapter_count,
+      totalWordCount: job.total_word_count,
+      error: job.error_message,
+      createdAt: job.created_at,
+      completedAt: job.completed_at,
+    };
+  }
+
+  /**
+   * Get the download for a completed export job.
+   * Streams the file directly from R2.
+   */
+  async getExportDownload(
+    userId: string,
+    jobId: string,
+  ): Promise<{ data: ReadableStream; fileName: string; contentType: string }> {
+    const job = await this.db
+      .prepare(
+        `SELECT id, user_id, r2_key, format, status FROM export_jobs WHERE id = ? AND user_id = ?`,
+      )
+      .bind(jobId, userId)
+      .first<{
+        id: string;
+        user_id: string;
+        r2_key: string | null;
+        format: string;
+        status: string;
+      }>();
+
+    if (!job) {
+      notFound("Export not found");
+    }
+
+    if (job.status !== "completed" || !job.r2_key) {
+      notFound("Export not available for download");
+    }
+
+    const object = await this.bucket.get(job.r2_key);
+    if (!object) {
+      notFound("Export file not found in storage");
+    }
+
+    const fileName = object.customMetadata?.fileName || `export-${jobId}.${job.format || "pdf"}`;
+    const contentType = job.format === "epub" ? "application/epub+zip" : "application/pdf";
+
+    return {
+      data: object.body,
+      fileName,
+      contentType,
+    };
+  }
+
+  /**
+   * Save a completed export to Google Drive.
+   *
+   * Per US-021:
+   * 1. Verify the export job belongs to the user and is completed
+   * 2. Look up the project's drive_folder_id
+   * 3. Find or create the _exports/ subfolder
+   * 4. Fetch the export artifact from R2
+   * 5. Upload to Drive with date-stamped file name
+   * 6. Update the export_jobs row with drive_file_id
+   *
+   * @param userId - Authenticated user ID
+   * @param jobId - Export job ID
+   * @param driveService - DriveService instance for Drive API calls
+   * @returns Drive file metadata (id, fileName, webViewLink)
+   */
+  async saveToDrive(
+    userId: string,
+    jobId: string,
+    driveService: DriveService,
+  ): Promise<ExportToDriveResult> {
+    // 1. Verify the export job belongs to the user and is completed
+    const job = await this.db
+      .prepare(
+        `SELECT id, project_id, user_id, r2_key, format, status, drive_file_id
+         FROM export_jobs WHERE id = ? AND user_id = ?`,
+      )
+      .bind(jobId, userId)
+      .first<{
+        id: string;
+        project_id: string;
+        user_id: string;
+        r2_key: string | null;
+        format: string;
+        status: string;
+        drive_file_id: string | null;
+      }>();
+
+    if (!job) {
+      notFound("Export not found");
+    }
+
+    if (job.status !== "completed" || !job.r2_key) {
+      validationError("Export is not available for saving to Drive");
+    }
+
+    // If already saved to Drive, return the existing info
+    if (job.drive_file_id) {
+      // Fetch the file name from R2 metadata
+      const head = await this.bucket.head(job.r2_key);
+      const fileName = head?.customMetadata?.fileName || `export-${jobId}.${job.format}`;
+      return {
+        driveFileId: job.drive_file_id,
+        fileName,
+        webViewLink: `https://drive.google.com/file/d/${job.drive_file_id}/view`,
+      };
+    }
+
+    // 2. Look up the project's drive_folder_id
+    const project = await this.db
+      .prepare(
+        `SELECT id, title, drive_folder_id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`,
+      )
+      .bind(job.project_id, userId)
+      .first<{ id: string; title: string; drive_folder_id: string | null }>();
+
+    if (!project) {
+      notFound("Project not found");
+    }
+
+    if (!project.drive_folder_id) {
+      validationError(
+        "Project does not have a Google Drive folder. Connect Drive and create a book folder first.",
+      );
+    }
+
+    // 3. Get valid Drive tokens
+    const tokens = await driveService.getValidTokens(userId);
+    if (!tokens) {
+      validationError("Google Drive is not connected");
+    }
+
+    // 4. Find or create the _exports/ subfolder
+    const exportsFolderId = await driveService.findOrCreateSubfolder(
+      tokens.accessToken,
+      project.drive_folder_id,
+      "_exports",
+    );
+
+    // 5. Fetch the export artifact from R2
+    const object = await this.bucket.get(job.r2_key);
+    if (!object) {
+      notFound("Export file not found in storage");
+    }
+
+    const fileName = object.customMetadata?.fileName || `export-${jobId}.${job.format}`;
+    const contentType = job.format === "epub" ? "application/epub+zip" : "application/pdf";
+    const fileData = await object.arrayBuffer();
+
+    // 6. Upload to Drive
+    const driveFile = await driveService.uploadFile(
+      tokens.accessToken,
+      exportsFolderId,
+      fileName,
+      contentType,
+      fileData,
+    );
+
+    // 7. Update the export_jobs row with drive_file_id
+    await this.db
+      .prepare(`UPDATE export_jobs SET drive_file_id = ? WHERE id = ?`)
+      .bind(driveFile.id, jobId)
+      .run();
+
+    return {
+      driveFileId: driveFile.id,
+      fileName,
+      webViewLink: driveFile.webViewLink || `https://drive.google.com/file/d/${driveFile.id}/view`,
+    };
+  }
+}

--- a/workers/dc-api/src/services/export-job.ts
+++ b/workers/dc-api/src/services/export-job.ts
@@ -1,0 +1,377 @@
+/**
+ * Export job creation -- generates PDF and EPUB exports for books and chapters.
+ *
+ * Split from export.ts per Single Responsibility Principle.
+ * Handles the "write" side of exports: creating jobs, fetching content,
+ * generating artifacts (PDF/EPUB), and storing in R2.
+ *
+ * Per ADR-004:
+ * 1. Create export_jobs row (status: 'processing')
+ * 2. Fetch chapter content from R2 (sequential, memory-safe)
+ * 3. Branch by format (PDF via Browser Rendering, EPUB via JSZip)
+ * 4. Store result in R2 (EXPORTS_BUCKET)
+ * 5. Update export_jobs (status: 'completed', r2_key)
+ */
+
+import { ulid } from "ulidx";
+import { notFound, validationError } from "../middleware/error-handler.js";
+import { buildFileName, formatDate } from "../utils/file-names.js";
+import { fetchChapterContentsFromR2 } from "../utils/r2-content.js";
+import {
+  assembleBookHtml,
+  assembleChapterHtml,
+  PRINT_CSS,
+  type BookMetadata,
+  type ChapterContent,
+} from "./book-template.js";
+import { generateEpub } from "./epub-generator.js";
+import { generatePdf, type PdfGeneratorConfig } from "./pdf-generator.js";
+
+export interface ExportJobResult {
+  jobId: string;
+  status: "completed" | "failed";
+  fileName: string | null;
+  downloadUrl: string | null;
+  error: string | null;
+}
+
+interface ProjectRow {
+  id: string;
+  user_id: string;
+  title: string;
+}
+
+interface ChapterRow {
+  id: string;
+  title: string;
+  sort_order: number;
+  r2_key: string | null;
+  word_count: number;
+}
+
+interface UserRow {
+  display_name: string | null;
+  email: string;
+}
+
+export class ExportJobService {
+  constructor(
+    private readonly db: D1Database,
+    private readonly bucket: R2Bucket,
+    private readonly pdfConfig: PdfGeneratorConfig,
+    private readonly apiBaseUrl: string,
+  ) {}
+
+  /**
+   * Export a full book as PDF or EPUB.
+   *
+   * @param userId - Authenticated user ID
+   * @param projectId - Project to export
+   * @param format - Export format: "pdf" or "epub"
+   * @returns Export job result with download URL
+   */
+  async exportBook(
+    userId: string,
+    projectId: string,
+    format: "pdf" | "epub" = "pdf",
+  ): Promise<ExportJobResult> {
+    // Verify project ownership
+    const project = await this.db
+      .prepare(
+        `SELECT id, user_id, title FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`,
+      )
+      .bind(projectId, userId)
+      .first<ProjectRow>();
+
+    if (!project) {
+      notFound("Project not found");
+    }
+
+    // Fetch chapters
+    const chaptersResult = await this.db
+      .prepare(
+        `SELECT id, title, sort_order, r2_key, word_count
+         FROM chapters WHERE project_id = ? ORDER BY sort_order ASC`,
+      )
+      .bind(projectId)
+      .all<ChapterRow>();
+
+    const chapterRows = chaptersResult.results ?? [];
+
+    if (chapterRows.length === 0) {
+      validationError("Project has no chapters to export");
+    }
+
+    // Create export job
+    const jobId = ulid();
+    const now = new Date().toISOString();
+
+    await this.db
+      .prepare(
+        `INSERT INTO export_jobs (id, project_id, user_id, format, status, chapter_count, total_word_count, created_at)
+         VALUES (?, ?, ?, ?, 'processing', ?, ?, ?)`,
+      )
+      .bind(
+        jobId,
+        projectId,
+        userId,
+        format,
+        chapterRows.length,
+        chapterRows.reduce((sum, ch) => sum + ch.word_count, 0),
+        now,
+      )
+      .run();
+
+    try {
+      // Fetch chapter content from R2 sequentially (memory-safe per ADR-004)
+      const chapters = await this.fetchChapterContents(chapterRows);
+
+      // Get author name
+      const authorName = await this.getAuthorName(userId);
+
+      // Assemble metadata
+      const metadata: BookMetadata = {
+        title: project.title,
+        authorName,
+        generatedDate: formatDate(new Date()),
+      };
+
+      // Branch by format (ADR-004 architecture)
+      let fileData: ArrayBuffer;
+      let contentType: string;
+
+      if (format === "epub") {
+        fileData = await generateEpub(metadata, chapters);
+        contentType = "application/epub+zip";
+      } else {
+        const html = assembleBookHtml(metadata, chapters);
+        const pdf = await generatePdf(html, PRINT_CSS, this.pdfConfig);
+        fileData = pdf.data;
+        contentType = "application/pdf";
+      }
+
+      // Build file name: {Book Title} - YYYY-MM-DD.{ext}
+      const fileName = buildFileName(project.title, format);
+      const r2Key = `exports/${jobId}.${format}`;
+
+      // Store in R2
+      await this.bucket.put(r2Key, fileData, {
+        httpMetadata: {
+          contentType,
+          contentDisposition: `attachment; filename="${fileName}"`,
+        },
+        customMetadata: {
+          jobId,
+          projectId,
+          userId,
+          fileName,
+        },
+      });
+
+      // Update job as completed
+      await this.db
+        .prepare(
+          `UPDATE export_jobs SET status = 'completed', r2_key = ?, completed_at = ? WHERE id = ?`,
+        )
+        .bind(r2Key, new Date().toISOString(), jobId)
+        .run();
+
+      return {
+        jobId,
+        status: "completed",
+        fileName,
+        downloadUrl: `${this.apiBaseUrl}/exports/${jobId}/download`,
+        error: null,
+      };
+    } catch (err) {
+      // Update job as failed
+      const errorMessage = err instanceof Error ? err.message : "Unknown error";
+      await this.db
+        .prepare(
+          `UPDATE export_jobs SET status = 'failed', error_message = ?, completed_at = ? WHERE id = ?`,
+        )
+        .bind(errorMessage, new Date().toISOString(), jobId)
+        .run();
+
+      return {
+        jobId,
+        status: "failed",
+        fileName: null,
+        downloadUrl: null,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Export a single chapter as PDF or EPUB.
+   *
+   * @param userId - Authenticated user ID
+   * @param projectId - Project the chapter belongs to
+   * @param chapterId - Chapter to export
+   * @param format - Export format: "pdf" or "epub"
+   * @returns Export job result with download URL
+   */
+  async exportChapter(
+    userId: string,
+    projectId: string,
+    chapterId: string,
+    format: "pdf" | "epub" = "pdf",
+  ): Promise<ExportJobResult> {
+    // Verify project ownership
+    const project = await this.db
+      .prepare(
+        `SELECT id, user_id, title FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`,
+      )
+      .bind(projectId, userId)
+      .first<ProjectRow>();
+
+    if (!project) {
+      notFound("Project not found");
+    }
+
+    // Verify chapter belongs to project
+    const chapter = await this.db
+      .prepare(
+        `SELECT id, title, sort_order, r2_key, word_count
+         FROM chapters WHERE id = ? AND project_id = ?`,
+      )
+      .bind(chapterId, projectId)
+      .first<ChapterRow>();
+
+    if (!chapter) {
+      notFound("Chapter not found");
+    }
+
+    // Create export job
+    const jobId = ulid();
+    const now = new Date().toISOString();
+
+    await this.db
+      .prepare(
+        `INSERT INTO export_jobs (id, project_id, user_id, chapter_id, format, status, chapter_count, total_word_count, created_at)
+         VALUES (?, ?, ?, ?, ?, 'processing', 1, ?, ?)`,
+      )
+      .bind(jobId, projectId, userId, chapterId, format, chapter.word_count, now)
+      .run();
+
+    try {
+      // Fetch chapter content from R2
+      const chapters = await this.fetchChapterContents([chapter]);
+      if (chapters.length === 0) {
+        validationError("Chapter has no content to export");
+      }
+
+      const authorName = await this.getAuthorName(userId);
+
+      const metadata: BookMetadata = {
+        title: project.title,
+        authorName,
+        generatedDate: formatDate(new Date()),
+      };
+
+      // Branch by format (ADR-004 architecture)
+      let fileData: ArrayBuffer;
+      let contentType: string;
+
+      if (format === "epub") {
+        fileData = await generateEpub(metadata, chapters);
+        contentType = "application/epub+zip";
+      } else {
+        const html = assembleChapterHtml(metadata, chapters[0]);
+        const pdf = await generatePdf(html, PRINT_CSS, this.pdfConfig);
+        fileData = pdf.data;
+        contentType = "application/pdf";
+      }
+
+      // Build file name: {Book Title} - {Chapter Title} - YYYY-MM-DD.{ext}
+      const fileName = buildFileName(`${project.title} - ${chapter.title}`, format);
+      const r2Key = `exports/${jobId}.${format}`;
+
+      // Store in R2
+      await this.bucket.put(r2Key, fileData, {
+        httpMetadata: {
+          contentType,
+          contentDisposition: `attachment; filename="${fileName}"`,
+        },
+        customMetadata: {
+          jobId,
+          projectId,
+          userId,
+          chapterId,
+          fileName,
+        },
+      });
+
+      // Update job as completed
+      await this.db
+        .prepare(
+          `UPDATE export_jobs SET status = 'completed', r2_key = ?, completed_at = ? WHERE id = ?`,
+        )
+        .bind(r2Key, new Date().toISOString(), jobId)
+        .run();
+
+      return {
+        jobId,
+        status: "completed",
+        fileName,
+        downloadUrl: `${this.apiBaseUrl}/exports/${jobId}/download`,
+        error: null,
+      };
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Unknown error";
+      await this.db
+        .prepare(
+          `UPDATE export_jobs SET status = 'failed', error_message = ?, completed_at = ? WHERE id = ?`,
+        )
+        .bind(errorMessage, new Date().toISOString(), jobId)
+        .run();
+
+      return {
+        jobId,
+        status: "failed",
+        fileName: null,
+        downloadUrl: null,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Fetch chapter content from R2 sequentially.
+   * Per ADR-004: sequential fetching is memory-safe for book-length documents.
+   */
+  private async fetchChapterContents(chapterRows: ChapterRow[]): Promise<ChapterContent[]> {
+    const contentMap = await fetchChapterContentsFromR2(this.bucket, chapterRows);
+
+    // Include chapters even with empty content (they'll just have the heading)
+    return chapterRows.map((row) => ({
+      id: row.id,
+      title: row.title,
+      sortOrder: row.sort_order,
+      html: contentMap.get(row) ?? "",
+      wordCount: row.word_count,
+    }));
+  }
+
+  /**
+   * Get the author's display name from the users table.
+   */
+  async getAuthorName(userId: string): Promise<string> {
+    const user = await this.db
+      .prepare(`SELECT display_name, email FROM users WHERE id = ?`)
+      .bind(userId)
+      .first<UserRow>();
+
+    if (user?.display_name) {
+      return user.display_name;
+    }
+
+    // Fall back to email prefix
+    if (user?.email) {
+      return user.email.split("@")[0];
+    }
+
+    return "Author";
+  }
+}

--- a/workers/dc-api/src/services/export.ts
+++ b/workers/dc-api/src/services/export.ts
@@ -1,621 +1,78 @@
-import { ulid } from "ulidx";
-import { notFound, validationError } from "../middleware/error-handler.js";
-import { buildFileName, formatDate } from "../utils/file-names.js";
-import { fetchChapterContentsFromR2 } from "../utils/r2-content.js";
-import type { DriveService } from "./drive.js";
-import {
-  assembleBookHtml,
-  assembleChapterHtml,
-  PRINT_CSS,
-  type BookMetadata,
-  type ChapterContent,
-} from "./book-template.js";
-import { generateEpub } from "./epub-generator.js";
-import { generatePdf, type PdfGeneratorConfig } from "./pdf-generator.js";
-
 /**
- * ExportService - Orchestrates PDF and EPUB export for full books and single chapters.
+ * Export service facade -- composes ExportJobService and ExportDeliveryService.
  *
- * Per ADR-004:
- * 1. Create export_jobs row (status: 'processing')
- * 2. Fetch chapter content from R2 (sequential, memory-safe)
- * 3. Branch by format:
- *    - PDF: Assemble HTML with print stylesheet, generate via Browser Rendering
- *    - EPUB: Generate EPUB 3.0 ZIP via JSZip (EpubGenerator)
- * 4. Store result in R2 (EXPORTS_BUCKET)
- * 5. Update export_jobs (status: 'completed', r2_key)
- * 6. Return download URL (served via download endpoint)
+ * This module preserves the original ExportService public API so that route files
+ * and test files do not need import changes. Internally, responsibilities
+ * are delegated to focused sub-services:
+ *
+ *   - export-job.ts     -- Export generation (book & chapter PDF/EPUB creation)
+ *   - export-delivery.ts -- Status queries, download streaming, Drive upload
+ *
+ * Re-exports all public types from sub-modules for backward compatibility.
  */
 
-export interface ExportJobResult {
-  jobId: string;
-  status: "completed" | "failed";
-  fileName: string | null;
-  downloadUrl: string | null;
-  error: string | null;
-}
+import { ExportJobService } from "./export-job.js";
+import type { ExportJobResult } from "./export-job.js";
+import { ExportDeliveryService } from "./export-delivery.js";
+import type { ExportJobStatus, ExportToDriveResult } from "./export-delivery.js";
+import type { DriveService } from "./drive.js";
+import type { PdfGeneratorConfig } from "./pdf-generator.js";
 
-export interface ExportToDriveResult {
-  driveFileId: string;
-  fileName: string;
-  webViewLink: string;
-}
+// Re-export public types so existing imports from "./export.js" still work
+export type { ExportJobResult } from "./export-job.js";
+export type { ExportJobStatus, ExportToDriveResult } from "./export-delivery.js";
 
-export interface ExportJobStatus {
-  jobId: string;
-  status: "pending" | "processing" | "completed" | "failed";
-  format: string;
-  fileName: string | null;
-  downloadUrl: string | null;
-  chapterCount: number;
-  totalWordCount: number;
-  error: string | null;
-  createdAt: string;
-  completedAt: string | null;
-}
-
-interface ExportJobRow {
-  id: string;
-  project_id: string;
-  user_id: string;
-  chapter_id: string | null;
-  format: string;
-  status: string;
-  r2_key: string | null;
-  drive_file_id: string | null;
-  error_message: string | null;
-  chapter_count: number;
-  total_word_count: number;
-  created_at: string;
-  completed_at: string | null;
-}
-
-interface ProjectRow {
-  id: string;
-  user_id: string;
-  title: string;
-}
-
-interface ChapterRow {
-  id: string;
-  title: string;
-  sort_order: number;
-  r2_key: string | null;
-  word_count: number;
-}
-
-interface UserRow {
-  display_name: string | null;
-  email: string;
-}
-
+/**
+ * ExportService composes job creation and delivery into a single unified API.
+ * Route files instantiate `new ExportService(db, bucket, pdfConfig, apiBaseUrl)`
+ * and call methods directly -- this facade delegates to the appropriate sub-service.
+ */
 export class ExportService {
-  constructor(
-    private readonly db: D1Database,
-    private readonly bucket: R2Bucket,
-    private readonly pdfConfig: PdfGeneratorConfig,
-    private readonly apiBaseUrl: string,
-  ) {}
+  private readonly jobs: ExportJobService;
+  private readonly delivery: ExportDeliveryService;
 
-  /**
-   * Export a full book as PDF or EPUB.
-   *
-   * @param userId - Authenticated user ID
-   * @param projectId - Project to export
-   * @param format - Export format: "pdf" or "epub"
-   * @returns Export job result with download URL
-   */
-  async exportBook(
+  constructor(db: D1Database, bucket: R2Bucket, pdfConfig: PdfGeneratorConfig, apiBaseUrl: string) {
+    this.jobs = new ExportJobService(db, bucket, pdfConfig, apiBaseUrl);
+    this.delivery = new ExportDeliveryService(db, bucket, apiBaseUrl);
+  }
+
+  // ── Job creation (delegated to ExportJobService) ──
+
+  exportBook(
     userId: string,
     projectId: string,
     format: "pdf" | "epub" = "pdf",
   ): Promise<ExportJobResult> {
-    // Verify project ownership
-    const project = await this.db
-      .prepare(
-        `SELECT id, user_id, title FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`,
-      )
-      .bind(projectId, userId)
-      .first<ProjectRow>();
-
-    if (!project) {
-      notFound("Project not found");
-    }
-
-    // Fetch chapters
-    const chaptersResult = await this.db
-      .prepare(
-        `SELECT id, title, sort_order, r2_key, word_count
-         FROM chapters WHERE project_id = ? ORDER BY sort_order ASC`,
-      )
-      .bind(projectId)
-      .all<ChapterRow>();
-
-    const chapterRows = chaptersResult.results ?? [];
-
-    if (chapterRows.length === 0) {
-      validationError("Project has no chapters to export");
-    }
-
-    // Create export job
-    const jobId = ulid();
-    const now = new Date().toISOString();
-
-    await this.db
-      .prepare(
-        `INSERT INTO export_jobs (id, project_id, user_id, format, status, chapter_count, total_word_count, created_at)
-         VALUES (?, ?, ?, ?, 'processing', ?, ?, ?)`,
-      )
-      .bind(
-        jobId,
-        projectId,
-        userId,
-        format,
-        chapterRows.length,
-        chapterRows.reduce((sum, ch) => sum + ch.word_count, 0),
-        now,
-      )
-      .run();
-
-    try {
-      // Fetch chapter content from R2 sequentially (memory-safe per ADR-004)
-      const chapters = await this.fetchChapterContents(chapterRows);
-
-      // Get author name
-      const authorName = await this.getAuthorName(userId);
-
-      // Assemble metadata
-      const metadata: BookMetadata = {
-        title: project.title,
-        authorName,
-        generatedDate: formatDate(new Date()),
-      };
-
-      // Branch by format (ADR-004 architecture)
-      let fileData: ArrayBuffer;
-      let contentType: string;
-
-      if (format === "epub") {
-        fileData = await generateEpub(metadata, chapters);
-        contentType = "application/epub+zip";
-      } else {
-        const html = assembleBookHtml(metadata, chapters);
-        const pdf = await generatePdf(html, PRINT_CSS, this.pdfConfig);
-        fileData = pdf.data;
-        contentType = "application/pdf";
-      }
-
-      // Build file name: {Book Title} - YYYY-MM-DD.{ext}
-      const fileName = buildFileName(project.title, format);
-      const r2Key = `exports/${jobId}.${format}`;
-
-      // Store in R2
-      await this.bucket.put(r2Key, fileData, {
-        httpMetadata: {
-          contentType,
-          contentDisposition: `attachment; filename="${fileName}"`,
-        },
-        customMetadata: {
-          jobId,
-          projectId,
-          userId,
-          fileName,
-        },
-      });
-
-      // Update job as completed
-      await this.db
-        .prepare(
-          `UPDATE export_jobs SET status = 'completed', r2_key = ?, completed_at = ? WHERE id = ?`,
-        )
-        .bind(r2Key, new Date().toISOString(), jobId)
-        .run();
-
-      return {
-        jobId,
-        status: "completed",
-        fileName,
-        downloadUrl: `${this.apiBaseUrl}/exports/${jobId}/download`,
-        error: null,
-      };
-    } catch (err) {
-      // Update job as failed
-      const errorMessage = err instanceof Error ? err.message : "Unknown error";
-      await this.db
-        .prepare(
-          `UPDATE export_jobs SET status = 'failed', error_message = ?, completed_at = ? WHERE id = ?`,
-        )
-        .bind(errorMessage, new Date().toISOString(), jobId)
-        .run();
-
-      return {
-        jobId,
-        status: "failed",
-        fileName: null,
-        downloadUrl: null,
-        error: errorMessage,
-      };
-    }
+    return this.jobs.exportBook(userId, projectId, format);
   }
 
-  /**
-   * Export a single chapter as PDF or EPUB.
-   *
-   * @param userId - Authenticated user ID
-   * @param projectId - Project the chapter belongs to
-   * @param chapterId - Chapter to export
-   * @param format - Export format: "pdf" or "epub"
-   * @returns Export job result with download URL
-   */
-  async exportChapter(
+  exportChapter(
     userId: string,
     projectId: string,
     chapterId: string,
     format: "pdf" | "epub" = "pdf",
   ): Promise<ExportJobResult> {
-    // Verify project ownership
-    const project = await this.db
-      .prepare(
-        `SELECT id, user_id, title FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`,
-      )
-      .bind(projectId, userId)
-      .first<ProjectRow>();
-
-    if (!project) {
-      notFound("Project not found");
-    }
-
-    // Verify chapter belongs to project
-    const chapter = await this.db
-      .prepare(
-        `SELECT id, title, sort_order, r2_key, word_count
-         FROM chapters WHERE id = ? AND project_id = ?`,
-      )
-      .bind(chapterId, projectId)
-      .first<ChapterRow>();
-
-    if (!chapter) {
-      notFound("Chapter not found");
-    }
-
-    // Create export job
-    const jobId = ulid();
-    const now = new Date().toISOString();
-
-    await this.db
-      .prepare(
-        `INSERT INTO export_jobs (id, project_id, user_id, chapter_id, format, status, chapter_count, total_word_count, created_at)
-         VALUES (?, ?, ?, ?, ?, 'processing', 1, ?, ?)`,
-      )
-      .bind(jobId, projectId, userId, chapterId, format, chapter.word_count, now)
-      .run();
-
-    try {
-      // Fetch chapter content from R2
-      const chapters = await this.fetchChapterContents([chapter]);
-      if (chapters.length === 0) {
-        validationError("Chapter has no content to export");
-      }
-
-      const authorName = await this.getAuthorName(userId);
-
-      const metadata: BookMetadata = {
-        title: project.title,
-        authorName,
-        generatedDate: formatDate(new Date()),
-      };
-
-      // Branch by format (ADR-004 architecture)
-      let fileData: ArrayBuffer;
-      let contentType: string;
-
-      if (format === "epub") {
-        fileData = await generateEpub(metadata, chapters);
-        contentType = "application/epub+zip";
-      } else {
-        const html = assembleChapterHtml(metadata, chapters[0]);
-        const pdf = await generatePdf(html, PRINT_CSS, this.pdfConfig);
-        fileData = pdf.data;
-        contentType = "application/pdf";
-      }
-
-      // Build file name: {Book Title} - {Chapter Title} - YYYY-MM-DD.{ext}
-      const fileName = buildFileName(`${project.title} - ${chapter.title}`, format);
-      const r2Key = `exports/${jobId}.${format}`;
-
-      // Store in R2
-      await this.bucket.put(r2Key, fileData, {
-        httpMetadata: {
-          contentType,
-          contentDisposition: `attachment; filename="${fileName}"`,
-        },
-        customMetadata: {
-          jobId,
-          projectId,
-          userId,
-          chapterId,
-          fileName,
-        },
-      });
-
-      // Update job as completed
-      await this.db
-        .prepare(
-          `UPDATE export_jobs SET status = 'completed', r2_key = ?, completed_at = ? WHERE id = ?`,
-        )
-        .bind(r2Key, new Date().toISOString(), jobId)
-        .run();
-
-      return {
-        jobId,
-        status: "completed",
-        fileName,
-        downloadUrl: `${this.apiBaseUrl}/exports/${jobId}/download`,
-        error: null,
-      };
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "Unknown error";
-      await this.db
-        .prepare(
-          `UPDATE export_jobs SET status = 'failed', error_message = ?, completed_at = ? WHERE id = ?`,
-        )
-        .bind(errorMessage, new Date().toISOString(), jobId)
-        .run();
-
-      return {
-        jobId,
-        status: "failed",
-        fileName: null,
-        downloadUrl: null,
-        error: errorMessage,
-      };
-    }
+    return this.jobs.exportChapter(userId, projectId, chapterId, format);
   }
 
-  /**
-   * Get the status of an export job.
-   *
-   * Per US-022: GET /exports/:jobId returns job status + signed download URL.
-   * Download URL is only included for completed jobs (1-hour cache via download endpoint).
-   */
-  async getExportStatus(userId: string, jobId: string): Promise<ExportJobStatus> {
-    const job = await this.db
-      .prepare(
-        `SELECT id, user_id, format, status, r2_key, error_message, chapter_count,
-                total_word_count, created_at, completed_at
-         FROM export_jobs WHERE id = ? AND user_id = ?`,
-      )
-      .bind(jobId, userId)
-      .first<ExportJobRow>();
+  // ── Delivery (delegated to ExportDeliveryService) ──
 
-    if (!job) {
-      notFound("Export not found");
-    }
-
-    let fileName: string | null = null;
-    let downloadUrl: string | null = null;
-
-    if (job.status === "completed" && job.r2_key) {
-      // Retrieve the file name from R2 custom metadata
-      const head = await this.bucket.head(job.r2_key);
-      fileName = head?.customMetadata?.fileName || `export-${jobId}.${job.format}`;
-      downloadUrl = `${this.apiBaseUrl}/exports/${jobId}/download`;
-    }
-
-    return {
-      jobId: job.id,
-      status: job.status as ExportJobStatus["status"],
-      format: job.format,
-      fileName,
-      downloadUrl,
-      chapterCount: job.chapter_count,
-      totalWordCount: job.total_word_count,
-      error: job.error_message,
-      createdAt: job.created_at,
-      completedAt: job.completed_at,
-    };
+  getExportStatus(userId: string, jobId: string): Promise<ExportJobStatus> {
+    return this.delivery.getExportStatus(userId, jobId);
   }
 
-  /**
-   * Get the download for a completed export job.
-   * Streams the file directly from R2.
-   */
-  async getExportDownload(
+  getExportDownload(
     userId: string,
     jobId: string,
   ): Promise<{ data: ReadableStream; fileName: string; contentType: string }> {
-    const job = await this.db
-      .prepare(
-        `SELECT id, user_id, r2_key, format, status FROM export_jobs WHERE id = ? AND user_id = ?`,
-      )
-      .bind(jobId, userId)
-      .first<{
-        id: string;
-        user_id: string;
-        r2_key: string | null;
-        format: string;
-        status: string;
-      }>();
-
-    if (!job) {
-      notFound("Export not found");
-    }
-
-    if (job.status !== "completed" || !job.r2_key) {
-      notFound("Export not available for download");
-    }
-
-    const object = await this.bucket.get(job.r2_key);
-    if (!object) {
-      notFound("Export file not found in storage");
-    }
-
-    const fileName = object.customMetadata?.fileName || `export-${jobId}.${job.format || "pdf"}`;
-    const contentType = job.format === "epub" ? "application/epub+zip" : "application/pdf";
-
-    return {
-      data: object.body,
-      fileName,
-      contentType,
-    };
+    return this.delivery.getExportDownload(userId, jobId);
   }
 
-  /**
-   * Save a completed export to Google Drive.
-   *
-   * Per US-021:
-   * 1. Verify the export job belongs to the user and is completed
-   * 2. Look up the project's drive_folder_id
-   * 3. Find or create the _exports/ subfolder
-   * 4. Fetch the export artifact from R2
-   * 5. Upload to Drive with date-stamped file name
-   * 6. Update the export_jobs row with drive_file_id
-   *
-   * @param userId - Authenticated user ID
-   * @param jobId - Export job ID
-   * @param driveService - DriveService instance for Drive API calls
-   * @returns Drive file metadata (id, fileName, webViewLink)
-   */
-  async saveToDrive(
+  saveToDrive(
     userId: string,
     jobId: string,
     driveService: DriveService,
   ): Promise<ExportToDriveResult> {
-    // 1. Verify the export job belongs to the user and is completed
-    const job = await this.db
-      .prepare(
-        `SELECT id, project_id, user_id, r2_key, format, status, drive_file_id
-         FROM export_jobs WHERE id = ? AND user_id = ?`,
-      )
-      .bind(jobId, userId)
-      .first<{
-        id: string;
-        project_id: string;
-        user_id: string;
-        r2_key: string | null;
-        format: string;
-        status: string;
-        drive_file_id: string | null;
-      }>();
-
-    if (!job) {
-      notFound("Export not found");
-    }
-
-    if (job.status !== "completed" || !job.r2_key) {
-      validationError("Export is not available for saving to Drive");
-    }
-
-    // If already saved to Drive, return the existing info
-    if (job.drive_file_id) {
-      // Fetch the file name from R2 metadata
-      const head = await this.bucket.head(job.r2_key);
-      const fileName = head?.customMetadata?.fileName || `export-${jobId}.${job.format}`;
-      return {
-        driveFileId: job.drive_file_id,
-        fileName,
-        webViewLink: `https://drive.google.com/file/d/${job.drive_file_id}/view`,
-      };
-    }
-
-    // 2. Look up the project's drive_folder_id
-    const project = await this.db
-      .prepare(
-        `SELECT id, title, drive_folder_id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`,
-      )
-      .bind(job.project_id, userId)
-      .first<{ id: string; title: string; drive_folder_id: string | null }>();
-
-    if (!project) {
-      notFound("Project not found");
-    }
-
-    if (!project.drive_folder_id) {
-      validationError(
-        "Project does not have a Google Drive folder. Connect Drive and create a book folder first.",
-      );
-    }
-
-    // 3. Get valid Drive tokens
-    const tokens = await driveService.getValidTokens(userId);
-    if (!tokens) {
-      validationError("Google Drive is not connected");
-    }
-
-    // 4. Find or create the _exports/ subfolder
-    const exportsFolderId = await driveService.findOrCreateSubfolder(
-      tokens.accessToken,
-      project.drive_folder_id,
-      "_exports",
-    );
-
-    // 5. Fetch the export artifact from R2
-    const object = await this.bucket.get(job.r2_key);
-    if (!object) {
-      notFound("Export file not found in storage");
-    }
-
-    const fileName = object.customMetadata?.fileName || `export-${jobId}.${job.format}`;
-    const contentType = job.format === "epub" ? "application/epub+zip" : "application/pdf";
-    const fileData = await object.arrayBuffer();
-
-    // 6. Upload to Drive
-    const driveFile = await driveService.uploadFile(
-      tokens.accessToken,
-      exportsFolderId,
-      fileName,
-      contentType,
-      fileData,
-    );
-
-    // 7. Update the export_jobs row with drive_file_id
-    await this.db
-      .prepare(`UPDATE export_jobs SET drive_file_id = ? WHERE id = ?`)
-      .bind(driveFile.id, jobId)
-      .run();
-
-    return {
-      driveFileId: driveFile.id,
-      fileName,
-      webViewLink: driveFile.webViewLink || `https://drive.google.com/file/d/${driveFile.id}/view`,
-    };
-  }
-
-  /**
-   * Fetch chapter content from R2 sequentially.
-   * Per ADR-004: sequential fetching is memory-safe for book-length documents.
-   */
-  private async fetchChapterContents(chapterRows: ChapterRow[]): Promise<ChapterContent[]> {
-    const contentMap = await fetchChapterContentsFromR2(this.bucket, chapterRows);
-
-    // Include chapters even with empty content (they'll just have the heading)
-    return chapterRows.map((row) => ({
-      id: row.id,
-      title: row.title,
-      sortOrder: row.sort_order,
-      html: contentMap.get(row) ?? "",
-      wordCount: row.word_count,
-    }));
-  }
-
-  /**
-   * Get the author's display name from the users table.
-   */
-  private async getAuthorName(userId: string): Promise<string> {
-    const user = await this.db
-      .prepare(`SELECT display_name, email FROM users WHERE id = ?`)
-      .bind(userId)
-      .first<UserRow>();
-
-    if (user?.display_name) {
-      return user.display_name;
-    }
-
-    // Fall back to email prefix
-    if (user?.email) {
-      return user.email.split("@")[0];
-    }
-
-    return "Author";
+    return this.delivery.saveToDrive(userId, jobId, driveService);
   }
 }

--- a/workers/dc-api/src/services/source-drive.ts
+++ b/workers/dc-api/src/services/source-drive.ts
@@ -1,0 +1,299 @@
+/**
+ * Drive source material handling -- adding sources from Google Picker, folder expansion,
+ * fetching and caching Drive content.
+ *
+ * Split from source-material.ts per Single Responsibility Principle.
+ * Handles the Google Drive integration side of source materials:
+ * - Adding Drive files selected via Picker
+ * - Recursive folder expansion to discover Google Docs
+ * - Fetching, sanitizing, and caching Google Docs content in R2
+ */
+
+import { ulid } from "ulidx";
+import { notFound, validationError } from "../middleware/error-handler.js";
+import { countWords } from "../utils/word-count.js";
+import { sanitizeGoogleDocsHtml } from "../utils/html-sanitize.js";
+import type { DriveService } from "./drive.js";
+import {
+  type AddSourceInput,
+  type AddSourcesResult,
+  type SourceMaterial,
+  type SourceContentResult,
+} from "./source-types.js";
+
+const ALLOWED_MIME_TYPE = "application/vnd.google-apps.document";
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
+const MAX_SOURCES_PER_REQUEST = 20;
+const MAX_EXPANDED_DOCS_PER_REQUEST = 200;
+
+export class SourceDriveService {
+  constructor(
+    private readonly db: D1Database,
+    private readonly bucket: R2Bucket,
+  ) {}
+
+  /**
+   * Add source materials from Google Picker selection.
+   * Validates mime types (Google Docs only) and deduplicates silently.
+   *
+   * @param connectionId - The Drive connection to associate these sources with
+   */
+  async addSources(
+    userId: string,
+    projectId: string,
+    files: AddSourceInput[],
+    driveService?: DriveService,
+    connectionId?: string,
+  ): Promise<AddSourcesResult> {
+    // Verify project ownership
+    const project = await this.db
+      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`)
+      .bind(projectId, userId)
+      .first<{ id: string }>();
+
+    if (!project) {
+      notFound("Project not found");
+    }
+
+    if (!files || files.length === 0) {
+      validationError("At least one file is required");
+    }
+
+    if (files.length > MAX_SOURCES_PER_REQUEST) {
+      validationError(`Maximum ${MAX_SOURCES_PER_REQUEST} files per request`);
+    }
+
+    const selectedDocs = files.filter((f) => f.mimeType === ALLOWED_MIME_TYPE);
+    const selectedFolders = files.filter((f) => f.mimeType === GOOGLE_FOLDER_MIME_TYPE);
+
+    // Expand selected folders into Google Docs (recursive).
+    let discoveredFromFolders: AddSourceInput[] = [];
+    if (selectedFolders.length > 0) {
+      if (!driveService || !connectionId) {
+        throw new Error(
+          "DriveService and connectionId are required when adding folders as sources",
+        );
+      }
+
+      const tokens = await driveService.getValidTokensByConnection(connectionId);
+      if (!tokens) {
+        validationError("Google Drive is not connected. Connect Drive to add folder sources.");
+      }
+
+      try {
+        const docs = await driveService.listDocsInFoldersRecursive(
+          tokens.accessToken,
+          selectedFolders.map((f) => f.driveFileId),
+          MAX_EXPANDED_DOCS_PER_REQUEST,
+        );
+        discoveredFromFolders = docs.map((doc) => ({
+          driveFileId: doc.id,
+          title: doc.name || "Untitled Google Doc",
+          mimeType: ALLOWED_MIME_TYPE,
+        }));
+      } catch (err) {
+        if (err instanceof Error && err.message === "MAX_DOCS_EXCEEDED") {
+          validationError(`Maximum ${MAX_EXPANDED_DOCS_PER_REQUEST} docs may be imported at once`);
+        }
+        throw err;
+      }
+    }
+
+    const docsToInsert = [...selectedDocs, ...discoveredFromFolders];
+    const docsById = new Map<string, AddSourceInput>();
+    for (const file of docsToInsert) {
+      if (!docsById.has(file.driveFileId)) {
+        docsById.set(file.driveFileId, file);
+      }
+    }
+    const uniqueDocsToInsert = Array.from(docsById.values());
+
+    // Get current max sort_order
+    const maxSort = await this.db
+      .prepare(
+        `SELECT MAX(sort_order) as max_sort FROM source_materials
+         WHERE project_id = ? AND status = 'active'`,
+      )
+      .bind(projectId)
+      .first<{ max_sort: number | null }>();
+
+    let sortOrder = (maxSort?.max_sort || 0) + 1;
+    const now = new Date().toISOString();
+    const created: SourceMaterial[] = [];
+
+    for (const file of uniqueDocsToInsert) {
+      const id = ulid();
+
+      // Check for existing source with same drive_file_id (partial unique index not usable with ON CONFLICT)
+      const existing = await this.db
+        .prepare(`SELECT id FROM source_materials WHERE project_id = ? AND drive_file_id = ?`)
+        .bind(projectId, file.driveFileId)
+        .first<{ id: string }>();
+
+      if (existing) continue;
+
+      await this.db
+        .prepare(
+          `INSERT INTO source_materials (id, project_id, source_type, drive_connection_id, drive_file_id, title, mime_type, sort_order, created_at, updated_at)
+           VALUES (?, ?, 'drive', ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .bind(
+          id,
+          projectId,
+          connectionId || null,
+          file.driveFileId,
+          file.title,
+          file.mimeType,
+          sortOrder,
+          now,
+          now,
+        )
+        .run();
+
+      created.push({
+        id,
+        projectId,
+        sourceType: "drive",
+        driveConnectionId: connectionId || null,
+        driveFileId: file.driveFileId,
+        title: file.title,
+        mimeType: file.mimeType,
+        originalFilename: null,
+        driveModifiedTime: null,
+        wordCount: 0,
+        r2Key: null,
+        cachedAt: null,
+        status: "active",
+        sortOrder,
+        createdAt: now,
+        updatedAt: now,
+      });
+      sortOrder++;
+    }
+
+    if (selectedFolders.length > 0) {
+      console.info(
+        JSON.stringify({
+          level: "info",
+          event: "sources_folder_expand_complete",
+          user_id: userId,
+          project_id: projectId,
+          selected_folders: selectedFolders.length,
+          docs_discovered: discoveredFromFolders.length,
+          docs_inserted: created.length,
+        }),
+      );
+      return {
+        sources: created,
+        expandedCounts: {
+          selectedFolders: selectedFolders.length,
+          docsDiscovered: discoveredFromFolders.length,
+          docsInserted: created.length,
+        },
+      };
+    }
+
+    return { sources: created };
+  }
+
+  /**
+   * Fetch content from Drive, sanitize, and cache in R2.
+   * Updates D1 metadata (word_count, cached_at, drive_modified_time).
+   */
+  async fetchAndCache(
+    userId: string,
+    sourceId: string,
+    driveFileId: string,
+    driveConnectionId: string | null,
+    driveService: DriveService,
+  ): Promise<SourceContentResult> {
+    // Get tokens: prefer connection-specific, fall back to user's first connection
+    let accessToken: string;
+    if (driveConnectionId) {
+      const tokens = await driveService.getValidTokensByConnection(driveConnectionId);
+      if (!tokens) {
+        validationError(
+          "Drive connection not found. The Google account may have been disconnected.",
+        );
+      }
+      accessToken = tokens.accessToken;
+    } else {
+      const tokens = await driveService.getValidTokens(userId);
+      if (!tokens) {
+        validationError("Google Drive is not connected. Connect Drive to access source content.");
+      }
+      accessToken = tokens.accessToken;
+    }
+
+    let rawHtml: string;
+    try {
+      rawHtml = await driveService.exportFile(accessToken, driveFileId, "text/html");
+    } catch (err) {
+      // Mark source as error state so UI can show appropriate message
+      await this.db
+        .prepare(`UPDATE source_materials SET status = 'error', updated_at = ? WHERE id = ?`)
+        .bind(new Date().toISOString(), sourceId)
+        .run();
+      throw err;
+    }
+
+    const content = sanitizeGoogleDocsHtml(rawHtml);
+    const wordCount = countWords(content);
+    const now = new Date().toISOString();
+    const r2Key = `sources/${sourceId}/content.html`;
+
+    // Get Drive file's modifiedTime for staleness tracking
+    let driveModifiedTime: string | null = null;
+    try {
+      const metadata = await driveService.getFileMetadata(accessToken, driveFileId);
+      driveModifiedTime = metadata.modifiedTime ?? null;
+    } catch {
+      // Non-critical -- staleness detection just won't work until next fetch
+    }
+
+    // Write sanitized content to R2
+    await this.bucket.put(r2Key, content, {
+      httpMetadata: { contentType: "text/html; charset=utf-8" },
+      customMetadata: { sourceId, cachedAt: now },
+    });
+
+    // Update D1 metadata
+    await this.db
+      .prepare(
+        `UPDATE source_materials
+         SET r2_key = ?, word_count = ?, cached_at = ?, drive_modified_time = ?,
+             status = 'active', updated_at = ?
+         WHERE id = ?`,
+      )
+      .bind(r2Key, wordCount, now, driveModifiedTime, now, sourceId)
+      .run();
+
+    return { content, wordCount, cachedAt: now };
+  }
+
+  /**
+   * Archive all sources for a disconnected Drive connection.
+   * Also soft-archives related chapter_sources links (preserving them for reconnection).
+   */
+  async archiveByConnection(connectionId: string): Promise<void> {
+    const now = new Date().toISOString();
+
+    // Archive source materials
+    await this.db
+      .prepare(
+        `UPDATE source_materials SET status = 'archived', updated_at = ?
+         WHERE drive_connection_id = ?`,
+      )
+      .bind(now, connectionId)
+      .run();
+
+    // Soft-archive chapter-source links
+    await this.db
+      .prepare(
+        `UPDATE chapter_sources SET status = 'archived'
+         WHERE source_id IN (SELECT id FROM source_materials WHERE drive_connection_id = ?)`,
+      )
+      .bind(connectionId)
+      .run();
+  }
+}

--- a/workers/dc-api/src/services/source-local.ts
+++ b/workers/dc-api/src/services/source-local.ts
@@ -1,0 +1,227 @@
+/**
+ * Local source material handling -- file upload, text/markdown conversion, dedup.
+ *
+ * Split from source-material.ts per Single Responsibility Principle.
+ * Handles .txt and .md file uploads: validation, content conversion to HTML,
+ * content hash dedup, R2 storage, and D1 metadata.
+ */
+
+import { ulid } from "ulidx";
+import { notFound, validationError } from "../middleware/error-handler.js";
+import { countWords } from "../utils/word-count.js";
+import { type SourceMaterial, type SourceRow, rowToSource } from "./source-types.js";
+
+const MAX_LOCAL_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_LOCAL_EXTENSIONS = [".txt", ".md"];
+
+/** Convert plain text to simple HTML paragraphs */
+export function textToHtml(text: string): string {
+  return text
+    .split(/\n\n+/)
+    .filter((p) => p.trim().length > 0)
+    .map(
+      (p) =>
+        `<p>${p.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").trim()}</p>`,
+    )
+    .join("\n");
+}
+
+/** Lightweight Markdown to HTML (headings, bold, italic, lists, paragraphs) */
+export function markdownToHtml(md: string): string {
+  const lines = md.split("\n");
+  const htmlLines: string[] = [];
+  let inList = false;
+
+  for (const rawLine of lines) {
+    const line = rawLine;
+
+    // Headings
+    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
+    if (headingMatch) {
+      if (inList) {
+        htmlLines.push("</ul>");
+        inList = false;
+      }
+      const level = headingMatch[1].length;
+      htmlLines.push(`<h${level}>${headingMatch[2]}</h${level}>`);
+      continue;
+    }
+
+    // Unordered list items
+    const listMatch = line.match(/^[-*+]\s+(.+)$/);
+    if (listMatch) {
+      if (!inList) {
+        htmlLines.push("<ul>");
+        inList = true;
+      }
+      htmlLines.push(`<li>${listMatch[1]}</li>`);
+      continue;
+    }
+
+    // Close list if not a list item
+    if (inList) {
+      htmlLines.push("</ul>");
+      inList = false;
+    }
+
+    // Empty lines
+    if (line.trim() === "") {
+      continue;
+    }
+
+    // Regular paragraph - apply inline formatting
+    let formatted = line
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+      .replace(/__(.+?)__/g, "<strong>$1</strong>")
+      .replace(/\*(.+?)\*/g, "<em>$1</em>")
+      .replace(/_(.+?)_/g, "<em>$1</em>");
+    htmlLines.push(`<p>${formatted}</p>`);
+  }
+
+  if (inList) htmlLines.push("</ul>");
+  return htmlLines.join("\n");
+}
+
+export class SourceLocalService {
+  constructor(
+    private readonly db: D1Database,
+    private readonly bucket: R2Bucket,
+  ) {}
+
+  /**
+   * Add a local file as a source material.
+   * Supports .txt and .md files up to 5MB.
+   * Deduplicates on (project_id, content_hash).
+   */
+  async addLocalSource(
+    userId: string,
+    projectId: string,
+    file: { name: string; content: ArrayBuffer },
+  ): Promise<SourceMaterial> {
+    // Verify project ownership
+    const project = await this.db
+      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`)
+      .bind(projectId, userId)
+      .first<{ id: string }>();
+
+    if (!project) {
+      notFound("Project not found");
+    }
+
+    // Validate file size
+    if (file.content.byteLength > MAX_LOCAL_FILE_SIZE) {
+      validationError(`File must be under ${MAX_LOCAL_FILE_SIZE / 1024 / 1024}MB`);
+    }
+
+    // Validate extension
+    const ext =
+      file.name.lastIndexOf(".") >= 0
+        ? file.name.slice(file.name.lastIndexOf(".")).toLowerCase()
+        : "";
+    if (!ALLOWED_LOCAL_EXTENSIONS.includes(ext)) {
+      validationError(`Only ${ALLOWED_LOCAL_EXTENSIONS.join(", ")} files are supported`);
+    }
+
+    // Compute content hash for dedup (SHA-256 via Web Crypto)
+    const hashBuffer = await crypto.subtle.digest("SHA-256", file.content);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const contentHash = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+
+    // Check for existing source with same hash in this project
+    const existing = await this.db
+      .prepare(
+        `SELECT id FROM source_materials
+         WHERE project_id = ? AND content_hash = ? AND source_type = 'local' AND status = 'active'`,
+      )
+      .bind(projectId, contentHash)
+      .first<{ id: string }>();
+
+    if (existing) {
+      // Return the existing source
+      const row = await this.db
+        .prepare(`SELECT * FROM source_materials WHERE id = ?`)
+        .bind(existing.id)
+        .first<SourceRow>();
+      return rowToSource(row!);
+    }
+
+    // Decode content
+    const textContent = new TextDecoder().decode(file.content);
+
+    // Convert to HTML based on extension
+    const html = ext === ".md" ? markdownToHtml(textContent) : textToHtml(textContent);
+    const wordCount = countWords(html);
+    const mimeType = ext === ".md" ? "text/markdown" : "text/plain";
+
+    // Get next sort_order
+    const maxSort = await this.db
+      .prepare(
+        `SELECT MAX(sort_order) as max_sort FROM source_materials
+         WHERE project_id = ? AND status = 'active'`,
+      )
+      .bind(projectId)
+      .first<{ max_sort: number | null }>();
+
+    const sortOrder = (maxSort?.max_sort || 0) + 1;
+    const id = ulid();
+    const now = new Date().toISOString();
+    const r2Key = `sources/${id}/content.html`;
+    const title = file.name.replace(/\.[^.]+$/, ""); // Strip extension for title
+
+    // Write HTML content to R2
+    await this.bucket.put(r2Key, html, {
+      httpMetadata: { contentType: "text/html; charset=utf-8" },
+      customMetadata: { sourceId: id, cachedAt: now },
+    });
+
+    // Store original file in R2
+    await this.bucket.put(`sources/${id}/original${ext}`, file.content, {
+      httpMetadata: { contentType: mimeType },
+      customMetadata: { sourceId: id, originalFilename: file.name },
+    });
+
+    // Insert into D1
+    await this.db
+      .prepare(
+        `INSERT INTO source_materials (id, project_id, source_type, title, mime_type, original_filename, content_hash, word_count, r2_key, cached_at, sort_order, created_at, updated_at)
+         VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id,
+        projectId,
+        title,
+        mimeType,
+        file.name,
+        contentHash,
+        wordCount,
+        r2Key,
+        now,
+        sortOrder,
+        now,
+        now,
+      )
+      .run();
+
+    return {
+      id,
+      projectId,
+      sourceType: "local",
+      driveConnectionId: null,
+      driveFileId: null,
+      title,
+      mimeType,
+      originalFilename: file.name,
+      driveModifiedTime: null,
+      wordCount,
+      r2Key: r2Key,
+      cachedAt: now,
+      status: "active",
+      sortOrder,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+}

--- a/workers/dc-api/src/services/source-material.ts
+++ b/workers/dc-api/src/services/source-material.ts
@@ -1,495 +1,85 @@
+/**
+ * Source material service facade -- composes SourceDriveService, SourceLocalService,
+ * and CRUD operations.
+ *
+ * This module preserves the original SourceMaterialService public API so that route
+ * files and test files do not need import changes. Internally, responsibilities
+ * are delegated to focused sub-services:
+ *
+ *   - source-types.ts  -- Shared types and row-to-model mapping
+ *   - source-drive.ts  -- Drive source addition, folder expansion, content fetching
+ *   - source-local.ts  -- Local file upload and conversion
+ *
+ * CRUD operations (list, get, remove, importAsChapter, getContent) remain in this
+ * file as they are lightweight and cross-cutting.
+ *
+ * Re-exports all public types from sub-modules for backward compatibility.
+ */
+
 import { ulid } from "ulidx";
 import { notFound, validationError } from "../middleware/error-handler.js";
 import { countWords } from "../utils/word-count.js";
-import { sanitizeGoogleDocsHtml } from "../utils/html-sanitize.js";
 import type { DriveService } from "./drive.js";
+import { SourceDriveService } from "./source-drive.js";
+import { SourceLocalService } from "./source-local.js";
+import {
+  type AddSourceInput,
+  type AddSourcesResult,
+  type SourceMaterial,
+  type SourceContentResult,
+  type ImportAsChapterResult,
+  type SourceRow,
+  rowToSource,
+} from "./source-types.js";
 
-/**
- * SourceMaterialService - Manages reference material from Google Drive and local uploads.
- *
- * Sources are polymorphic: either Drive files (Google Docs selected via Picker)
- * or local uploads (.txt, .md). Content is cached in R2 as sanitized HTML.
- *
- * R2 key format:
- * - sources/{sourceId}/content.html -- processed/extracted HTML
- * - sources/{sourceId}/original.{ext} -- original file (local uploads only)
- *
- * No content stored in D1 -- only metadata.
- */
-
-/** Input for adding Drive sources from Google Picker selection */
-export interface AddSourceInput {
-  driveFileId: string;
-  title: string;
-  mimeType: string;
-}
-
-export interface AddSourcesResult {
-  sources: SourceMaterial[];
-  expandedCounts?: {
-    selectedFolders: number;
-    docsDiscovered: number;
-    docsInserted: number;
-  };
-}
-
-/** Source material as returned to the API */
-export interface SourceMaterial {
-  id: string;
-  projectId: string;
-  sourceType: "drive" | "local";
-  driveConnectionId: string | null;
-  driveFileId: string | null;
-  title: string;
-  mimeType: string;
-  originalFilename: string | null;
-  driveModifiedTime: string | null;
-  wordCount: number;
-  r2Key: string | null;
-  cachedAt: string | null;
-  status: "active" | "archived" | "error";
-  sortOrder: number;
-  createdAt: string;
-  updatedAt: string;
-}
-
-/** Result of fetching source content */
-export interface SourceContentResult {
-  content: string;
-  wordCount: number;
-  cachedAt: string;
-}
-
-/** Result of importing a source as a chapter */
-export interface ImportAsChapterResult {
-  chapterId: string;
-  title: string;
-  wordCount: number;
-}
-
-/** DB row shape */
-interface SourceRow {
-  id: string;
-  project_id: string;
-  source_type: string;
-  drive_connection_id: string | null;
-  drive_file_id: string | null;
-  title: string;
-  mime_type: string;
-  original_filename: string | null;
-  content_hash: string | null;
-  drive_modified_time: string | null;
-  word_count: number;
-  r2_key: string | null;
-  cached_at: string | null;
-  status: string;
-  sort_order: number;
-  created_at: string;
-  updated_at: string;
-}
-
-const ALLOWED_MIME_TYPE = "application/vnd.google-apps.document";
-const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
-const MAX_SOURCES_PER_REQUEST = 20;
-const MAX_EXPANDED_DOCS_PER_REQUEST = 200;
-const MAX_LOCAL_FILE_SIZE = 5 * 1024 * 1024; // 5MB
-const ALLOWED_LOCAL_EXTENSIONS = [".txt", ".md"];
-
-function rowToSource(row: SourceRow): SourceMaterial {
-  return {
-    id: row.id,
-    projectId: row.project_id,
-    sourceType: row.source_type as SourceMaterial["sourceType"],
-    driveConnectionId: row.drive_connection_id,
-    driveFileId: row.drive_file_id,
-    title: row.title,
-    mimeType: row.mime_type,
-    originalFilename: row.original_filename,
-    driveModifiedTime: row.drive_modified_time,
-    wordCount: row.word_count,
-    r2Key: row.r2_key,
-    cachedAt: row.cached_at,
-    status: row.status as SourceMaterial["status"],
-    sortOrder: row.sort_order,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
-  };
-}
-
-/** Convert plain text to simple HTML paragraphs */
-function textToHtml(text: string): string {
-  return text
-    .split(/\n\n+/)
-    .filter((p) => p.trim().length > 0)
-    .map(
-      (p) =>
-        `<p>${p.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").trim()}</p>`,
-    )
-    .join("\n");
-}
-
-/** Lightweight Markdown to HTML (headings, bold, italic, lists, paragraphs) */
-function markdownToHtml(md: string): string {
-  const lines = md.split("\n");
-  const htmlLines: string[] = [];
-  let inList = false;
-
-  for (const rawLine of lines) {
-    const line = rawLine;
-
-    // Headings
-    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
-    if (headingMatch) {
-      if (inList) {
-        htmlLines.push("</ul>");
-        inList = false;
-      }
-      const level = headingMatch[1].length;
-      htmlLines.push(`<h${level}>${headingMatch[2]}</h${level}>`);
-      continue;
-    }
-
-    // Unordered list items
-    const listMatch = line.match(/^[-*+]\s+(.+)$/);
-    if (listMatch) {
-      if (!inList) {
-        htmlLines.push("<ul>");
-        inList = true;
-      }
-      htmlLines.push(`<li>${listMatch[1]}</li>`);
-      continue;
-    }
-
-    // Close list if not a list item
-    if (inList) {
-      htmlLines.push("</ul>");
-      inList = false;
-    }
-
-    // Empty lines
-    if (line.trim() === "") {
-      continue;
-    }
-
-    // Regular paragraph - apply inline formatting
-    let formatted = line
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-      .replace(/__(.+?)__/g, "<strong>$1</strong>")
-      .replace(/\*(.+?)\*/g, "<em>$1</em>")
-      .replace(/_(.+?)_/g, "<em>$1</em>");
-    htmlLines.push(`<p>${formatted}</p>`);
-  }
-
-  if (inList) htmlLines.push("</ul>");
-  return htmlLines.join("\n");
-}
+// Re-export public types so existing imports from "./source-material.js" still work
+export type {
+  AddSourceInput,
+  AddSourcesResult,
+  SourceMaterial,
+  SourceContentResult,
+  ImportAsChapterResult,
+} from "./source-types.js";
 
 export class SourceMaterialService {
+  private readonly driveService: SourceDriveService;
+  private readonly localService: SourceLocalService;
+
   constructor(
     private readonly db: D1Database,
     private readonly bucket: R2Bucket,
-  ) {}
+  ) {
+    this.driveService = new SourceDriveService(db, bucket);
+    this.localService = new SourceLocalService(db, bucket);
+  }
 
-  /**
-   * Add source materials from Google Picker selection.
-   * Validates mime types (Google Docs only) and deduplicates silently.
-   *
-   * @param connectionId - The Drive connection to associate these sources with
-   */
-  async addSources(
+  // ── Drive sources (delegated to SourceDriveService) ──
+
+  addSources(
     userId: string,
     projectId: string,
     files: AddSourceInput[],
     driveService?: DriveService,
     connectionId?: string,
   ): Promise<AddSourcesResult> {
-    // Verify project ownership
-    const project = await this.db
-      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`)
-      .bind(projectId, userId)
-      .first<{ id: string }>();
-
-    if (!project) {
-      notFound("Project not found");
-    }
-
-    if (!files || files.length === 0) {
-      validationError("At least one file is required");
-    }
-
-    if (files.length > MAX_SOURCES_PER_REQUEST) {
-      validationError(`Maximum ${MAX_SOURCES_PER_REQUEST} files per request`);
-    }
-
-    const selectedDocs = files.filter((f) => f.mimeType === ALLOWED_MIME_TYPE);
-    const selectedFolders = files.filter((f) => f.mimeType === GOOGLE_FOLDER_MIME_TYPE);
-
-    // Expand selected folders into Google Docs (recursive).
-    let discoveredFromFolders: AddSourceInput[] = [];
-    if (selectedFolders.length > 0) {
-      if (!driveService || !connectionId) {
-        throw new Error(
-          "DriveService and connectionId are required when adding folders as sources",
-        );
-      }
-
-      const tokens = await driveService.getValidTokensByConnection(connectionId);
-      if (!tokens) {
-        validationError("Google Drive is not connected. Connect Drive to add folder sources.");
-      }
-
-      try {
-        const docs = await driveService.listDocsInFoldersRecursive(
-          tokens.accessToken,
-          selectedFolders.map((f) => f.driveFileId),
-          MAX_EXPANDED_DOCS_PER_REQUEST,
-        );
-        discoveredFromFolders = docs.map((doc) => ({
-          driveFileId: doc.id,
-          title: doc.name || "Untitled Google Doc",
-          mimeType: ALLOWED_MIME_TYPE,
-        }));
-      } catch (err) {
-        if (err instanceof Error && err.message === "MAX_DOCS_EXCEEDED") {
-          validationError(`Maximum ${MAX_EXPANDED_DOCS_PER_REQUEST} docs may be imported at once`);
-        }
-        throw err;
-      }
-    }
-
-    const docsToInsert = [...selectedDocs, ...discoveredFromFolders];
-    const docsById = new Map<string, AddSourceInput>();
-    for (const file of docsToInsert) {
-      if (!docsById.has(file.driveFileId)) {
-        docsById.set(file.driveFileId, file);
-      }
-    }
-    const uniqueDocsToInsert = Array.from(docsById.values());
-
-    // Get current max sort_order
-    const maxSort = await this.db
-      .prepare(
-        `SELECT MAX(sort_order) as max_sort FROM source_materials
-         WHERE project_id = ? AND status = 'active'`,
-      )
-      .bind(projectId)
-      .first<{ max_sort: number | null }>();
-
-    let sortOrder = (maxSort?.max_sort || 0) + 1;
-    const now = new Date().toISOString();
-    const created: SourceMaterial[] = [];
-
-    for (const file of uniqueDocsToInsert) {
-      const id = ulid();
-
-      // Check for existing source with same drive_file_id (partial unique index not usable with ON CONFLICT)
-      const existing = await this.db
-        .prepare(`SELECT id FROM source_materials WHERE project_id = ? AND drive_file_id = ?`)
-        .bind(projectId, file.driveFileId)
-        .first<{ id: string }>();
-
-      if (existing) continue;
-
-      await this.db
-        .prepare(
-          `INSERT INTO source_materials (id, project_id, source_type, drive_connection_id, drive_file_id, title, mime_type, sort_order, created_at, updated_at)
-           VALUES (?, ?, 'drive', ?, ?, ?, ?, ?, ?, ?)`,
-        )
-        .bind(
-          id,
-          projectId,
-          connectionId || null,
-          file.driveFileId,
-          file.title,
-          file.mimeType,
-          sortOrder,
-          now,
-          now,
-        )
-        .run();
-
-      created.push({
-        id,
-        projectId,
-        sourceType: "drive",
-        driveConnectionId: connectionId || null,
-        driveFileId: file.driveFileId,
-        title: file.title,
-        mimeType: file.mimeType,
-        originalFilename: null,
-        driveModifiedTime: null,
-        wordCount: 0,
-        r2Key: null,
-        cachedAt: null,
-        status: "active",
-        sortOrder,
-        createdAt: now,
-        updatedAt: now,
-      });
-      sortOrder++;
-    }
-
-    if (selectedFolders.length > 0) {
-      console.info(
-        JSON.stringify({
-          level: "info",
-          event: "sources_folder_expand_complete",
-          user_id: userId,
-          project_id: projectId,
-          selected_folders: selectedFolders.length,
-          docs_discovered: discoveredFromFolders.length,
-          docs_inserted: created.length,
-        }),
-      );
-      return {
-        sources: created,
-        expandedCounts: {
-          selectedFolders: selectedFolders.length,
-          docsDiscovered: discoveredFromFolders.length,
-          docsInserted: created.length,
-        },
-      };
-    }
-
-    return { sources: created };
+    return this.driveService.addSources(userId, projectId, files, driveService, connectionId);
   }
 
-  /**
-   * Add a local file as a source material.
-   * Supports .txt and .md files up to 5MB.
-   * Deduplicates on (project_id, content_hash).
-   */
-  async addLocalSource(
+  archiveByConnection(connectionId: string): Promise<void> {
+    return this.driveService.archiveByConnection(connectionId);
+  }
+
+  // ── Local sources (delegated to SourceLocalService) ──
+
+  addLocalSource(
     userId: string,
     projectId: string,
     file: { name: string; content: ArrayBuffer },
   ): Promise<SourceMaterial> {
-    // Verify project ownership
-    const project = await this.db
-      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`)
-      .bind(projectId, userId)
-      .first<{ id: string }>();
-
-    if (!project) {
-      notFound("Project not found");
-    }
-
-    // Validate file size
-    if (file.content.byteLength > MAX_LOCAL_FILE_SIZE) {
-      validationError(`File must be under ${MAX_LOCAL_FILE_SIZE / 1024 / 1024}MB`);
-    }
-
-    // Validate extension
-    const ext =
-      file.name.lastIndexOf(".") >= 0
-        ? file.name.slice(file.name.lastIndexOf(".")).toLowerCase()
-        : "";
-    if (!ALLOWED_LOCAL_EXTENSIONS.includes(ext)) {
-      validationError(`Only ${ALLOWED_LOCAL_EXTENSIONS.join(", ")} files are supported`);
-    }
-
-    // Compute content hash for dedup (SHA-256 via Web Crypto)
-    const hashBuffer = await crypto.subtle.digest("SHA-256", file.content);
-    const hashArray = Array.from(new Uint8Array(hashBuffer));
-    const contentHash = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
-
-    // Check for existing source with same hash in this project
-    const existing = await this.db
-      .prepare(
-        `SELECT id FROM source_materials
-         WHERE project_id = ? AND content_hash = ? AND source_type = 'local' AND status = 'active'`,
-      )
-      .bind(projectId, contentHash)
-      .first<{ id: string }>();
-
-    if (existing) {
-      // Return the existing source
-      const row = await this.db
-        .prepare(`SELECT * FROM source_materials WHERE id = ?`)
-        .bind(existing.id)
-        .first<SourceRow>();
-      return rowToSource(row!);
-    }
-
-    // Decode content
-    const textContent = new TextDecoder().decode(file.content);
-
-    // Convert to HTML based on extension
-    const html = ext === ".md" ? markdownToHtml(textContent) : textToHtml(textContent);
-    const wordCount = countWords(html);
-    const mimeType = ext === ".md" ? "text/markdown" : "text/plain";
-
-    // Get next sort_order
-    const maxSort = await this.db
-      .prepare(
-        `SELECT MAX(sort_order) as max_sort FROM source_materials
-         WHERE project_id = ? AND status = 'active'`,
-      )
-      .bind(projectId)
-      .first<{ max_sort: number | null }>();
-
-    const sortOrder = (maxSort?.max_sort || 0) + 1;
-    const id = ulid();
-    const now = new Date().toISOString();
-    const r2Key = `sources/${id}/content.html`;
-    const title = file.name.replace(/\.[^.]+$/, ""); // Strip extension for title
-
-    // Write HTML content to R2
-    await this.bucket.put(r2Key, html, {
-      httpMetadata: { contentType: "text/html; charset=utf-8" },
-      customMetadata: { sourceId: id, cachedAt: now },
-    });
-
-    // Store original file in R2
-    await this.bucket.put(`sources/${id}/original${ext}`, file.content, {
-      httpMetadata: { contentType: mimeType },
-      customMetadata: { sourceId: id, originalFilename: file.name },
-    });
-
-    // Insert into D1
-    await this.db
-      .prepare(
-        `INSERT INTO source_materials (id, project_id, source_type, title, mime_type, original_filename, content_hash, word_count, r2_key, cached_at, sort_order, created_at, updated_at)
-         VALUES (?, ?, 'local', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .bind(
-        id,
-        projectId,
-        title,
-        mimeType,
-        file.name,
-        contentHash,
-        wordCount,
-        r2Key,
-        now,
-        sortOrder,
-        now,
-        now,
-      )
-      .run();
-
-    return {
-      id,
-      projectId,
-      sourceType: "local",
-      driveConnectionId: null,
-      driveFileId: null,
-      title,
-      mimeType,
-      originalFilename: file.name,
-      driveModifiedTime: null,
-      wordCount,
-      r2Key: r2Key,
-      cachedAt: now,
-      status: "active",
-      sortOrder,
-      createdAt: now,
-      updatedAt: now,
-    };
+    return this.localService.addLocalSource(userId, projectId, file);
   }
+
+  // ── CRUD operations ──
 
   /**
    * List source materials for a project.
@@ -545,7 +135,7 @@ export class SourceMaterialService {
   async getContent(
     userId: string,
     sourceId: string,
-    driveService: DriveService,
+    driveApi: DriveService,
   ): Promise<SourceContentResult> {
     const source = await this.getSource(userId, sourceId);
 
@@ -570,88 +160,13 @@ export class SourceMaterialService {
     }
 
     // Fetch from Drive, sanitize, and cache
-    return this.fetchAndCache(
+    return this.driveService.fetchAndCache(
       userId,
       sourceId,
       source.driveFileId!,
       source.driveConnectionId,
-      driveService,
+      driveApi,
     );
-  }
-
-  /**
-   * Fetch content from Drive, sanitize, and cache in R2.
-   * Updates D1 metadata (word_count, cached_at, drive_modified_time).
-   */
-  private async fetchAndCache(
-    userId: string,
-    sourceId: string,
-    driveFileId: string,
-    driveConnectionId: string | null,
-    driveService: DriveService,
-  ): Promise<SourceContentResult> {
-    // Get tokens: prefer connection-specific, fall back to user's first connection
-    let accessToken: string;
-    if (driveConnectionId) {
-      const tokens = await driveService.getValidTokensByConnection(driveConnectionId);
-      if (!tokens) {
-        validationError(
-          "Drive connection not found. The Google account may have been disconnected.",
-        );
-      }
-      accessToken = tokens.accessToken;
-    } else {
-      const tokens = await driveService.getValidTokens(userId);
-      if (!tokens) {
-        validationError("Google Drive is not connected. Connect Drive to access source content.");
-      }
-      accessToken = tokens.accessToken;
-    }
-
-    let rawHtml: string;
-    try {
-      rawHtml = await driveService.exportFile(accessToken, driveFileId, "text/html");
-    } catch (err) {
-      // Mark source as error state so UI can show appropriate message
-      await this.db
-        .prepare(`UPDATE source_materials SET status = 'error', updated_at = ? WHERE id = ?`)
-        .bind(new Date().toISOString(), sourceId)
-        .run();
-      throw err;
-    }
-
-    const content = sanitizeGoogleDocsHtml(rawHtml);
-    const wordCount = countWords(content);
-    const now = new Date().toISOString();
-    const r2Key = `sources/${sourceId}/content.html`;
-
-    // Get Drive file's modifiedTime for staleness tracking
-    let driveModifiedTime: string | null = null;
-    try {
-      const metadata = await driveService.getFileMetadata(accessToken, driveFileId);
-      driveModifiedTime = metadata.modifiedTime ?? null;
-    } catch {
-      // Non-critical -- staleness detection just won't work until next fetch
-    }
-
-    // Write sanitized content to R2
-    await this.bucket.put(r2Key, content, {
-      httpMetadata: { contentType: "text/html; charset=utf-8" },
-      customMetadata: { sourceId, cachedAt: now },
-    });
-
-    // Update D1 metadata
-    await this.db
-      .prepare(
-        `UPDATE source_materials
-         SET r2_key = ?, word_count = ?, cached_at = ?, drive_modified_time = ?,
-             status = 'active', updated_at = ?
-         WHERE id = ?`,
-      )
-      .bind(r2Key, wordCount, now, driveModifiedTime, now, sourceId)
-      .run();
-
-    return { content, wordCount, cachedAt: now };
   }
 
   /**
@@ -676,32 +191,6 @@ export class SourceMaterialService {
   }
 
   /**
-   * Archive all sources for a disconnected Drive connection.
-   * Also soft-archives related chapter_sources links (preserving them for reconnection).
-   */
-  async archiveByConnection(connectionId: string): Promise<void> {
-    const now = new Date().toISOString();
-
-    // Archive source materials
-    await this.db
-      .prepare(
-        `UPDATE source_materials SET status = 'archived', updated_at = ?
-         WHERE drive_connection_id = ?`,
-      )
-      .bind(now, connectionId)
-      .run();
-
-    // Soft-archive chapter-source links
-    await this.db
-      .prepare(
-        `UPDATE chapter_sources SET status = 'archived'
-         WHERE source_id IN (SELECT id FROM source_materials WHERE drive_connection_id = ?)`,
-      )
-      .bind(connectionId)
-      .run();
-  }
-
-  /**
    * Import a source as a new chapter.
    * Creates chapter in D1, writes content to R2.
    * Returns chapter metadata for Drive file creation (fire-and-forget in route handler).
@@ -709,12 +198,12 @@ export class SourceMaterialService {
   async importAsChapter(
     userId: string,
     sourceId: string,
-    driveService: DriveService,
+    driveApi: DriveService,
   ): Promise<ImportAsChapterResult & { projectId: string; r2Key: string }> {
     const source = await this.getSource(userId, sourceId);
 
     // Get content -- from cache or Drive
-    const { content, wordCount } = await this.getContent(userId, sourceId, driveService);
+    const { content, wordCount } = await this.getContent(userId, sourceId, driveApi);
 
     // Get max sort_order for chapters in this project
     const maxSort = await this.db

--- a/workers/dc-api/src/services/source-types.ts
+++ b/workers/dc-api/src/services/source-types.ts
@@ -1,0 +1,99 @@
+/**
+ * Shared types and helpers for source material services.
+ *
+ * Extracted from source-material.ts so that source-local.ts and source-drive.ts
+ * can share these without circular dependencies.
+ */
+
+/** Input for adding Drive sources from Google Picker selection */
+export interface AddSourceInput {
+  driveFileId: string;
+  title: string;
+  mimeType: string;
+}
+
+export interface AddSourcesResult {
+  sources: SourceMaterial[];
+  expandedCounts?: {
+    selectedFolders: number;
+    docsDiscovered: number;
+    docsInserted: number;
+  };
+}
+
+/** Source material as returned to the API */
+export interface SourceMaterial {
+  id: string;
+  projectId: string;
+  sourceType: "drive" | "local";
+  driveConnectionId: string | null;
+  driveFileId: string | null;
+  title: string;
+  mimeType: string;
+  originalFilename: string | null;
+  driveModifiedTime: string | null;
+  wordCount: number;
+  r2Key: string | null;
+  cachedAt: string | null;
+  status: "active" | "archived" | "error";
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Result of fetching source content */
+export interface SourceContentResult {
+  content: string;
+  wordCount: number;
+  cachedAt: string;
+}
+
+/** Result of importing a source as a chapter */
+export interface ImportAsChapterResult {
+  chapterId: string;
+  title: string;
+  wordCount: number;
+}
+
+/** DB row shape */
+export interface SourceRow {
+  id: string;
+  project_id: string;
+  source_type: string;
+  drive_connection_id: string | null;
+  drive_file_id: string | null;
+  title: string;
+  mime_type: string;
+  original_filename: string | null;
+  content_hash: string | null;
+  drive_modified_time: string | null;
+  word_count: number;
+  r2_key: string | null;
+  cached_at: string | null;
+  status: string;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Convert a D1 row to the public SourceMaterial shape */
+export function rowToSource(row: SourceRow): SourceMaterial {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    sourceType: row.source_type as SourceMaterial["sourceType"],
+    driveConnectionId: row.drive_connection_id,
+    driveFileId: row.drive_file_id,
+    title: row.title,
+    mimeType: row.mime_type,
+    originalFilename: row.original_filename,
+    driveModifiedTime: row.drive_modified_time,
+    wordCount: row.word_count,
+    r2Key: row.r2_key,
+    cachedAt: row.cached_at,
+    status: row.status as SourceMaterial["status"],
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}


### PR DESCRIPTION
## Summary
- Split `drive.ts` (921 lines) into `drive-token.ts` (OAuth, token management, connections) and `drive-files.ts` (Google Drive file/folder operations), with `drive.ts` as a thin facade (147 lines)
- Split `export.ts` (621 lines) into `export-job.ts` (PDF/EPUB generation) and `export-delivery.ts` (status queries, download streaming, Drive upload), with `export.ts` as a thin facade (78 lines)
- Split `source-material.ts` (759 lines) into `source-types.ts` (shared types/helpers), `source-drive.ts` (Drive source addition, folder expansion, content caching), and `source-local.ts` (local file upload/conversion), with `source-material.ts` as a thin facade (248 lines)

## Approach
Uses the **facade pattern** to preserve backward compatibility: the original module files delegate to focused sub-services and re-export all public types. No route files or test files needed changes.

## Changes
- 7 new files: `drive-token.ts`, `drive-files.ts`, `export-job.ts`, `export-delivery.ts`, `source-types.ts`, `source-drive.ts`, `source-local.ts`
- 3 modified files: `drive.ts`, `export.ts`, `source-material.ts` (rewritten as thin facades)

## Test Plan
- [x] All 152 existing backend tests pass unchanged
- [x] All 84 frontend tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes (only pre-existing warning)
- [x] Prettier format check passes
- [x] No route file changes needed (zero import changes)

Closes #139

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>