### PR TITLE
refactor: decompose EditorPage god component

### DIFF
--- a/web/src/components/editor-dialogs.tsx
+++ b/web/src/components/editor-dialogs.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import type { ProjectData } from "@/types/editor";
+import type { AIRewriteResult } from "@/components/ai-rewrite-sheet";
+import type { SheetState } from "@/hooks/use-ai-rewrite";
+import type { SourceMaterial } from "@/hooks/use-sources";
+import type { DriveAccount } from "@/hooks/use-drive-accounts";
+import type { DriveFileItem } from "@/hooks/use-drive-files";
+import type { DriveBrowseItem } from "@/hooks/use-drive-browser";
+import { DeleteProjectDialog } from "@/components/delete-project-dialog";
+import { RenameProjectDialog } from "@/components/rename-project-dialog";
+import { DuplicateProjectDialog } from "@/components/duplicate-project-dialog";
+import { DeleteChapterDialog } from "@/components/delete-chapter-dialog";
+import { DisconnectDriveDialog } from "@/components/disconnect-drive-dialog";
+import { AIRewriteSheet } from "@/components/ai-rewrite-sheet";
+import { DriveFilesSheet } from "@/components/drive-files-sheet";
+import { SourcesPanel } from "@/components/sources-panel";
+import { AddSourceSheet } from "@/components/add-source-sheet";
+import { DriveBrowserSheet } from "@/components/drive-browser-sheet";
+import { AccountsSheet } from "@/components/accounts-sheet";
+import { SourceViewerSheet } from "@/components/source-viewer-sheet";
+
+interface EditorDialogsProps {
+  projectData: ProjectData | null;
+  projectId: string;
+  getToken: () => Promise<string | null>;
+  apiUrl: string;
+
+  // Delete project
+  deleteDialogOpen: boolean;
+  onDeleteProject: () => Promise<void>;
+  onCloseDeleteDialog: () => void;
+
+  // Rename project
+  renameDialogOpen: boolean;
+  onRenameProject: (projectId: string, newTitle: string) => Promise<boolean>;
+  onCloseRenameDialog: () => void;
+  setProjectData: React.Dispatch<React.SetStateAction<ProjectData | null>>;
+
+  // Duplicate project
+  duplicateDialogOpen: boolean;
+  onDuplicateProject: (projectId: string) => Promise<string | null>;
+  onCloseDuplicateDialog: () => void;
+
+  // Delete chapter
+  deleteChapterDialogOpen: boolean;
+  chapterToDelete: string | null;
+  onDeleteChapter: () => Promise<void>;
+  onCloseDeleteChapterDialog: () => void;
+
+  // Disconnect Drive
+  disconnectDriveDialogOpen: boolean;
+  driveEmail: string;
+  driveAccounts: DriveAccount[];
+  onDisconnectDriveAccount: (connectionId: string) => Promise<void>;
+  onCloseDisconnectDriveDialog: () => void;
+
+  // AI Rewrite
+  aiSheetState: SheetState;
+  aiCurrentResult: AIRewriteResult | null;
+  aiErrorMessage: string | null;
+  onAIAccept: (result: AIRewriteResult) => Promise<void>;
+  onAIRetry: (result: AIRewriteResult, instruction: string) => Promise<void>;
+  onAIDiscard: (result: AIRewriteResult) => Promise<void>;
+  onGoDeeper: (result: AIRewriteResult) => void;
+
+  // Drive files
+  driveFilesOpen: boolean;
+  driveFiles: DriveFileItem[];
+  driveFilesLoading: boolean;
+  driveFilesError: string | null;
+  isConnectingDrive: boolean;
+  isProjectConnected: boolean;
+  onCloseDriveFiles: () => void;
+  onRefreshDriveFiles: () => void;
+  onConnectProjectToDrive: () => Promise<void>;
+  onDisconnectProjectFromDrive: () => Promise<boolean>;
+  onOpenSourcesPanel: () => void;
+  onOpenDriveBrowser: (connectionId?: string) => Promise<void>;
+
+  // Sources panel
+  isSourcesPanelOpen: boolean;
+  sources: SourceMaterial[];
+  isSourcesLoading: boolean;
+  sourcesError: string | null;
+  isPickerLoading: boolean;
+  onCloseSourcesPanel: () => void;
+  onOpenAddSourceSheet: () => void;
+  onOpenSourceViewer: (source: SourceMaterial) => void;
+  onRemoveSource: (sourceId: string) => Promise<void>;
+  importSourceAsChapter: (sourceId: string) => Promise<{ chapterId: string } | null>;
+  activeChapterTitle: string | undefined;
+  linkedSources: SourceMaterial[];
+  onLinkSource: (sourceId: string) => Promise<void>;
+  onUnlinkSource: (sourceId: string) => Promise<void>;
+  setActiveChapterId: (id: string | null) => void;
+
+  // Add source sheet
+  isAddSourceSheetOpen: boolean;
+  onCloseAddSourceSheet: () => void;
+  onSelectDriveAccount: (connectionId: string) => void;
+  onUploadLocal: (file: File) => Promise<void>;
+
+  // Drive browser
+  isDriveBrowserOpen: boolean;
+  driveItems: DriveBrowseItem[];
+  isDriveLoading: boolean;
+  driveError: string | null;
+  driveCanGoBack: boolean;
+  onCloseDriveBrowser: () => void;
+  onDriveGoBack: () => void;
+  onOpenDriveFolder: (folderId: string) => void;
+  onAddFromDriveBrowser: (files: DriveBrowseItem[]) => Promise<void>;
+  isDriveDoc: (item: DriveBrowseItem) => boolean;
+  isDriveFolder: (item: DriveBrowseItem) => boolean;
+
+  // Accounts sheet
+  isAccountsSheetOpen: boolean;
+  onCloseAccountsSheet: () => void;
+  onConnectAccount: () => void;
+  onRefetchDriveAccounts: () => Promise<void>;
+
+  // Source viewer
+  isViewerOpen: boolean;
+  activeSource: SourceMaterial | null;
+  viewerContent: string;
+  viewerWordCount: number;
+  isContentLoading: boolean;
+  contentError: string | null;
+  onCloseSourceViewer: () => void;
+}
+
+/**
+ * EditorDialogs - All modal dialogs and sheet overlays for the editor page.
+ *
+ * Extracted to keep the page orchestrator focused on layout and state wiring.
+ * Each dialog/sheet is a controlled component receiving open/close state from the parent.
+ */
+export function EditorDialogs({
+  projectData,
+  projectId,
+  getToken,
+  apiUrl,
+  deleteDialogOpen,
+  onDeleteProject,
+  onCloseDeleteDialog,
+  renameDialogOpen,
+  onRenameProject,
+  onCloseRenameDialog,
+  setProjectData,
+  duplicateDialogOpen,
+  onDuplicateProject,
+  onCloseDuplicateDialog,
+  deleteChapterDialogOpen,
+  chapterToDelete,
+  onDeleteChapter,
+  onCloseDeleteChapterDialog,
+  disconnectDriveDialogOpen,
+  driveEmail,
+  driveAccounts,
+  onDisconnectDriveAccount,
+  onCloseDisconnectDriveDialog,
+  aiSheetState,
+  aiCurrentResult,
+  aiErrorMessage,
+  onAIAccept,
+  onAIRetry,
+  onAIDiscard,
+  onGoDeeper,
+  driveFilesOpen,
+  driveFiles,
+  driveFilesLoading,
+  driveFilesError,
+  isConnectingDrive,
+  isProjectConnected,
+  onCloseDriveFiles,
+  onRefreshDriveFiles,
+  onConnectProjectToDrive,
+  onDisconnectProjectFromDrive,
+  onOpenSourcesPanel,
+  onOpenDriveBrowser,
+  isSourcesPanelOpen,
+  sources,
+  isSourcesLoading,
+  sourcesError,
+  isPickerLoading,
+  onCloseSourcesPanel,
+  onOpenAddSourceSheet,
+  onOpenSourceViewer,
+  onRemoveSource,
+  importSourceAsChapter,
+  activeChapterTitle,
+  linkedSources,
+  onLinkSource,
+  onUnlinkSource,
+  setActiveChapterId,
+  isAddSourceSheetOpen,
+  onCloseAddSourceSheet,
+  onSelectDriveAccount,
+  onUploadLocal,
+  isDriveBrowserOpen,
+  driveItems,
+  isDriveLoading,
+  driveError,
+  driveCanGoBack,
+  onCloseDriveBrowser,
+  onDriveGoBack,
+  onOpenDriveFolder,
+  onAddFromDriveBrowser,
+  isDriveDoc,
+  isDriveFolder,
+  isAccountsSheetOpen,
+  onCloseAccountsSheet,
+  onConnectAccount,
+  onRefetchDriveAccounts,
+  isViewerOpen,
+  activeSource,
+  viewerContent,
+  viewerWordCount,
+  isContentLoading,
+  contentError,
+  onCloseSourceViewer,
+}: EditorDialogsProps) {
+  const router = useRouter();
+
+  const handleImportSourceAsChapter = useCallback(
+    async (sourceId: string) => {
+      const result = await importSourceAsChapter(sourceId);
+      if (result) {
+        const token = await getToken();
+        const response = await fetch(`${apiUrl}/projects/${projectId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (response.ok) {
+          const data = await response.json();
+          setProjectData(data);
+          setActiveChapterId(result.chapterId);
+        }
+        onCloseSourcesPanel();
+      }
+    },
+    [
+      importSourceAsChapter,
+      getToken,
+      apiUrl,
+      projectId,
+      setProjectData,
+      setActiveChapterId,
+      onCloseSourcesPanel,
+    ],
+  );
+
+  return (
+    <>
+      {/* Delete project confirmation dialog (US-023) */}
+      <DeleteProjectDialog
+        projectTitle={projectData?.title || ""}
+        isOpen={deleteDialogOpen}
+        onConfirm={onDeleteProject}
+        onCancel={onCloseDeleteDialog}
+      />
+
+      {/* Rename book dialog */}
+      <RenameProjectDialog
+        isOpen={renameDialogOpen}
+        projectTitle={projectData?.title || ""}
+        onConfirm={async (newTitle) => {
+          const success = await onRenameProject(projectId, newTitle);
+          if (success) {
+            setProjectData((prev) => (prev ? { ...prev, title: newTitle } : prev));
+            onCloseRenameDialog();
+          }
+        }}
+        onCancel={onCloseRenameDialog}
+      />
+
+      {/* Duplicate book confirmation dialog */}
+      <DuplicateProjectDialog
+        isOpen={duplicateDialogOpen}
+        projectTitle={projectData?.title || ""}
+        onConfirm={async () => {
+          const newProjectId = await onDuplicateProject(projectId);
+          onCloseDuplicateDialog();
+          if (newProjectId) {
+            router.push(`/editor/${newProjectId}`);
+          }
+        }}
+        onCancel={onCloseDuplicateDialog}
+      />
+
+      {/* Delete chapter confirmation dialog (US-014) */}
+      <DeleteChapterDialog
+        chapterTitle={
+          projectData?.chapters.find((ch) => ch.id === chapterToDelete)?.title || "Untitled Chapter"
+        }
+        isOpen={deleteChapterDialogOpen}
+        onConfirm={onDeleteChapter}
+        onCancel={onCloseDeleteChapterDialog}
+      />
+
+      {/* Disconnect Google Drive confirmation dialog (US-008) */}
+      <DisconnectDriveDialog
+        email={driveEmail}
+        isOpen={disconnectDriveDialogOpen}
+        onConfirm={async () => {
+          // Disconnect all accounts (legacy behavior)
+          for (const account of driveAccounts) {
+            await onDisconnectDriveAccount(account.id);
+          }
+          onCloseDisconnectDriveDialog();
+        }}
+        onCancel={onCloseDisconnectDriveDialog}
+      />
+
+      <AIRewriteSheet
+        sheetState={aiSheetState}
+        result={aiCurrentResult}
+        errorMessage={aiErrorMessage}
+        onAccept={onAIAccept}
+        onRetry={onAIRetry}
+        onDiscard={onAIDiscard}
+        onGoDeeper={onGoDeeper}
+      />
+
+      {/* Drive files listing sheet (US-007) */}
+      <DriveFilesSheet
+        isOpen={driveFilesOpen}
+        files={driveFiles}
+        isLoading={driveFilesLoading || isConnectingDrive}
+        error={driveFilesError}
+        onClose={onCloseDriveFiles}
+        onRefresh={onRefreshDriveFiles}
+        onConnectDrive={onConnectProjectToDrive}
+        onAddSources={async () => {
+          onOpenSourcesPanel();
+          await onOpenDriveBrowser();
+        }}
+        onViewSources={onOpenSourcesPanel}
+        onDisconnectProject={async () => {
+          const confirmed = window.confirm(
+            "Disconnect this project from its Drive folder? Your Drive account remains connected.",
+          );
+          if (!confirmed) return;
+          await onDisconnectProjectFromDrive();
+        }}
+        isProjectConnected={isProjectConnected}
+      />
+
+      {/* Source materials panel */}
+      <SourcesPanel
+        isOpen={isSourcesPanelOpen}
+        sources={sources}
+        isLoading={isSourcesLoading}
+        error={sourcesError}
+        isPickerLoading={isPickerLoading}
+        onClose={onCloseSourcesPanel}
+        onAddFromPicker={onOpenAddSourceSheet}
+        onViewSource={onOpenSourceViewer}
+        onImportAsChapter={handleImportSourceAsChapter}
+        onRemoveSource={onRemoveSource}
+        activeChapterTitle={activeChapterTitle}
+        linkedSourceIds={new Set(linkedSources.map((s) => s.id))}
+        onLinkSource={onLinkSource}
+        onUnlinkSource={onUnlinkSource}
+      />
+
+      {/* Add source sheet (multi-account + local upload) */}
+      <AddSourceSheet
+        isOpen={isAddSourceSheetOpen}
+        accounts={driveAccounts}
+        isPickerLoading={isDriveLoading}
+        onClose={onCloseAddSourceSheet}
+        onSelectDriveAccount={(connectionId) => onSelectDriveAccount(connectionId)}
+        onUploadLocal={onUploadLocal}
+        onConnectAccount={onConnectAccount}
+      />
+
+      <DriveBrowserSheet
+        isOpen={isDriveBrowserOpen}
+        items={driveItems}
+        isLoading={isDriveLoading}
+        error={driveError}
+        canGoBack={driveCanGoBack}
+        onClose={onCloseDriveBrowser}
+        onBack={onDriveGoBack}
+        onOpenFolder={onOpenDriveFolder}
+        onSelectDocs={onAddFromDriveBrowser}
+        isDoc={isDriveDoc}
+        isFolder={isDriveFolder}
+      />
+
+      {/* Google Accounts management sheet */}
+      <AccountsSheet
+        isOpen={isAccountsSheetOpen}
+        accounts={driveAccounts}
+        onClose={onCloseAccountsSheet}
+        onConnectAccount={onConnectAccount}
+        onDisconnectAccount={async (connectionId) => {
+          await onDisconnectDriveAccount(connectionId);
+          await onRefetchDriveAccounts();
+        }}
+      />
+
+      {/* Source content viewer */}
+      <SourceViewerSheet
+        isOpen={isViewerOpen}
+        title={activeSource?.title ?? ""}
+        content={viewerContent}
+        wordCount={viewerWordCount}
+        isLoading={isContentLoading}
+        error={contentError}
+        onClose={onCloseSourceViewer}
+        onImportAsChapter={async () => {
+          if (!activeSource) return;
+          await handleImportSourceAsChapter(activeSource.id);
+        }}
+        tabs={
+          linkedSources.length > 0
+            ? linkedSources.map((s) => ({ id: s.id, title: s.title }))
+            : undefined
+        }
+        activeTabId={activeSource?.id ?? null}
+        onTabChange={(sourceId) => {
+          const source = linkedSources.find((s) => s.id === sourceId);
+          if (source) onOpenSourceViewer(source);
+        }}
+      />
+    </>
+  );
+}

--- a/web/src/components/editor-sidebar.tsx
+++ b/web/src/components/editor-sidebar.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Sidebar, SidebarOverlay, type ChapterData } from "@/components/sidebar";
+
+interface EditorSidebarProps {
+  chapters: ChapterData[];
+  activeChapterId: string | undefined;
+  onChapterSelect: (chapterId: string) => Promise<void>;
+  onAddChapter: () => Promise<void>;
+  onDeleteChapter: (chapterId: string) => void;
+  onChapterRename: (chapterId: string, newTitle: string) => Promise<void>;
+  onChapterReorder: (chapterIds: string[]) => Promise<void>;
+  totalWordCount: number;
+  activeChapterWordCount: number;
+  /** Desktop sidebar collapsed state */
+  sidebarCollapsed: boolean;
+  onToggleSidebarCollapsed: () => void;
+  /** Mobile overlay state */
+  mobileOverlayOpen: boolean;
+  onOpenMobileOverlay: () => void;
+  onCloseMobileOverlay: () => void;
+}
+
+/**
+ * EditorSidebar - Responsive sidebar wrapper for the editor page.
+ *
+ * Handles the desktop persistent sidebar and the mobile overlay pattern
+ * per PRD Section 14 (iPad-First Design):
+ * - Sidebar persistent in landscape (240-280pt), hidden in portrait with "Ch X" pill
+ * - Touch targets 44x44pt minimum
+ */
+export function EditorSidebar({
+  chapters,
+  activeChapterId,
+  onChapterSelect,
+  onAddChapter,
+  onDeleteChapter,
+  onChapterRename,
+  onChapterReorder,
+  totalWordCount,
+  activeChapterWordCount,
+  sidebarCollapsed,
+  onToggleSidebarCollapsed,
+  mobileOverlayOpen,
+  onOpenMobileOverlay,
+  onCloseMobileOverlay,
+}: EditorSidebarProps) {
+  const sharedProps = {
+    chapters,
+    activeChapterId,
+    onChapterSelect,
+    onAddChapter,
+    onDeleteChapter,
+    onChapterRename,
+    onChapterReorder,
+    totalWordCount,
+    activeChapterWordCount,
+  };
+
+  return (
+    <>
+      {/* Desktop sidebar - persistent, collapsible */}
+      <div className="hidden lg:block">
+        <Sidebar
+          {...sharedProps}
+          collapsed={sidebarCollapsed}
+          onToggleCollapsed={onToggleSidebarCollapsed}
+        />
+      </div>
+
+      {/* Mobile sidebar - collapsed pill + overlay */}
+      <div className="lg:hidden">
+        <Sidebar {...sharedProps} collapsed={true} onToggleCollapsed={onOpenMobileOverlay} />
+
+        <SidebarOverlay isOpen={mobileOverlayOpen} onClose={onCloseMobileOverlay}>
+          <Sidebar {...sharedProps} collapsed={false} onToggleCollapsed={onCloseMobileOverlay} />
+        </SidebarOverlay>
+      </div>
+    </>
+  );
+}

--- a/web/src/components/editor-toolbar.tsx
+++ b/web/src/components/editor-toolbar.tsx
@@ -1,0 +1,177 @@
+"use client";
+
+import type { ProjectData } from "@/types/editor";
+import type { SaveStatus } from "@/hooks/use-auto-save";
+import type { SheetState } from "@/hooks/use-ai-rewrite";
+import type { ProjectSummary } from "@/hooks/use-project-actions";
+import { ProjectSwitcher } from "@/components/project-switcher";
+import { SaveIndicator } from "@/components/save-indicator";
+import { DriveStatusIndicator } from "@/components/drive-status-indicator";
+import { ExportMenu } from "@/components/export-menu";
+import { SettingsMenu } from "@/components/settings-menu";
+
+interface EditorToolbarProps {
+  projectData: ProjectData;
+  allProjects: ProjectSummary[];
+  totalWordCount: number;
+
+  // Save
+  saveStatus: SaveStatus;
+  onSaveRetry: () => void;
+
+  // Drive
+  driveConnected: boolean;
+  driveEmail: string;
+  onConnectDriveWithProject: () => void;
+  onViewDriveFiles: (() => void) | undefined;
+
+  // AI Rewrite
+  selectionWordCount: number;
+  aiSheetState: SheetState;
+  onOpenAiRewrite: () => void;
+
+  // Export
+  projectId: string;
+  activeChapterId: string | null;
+  getToken: () => Promise<string | null>;
+  apiUrl: string;
+
+  // Settings
+  hasDriveFolder: boolean;
+  onViewSources: () => void;
+  onManageAccounts: () => void;
+  onDisconnectDrive: () => void;
+  onRenameBook: () => void;
+  onDuplicateBook: () => void;
+  isDuplicating: boolean;
+  onDeleteProject: () => void;
+  onSignOut: () => void;
+  isSigningOut: boolean;
+}
+
+/**
+ * EditorToolbar - Top toolbar for the writing environment.
+ *
+ * Contains project switcher, save indicator, Drive status, AI rewrite button,
+ * export menu, and settings menu.
+ *
+ * Per PRD Section 9: minimal formatting, save status, Export, Settings.
+ */
+export function EditorToolbar({
+  projectData,
+  allProjects,
+  totalWordCount,
+  saveStatus,
+  onSaveRetry,
+  driveConnected,
+  driveEmail,
+  onConnectDriveWithProject,
+  onViewDriveFiles,
+  selectionWordCount,
+  aiSheetState,
+  onOpenAiRewrite,
+  projectId,
+  activeChapterId,
+  getToken,
+  apiUrl,
+  hasDriveFolder,
+  onViewSources,
+  onManageAccounts,
+  onDisconnectDrive,
+  onRenameBook,
+  onDuplicateBook,
+  isDuplicating,
+  onDeleteProject,
+  onSignOut,
+  isSigningOut,
+}: EditorToolbarProps) {
+  return (
+    <div className="flex items-center justify-between h-12 px-4 border-b border-border bg-background shrink-0">
+      <div className="flex items-center gap-2 min-w-0">
+        <ProjectSwitcher
+          currentProject={{
+            id: projectData.id,
+            title: projectData.title,
+            wordCount: totalWordCount,
+          }}
+          projects={allProjects.map((p) => ({
+            id: p.id,
+            title: p.title,
+            wordCount: p.wordCount,
+          }))}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        {/* Save status indicator (US-015) */}
+        <SaveIndicator status={saveStatus} onRetry={onSaveRetry} />
+
+        <div className="w-px h-5 bg-border" aria-hidden="true" />
+
+        {/* Persistent Drive connection status (US-005) */}
+        <DriveStatusIndicator
+          connected={driveConnected}
+          isProjectConnected={hasDriveFolder}
+          email={driveEmail}
+          onConnect={onConnectDriveWithProject}
+          onViewFiles={onViewDriveFiles}
+        />
+
+        {/* Toolbar AI Rewrite fallback - visible when text is selected */}
+        {selectionWordCount > 0 && aiSheetState === "idle" && (
+          <>
+            <button
+              onClick={onOpenAiRewrite}
+              className="h-9 px-2.5 flex items-center gap-1.5 rounded-lg text-sm font-medium
+                         text-blue-700 hover:bg-blue-50 transition-colors"
+              aria-label="AI Rewrite selected text"
+            >
+              <svg
+                className="w-4 h-4 shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
+                />
+              </svg>
+              <span className="hidden sm:inline">AI Rewrite</span>
+            </button>
+            <div className="w-px h-5 bg-border" aria-hidden="true" />
+          </>
+        )}
+
+        {/* SAVE_INDICATOR_PLACEHOLDER */}
+
+        <ExportMenu
+          projectId={projectId}
+          activeChapterId={activeChapterId}
+          getToken={getToken}
+          apiUrl={apiUrl}
+          driveConnected={driveConnected}
+        />
+
+        {/* Settings dropdown menu (US-023) */}
+        <SettingsMenu
+          driveConnected={driveConnected}
+          hasDriveFolder={hasDriveFolder}
+          onViewDriveFiles={onViewDriveFiles ?? (() => {})}
+          onViewSources={onViewSources}
+          onManageAccounts={onManageAccounts}
+          onDisconnectDrive={onDisconnectDrive}
+          onRenameBook={onRenameBook}
+          onDuplicateBook={onDuplicateBook}
+          isDuplicating={isDuplicating}
+          onDeleteProject={onDeleteProject}
+          onSignOut={onSignOut}
+          isSigningOut={isSigningOut}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/editor-writing-area.tsx
+++ b/web/src/components/editor-writing-area.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import type { RefObject } from "react";
+import type { Chapter } from "@/types/editor";
+import { ChapterEditor, type ChapterEditorHandle } from "@/components/chapter-editor";
+
+interface EditorWritingAreaProps {
+  editorRef: RefObject<ChapterEditorHandle | null>;
+  currentContent: string;
+  onContentChange: (html: string) => void;
+  onSelectionWordCountChange: (count: number) => void;
+
+  // Title editing
+  activeChapter: Chapter | undefined;
+  editingTitle: boolean;
+  titleValue: string;
+  onTitleValueChange: (value: string) => void;
+  onTitleEdit: () => void;
+  onTitleSave: () => void;
+  onTitleEditCancel: () => void;
+
+  // Word count display
+  currentWordCount: number;
+  selectionWordCount: number;
+}
+
+/**
+ * EditorWritingArea - The main writing surface.
+ *
+ * Contains the editable chapter title, the Tiptap rich text editor,
+ * and the word count display.
+ *
+ * Per PRD Section 9: clean writing area with editable chapter title.
+ * Per US-011: content width constrained to ~680-720px.
+ */
+export function EditorWritingArea({
+  editorRef,
+  currentContent,
+  onContentChange,
+  onSelectionWordCountChange,
+  activeChapter,
+  editingTitle,
+  titleValue,
+  onTitleValueChange,
+  onTitleEdit,
+  onTitleSave,
+  onTitleEditCancel,
+  currentWordCount,
+  selectionWordCount,
+}: EditorWritingAreaProps) {
+  return (
+    <div className="flex-1 overflow-auto">
+      <div className="max-w-[700px] mx-auto px-6 py-8">
+        {/* Chapter title - editable at top of editor (US-011) */}
+        {editingTitle ? (
+          <input
+            type="text"
+            value={titleValue}
+            onChange={(e) => onTitleValueChange(e.target.value)}
+            onBlur={onTitleSave}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") onTitleSave();
+              if (e.key === "Escape") onTitleEditCancel();
+            }}
+            className="text-3xl font-semibold text-foreground mb-6 outline-none w-full
+                       border-b-2 border-blue-500 bg-transparent"
+            autoFocus
+            maxLength={200}
+          />
+        ) : (
+          <h1
+            className="text-3xl font-semibold text-foreground mb-6 outline-none cursor-text
+                       hover:bg-gray-50 focus:bg-gray-50 focus:ring-2 focus:ring-blue-500
+                       rounded px-1 -mx-1 transition-colors"
+            onClick={onTitleEdit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onTitleEdit();
+              }
+            }}
+            role="button"
+            tabIndex={0}
+            aria-label={`Edit chapter title: ${activeChapter?.title || "Untitled Chapter"}`}
+            title="Click to edit title"
+          >
+            {activeChapter?.title || "Untitled Chapter"}
+          </h1>
+        )}
+
+        <ChapterEditor
+          ref={editorRef}
+          content={currentContent}
+          onUpdate={onContentChange}
+          onSelectionWordCountChange={onSelectionWordCountChange}
+        />
+
+        <div className="mt-4 flex items-center justify-end">
+          <span className="text-sm text-muted-foreground tabular-nums">
+            {selectionWordCount > 0
+              ? `${selectionWordCount.toLocaleString()} / ${currentWordCount.toLocaleString()} words`
+              : `${currentWordCount.toLocaleString()} words`}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-chapter-content.ts
+++ b/web/src/hooks/use-chapter-content.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+interface UseChapterContentOptions {
+  activeChapterId: string | null;
+  getToken: () => Promise<string | null>;
+  /** setContent from useAutoSave — populates the editor when chapter content arrives */
+  setContent: (html: string) => void;
+  /** Current content HTML from useAutoSave */
+  currentContent: string;
+}
+
+interface UseChapterContentReturn {
+  /** Word count of the current editor content */
+  currentWordCount: number;
+  /** Word count of the active text selection */
+  selectionWordCount: number;
+  /** Callback for the editor to report selection word count changes */
+  handleSelectionWordCountChange: (count: number) => void;
+}
+
+/**
+ * Loads chapter content from the API when the active chapter changes and
+ * provides word-count helpers.
+ *
+ * Extracted from EditorPage to keep content-loading logic isolated.
+ */
+export function useChapterContent({
+  activeChapterId,
+  getToken,
+  setContent,
+  currentContent,
+}: UseChapterContentOptions): UseChapterContentReturn {
+  const [selectionWordCount, setSelectionWordCount] = useState(0);
+
+  // Load chapter content from API when active chapter changes
+  useEffect(() => {
+    if (!activeChapterId) return;
+
+    let cancelled = false;
+
+    async function loadContent() {
+      try {
+        const token = await getToken();
+        const response = await fetch(`${API_URL}/chapters/${activeChapterId}/content`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (cancelled) return;
+
+        if (response.ok) {
+          const data = (await response.json()) as { content: string; version: number };
+          setContent(data.content || "");
+        } else if (response.status === 404) {
+          setContent("");
+        }
+      } catch (err) {
+        console.error("Failed to load chapter content:", err);
+        if (!cancelled) {
+          setContent("");
+        }
+      }
+    }
+
+    loadContent();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activeChapterId, getToken, setContent]);
+
+  const handleSelectionWordCountChange = useCallback((count: number) => {
+    setSelectionWordCount(count);
+  }, []);
+
+  const countWords = useCallback((html: string): number => {
+    const text = html
+      .replace(/<[^>]*>/g, " ")
+      .replace(/&nbsp;/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    return text.length > 0 ? text.split(" ").length : 0;
+  }, []);
+
+  const currentWordCount = countWords(currentContent);
+
+  return {
+    currentWordCount,
+    selectionWordCount,
+    handleSelectionWordCountChange,
+  };
+}

--- a/web/src/hooks/use-editor-project.ts
+++ b/web/src/hooks/use-editor-project.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useState, useCallback, useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import type { ProjectData } from "@/types/editor";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+interface UseEditorProjectOptions {
+  projectId: string;
+  getToken: () => Promise<string | null>;
+}
+
+interface UseEditorProjectReturn {
+  projectData: ProjectData | null;
+  setProjectData: React.Dispatch<React.SetStateAction<ProjectData | null>>;
+  activeChapterId: string | null;
+  setActiveChapterId: (id: string | null) => void;
+  isLoading: boolean;
+  error: string | null;
+  fetchProjectData: () => Promise<void>;
+  handleProjectConnected: (driveFolderId: string) => Promise<void>;
+  handleProjectDisconnected: () => Promise<void>;
+}
+
+/**
+ * Manages project data fetching, active chapter selection, and Drive connection callbacks.
+ *
+ * Extracted from EditorPage to reduce the orchestrator's responsibility surface.
+ */
+export function useEditorProject({
+  projectId,
+  getToken,
+}: UseEditorProjectOptions): UseEditorProjectReturn {
+  const router = useRouter();
+
+  const [projectData, setProjectData] = useState<ProjectData | null>(null);
+  const [activeChapterId, setActiveChapterId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Use a ref to track activeChapterId to avoid re-creating fetchProjectData
+  // every time activeChapterId changes (which would cause an infinite loop
+  // via the useEffect that triggers fetchProjectData).
+  const activeChapterIdRef = useRef(activeChapterId);
+  useEffect(() => {
+    activeChapterIdRef.current = activeChapterId;
+  }, [activeChapterId]);
+
+  const fetchProjectData = useCallback(async () => {
+    try {
+      const token = await getToken();
+
+      const projectResponse = await fetch(`${API_URL}/projects/${projectId}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (!projectResponse.ok) {
+        if (projectResponse.status === 404) {
+          router.push("/dashboard");
+          return;
+        }
+        throw new Error("Failed to load project");
+      }
+
+      const data: ProjectData = await projectResponse.json();
+      setProjectData(data);
+
+      if (data.chapters.length > 0 && !activeChapterIdRef.current) {
+        const sortedChapters = [...data.chapters].sort((a, b) => a.sortOrder - b.sortOrder);
+        setActiveChapterId(sortedChapters[0].id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [getToken, projectId, router]);
+
+  useEffect(() => {
+    fetchProjectData();
+  }, [fetchProjectData]);
+
+  const handleProjectConnected = useCallback(
+    async (driveFolderId: string) => {
+      // Optimistically reflect connection in the current view.
+      setProjectData((prev) => (prev ? { ...prev, driveFolderId } : prev));
+      // Then refresh canonical server state.
+      await fetchProjectData();
+    },
+    [fetchProjectData],
+  );
+
+  const handleProjectDisconnected = useCallback(async () => {
+    setProjectData((prev) => (prev ? { ...prev, driveFolderId: null } : prev));
+    await fetchProjectData();
+  }, [fetchProjectData]);
+
+  return {
+    projectData,
+    setProjectData,
+    activeChapterId,
+    setActiveChapterId,
+    isLoading,
+    error,
+    fetchProjectData,
+    handleProjectConnected,
+    handleProjectDisconnected,
+  };
+}

--- a/web/src/types/editor.ts
+++ b/web/src/types/editor.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared types for the editor page and its sub-components.
+ *
+ * These were previously duplicated across page.tsx and multiple hooks.
+ * Centralising them here avoids drift and makes refactors safer.
+ */
+
+export interface Chapter {
+  id: string;
+  title: string;
+  sortOrder: number;
+  wordCount: number;
+  version: number;
+  status: string;
+}
+
+/**
+ * Shape returned by GET /projects/:projectId.
+ * The API returns a flat object with project fields + chapters array,
+ * NOT a nested { project, chapters } structure.
+ */
+export interface ProjectData {
+  id: string;
+  title: string;
+  description?: string;
+  driveFolderId?: string | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  chapters: Chapter[];
+}


### PR DESCRIPTION
## Summary
- Extract 4 focused child components from the 836-line EditorPage god component: `EditorSidebar`, `EditorToolbar`, `EditorWritingArea`, and `EditorDialogs`
- Extract 2 new hooks (`useEditorProject`, `useChapterContent`) to isolate project data fetching, chapter content loading, and word count logic
- Add shared `types/editor.ts` for `Chapter` and `ProjectData` types, eliminating duplication across hooks
- Reduce page.tsx from 836 lines to 490 lines (41% reduction) while preserving identical behavior

## Changes
- **`web/src/components/editor-sidebar.tsx`** (new) - Responsive desktop/mobile sidebar with overlay pattern
- **`web/src/components/editor-toolbar.tsx`** (new) - Project switcher, save indicator, Drive status, AI rewrite button, export menu, settings menu
- **`web/src/components/editor-writing-area.tsx`** (new) - Chapter title editing, Tiptap editor, word count display
- **`web/src/components/editor-dialogs.tsx`** (new) - All 12+ modal dialogs and sheet overlays
- **`web/src/hooks/use-editor-project.ts`** (new) - Project data fetching, active chapter selection, Drive connection callbacks
- **`web/src/hooks/use-chapter-content.ts`** (new) - Chapter content loading from API and word count computation
- **`web/src/types/editor.ts`** (new) - Shared Chapter and ProjectData interfaces
- **`web/src/app/(protected)/editor/[projectId]/page.tsx`** (modified) - Reduced to thin orchestrator wiring hooks and child components
- **`web/test/hooks/editor-page-init-order.test.ts`** (modified) - Updated regression tests to validate new architecture while preserving #119 TDZ invariant

## Test Plan
- [x] All 152 existing tests pass (14/14 test files)
- [x] Lint passes (0 errors)
- [x] TypeScript typecheck passes across all workspaces
- [x] Prettier format check passes
- [x] Editor page renders and functions identically (pure refactor, no behavior changes)
- [x] TDZ regression tests (#119) updated and passing

Closes #138

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>