### PR TITLE
test: add happy-path integration tests for API

### DIFF
--- a/workers/dc-api/test/integration.test.ts
+++ b/workers/dc-api/test/integration.test.ts
@@ -365,12 +365,9 @@ describe("Integration: Chapters", () => {
     const ch1 = await seedChapter(projectId, { title: "First", sortOrder: 1 });
     const ch2 = await seedChapter(projectId, { title: "Second", sortOrder: 2 });
 
-    const res = await jsonRequest(
-      "PATCH",
-      `/projects/${projectId}/chapters/reorder`,
-      userId,
-      { chapterIds: [ch2.id, ch1.id] },
-    );
+    const res = await jsonRequest("PATCH", `/projects/${projectId}/chapters/reorder`, userId, {
+      chapterIds: [ch2.id, ch1.id],
+    });
 
     expect(res.status).toBe(200);
 
@@ -501,9 +498,7 @@ describe("Integration: Export", () => {
     // Put content in R2 for the export
     const r2Key = `chapters/${ch.id}/content.html`;
     await env.EXPORTS_BUCKET.put(r2Key, "<p>Content for export testing.</p>");
-    await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
-      .bind(r2Key, ch.id)
-      .run();
+    await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`).bind(r2Key, ch.id).run();
 
     const res = await jsonRequest("POST", `/projects/${projectId}/export`, userId, {
       format: "epub",
@@ -530,9 +525,7 @@ describe("Integration: Export", () => {
     const ch = await seedChapter(projectId, { sortOrder: 1, wordCount: 3 });
     const r2Key = `chapters/${ch.id}/content.html`;
     await env.EXPORTS_BUCKET.put(r2Key, "<p>Status check content.</p>");
-    await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
-      .bind(r2Key, ch.id)
-      .run();
+    await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`).bind(r2Key, ch.id).run();
 
     // Create an export first
     const createRes = await jsonRequest("POST", `/projects/${projectId}/export`, userId, {
@@ -562,9 +555,7 @@ describe("Integration: Export", () => {
     const ch = await seedChapter(projectId, { sortOrder: 1, wordCount: 2 });
     const r2Key = `chapters/${ch.id}/content.html`;
     await env.EXPORTS_BUCKET.put(r2Key, "<p>Download test.</p>");
-    await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
-      .bind(r2Key, ch.id)
-      .run();
+    await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`).bind(r2Key, ch.id).run();
 
     // Create export
     const createRes = await jsonRequest("POST", `/projects/${projectId}/export`, userId, {
@@ -610,9 +601,7 @@ describe("Integration: Backup", () => {
     // Put content in R2
     const r2Key = `chapters/${ch.id}/content.html`;
     await env.EXPORTS_BUCKET.put(r2Key, "<p>Backup content here.</p>");
-    await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`)
-      .bind(r2Key, ch.id)
-      .run();
+    await env.DB.prepare(`UPDATE chapters SET r2_key = ? WHERE id = ?`).bind(r2Key, ch.id).run();
 
     const res = await SELF.fetch(`${BASE}/projects/${proj.id}/backup`, {
       headers: authHeaders(userId),


### PR DESCRIPTION
## Summary
- Add end-to-end integration tests exercising authenticated CRUD flows through the Worker HTTP layer
- 30 new tests covering: project CRUD (8), chapter CRUD (9), content save/load (4), export EPUB (3), backup download (1), auth enforcement (1), user isolation (2), 404 fallback (1), health (1)
- Uses `SELF.fetch` with `X-Test-User-Id` header bypass (already configured in `wrangler.test.toml`)

## Changes
- `workers/dc-api/test/integration.test.ts` — new file, 656 lines, 30 tests across 6 describe blocks

## Test Plan
- [x] All 30 new integration tests pass
- [x] All 150 existing tests still pass (180 total)
- [x] Lint passes (no new warnings)
- [x] Typecheck passes

Closes #104

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>