### PR TITLE
chore: update react and react-dom to 19.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9143,24 +9143,24 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
-      "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
+      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.3"
+        "react": "^19.2.4"
       }
     },
     "node_modules/react-is": {
@@ -11432,8 +11432,8 @@
         "@tiptap/react": "^3.19.0",
         "@tiptap/starter-kit": "^3.19.0",
         "next": "16.1.6",
-        "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react": "19.2.4",
+        "react-dom": "19.2.4"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",

--- a/web/package.json
+++ b/web/package.json
@@ -21,8 +21,8 @@
     "@tiptap/react": "^3.19.0",
     "@tiptap/starter-kit": "^3.19.0",
     "next": "16.1.6",
-    "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- Update `react` and `react-dom` from 19.2.3 to 19.2.4 (patch release)
- ESLint 10 was evaluated but rolled back: `eslint-plugin-react` (transitive dep via `eslint-config-next`) uses the deprecated `getFilename()` API that was removed in ESLint 10
- `@types/node` stays at `^20` (matches Node 20.20.0 runtime)
- `vitest` in `dc-api` stays at `~3.2.0` per `@cloudflare/vitest-pool-workers` compatibility constraint

## Changes
- `react`: 19.2.3 -> 19.2.4
- `react-dom`: 19.2.3 -> 19.2.4

## Not Updated (with rationale)
| Package | Current | Latest | Reason |
|---------|---------|--------|--------|
| `eslint` | 9.39.2 | 10.0.0 | `eslint-plugin-react` incompatible with ESLint 10 (`getFilename` removal) |
| `@types/node` | 20.19.33 | 25.3.0 | Project runs Node 20; `@types/node@25` is for Node 25 |
| `vitest` (dc-api) | 3.2.4 | 4.0.18 | Pinned to `~3.2.0` for `@cloudflare/vitest-pool-workers` compat |

## Test Plan
- [x] All existing tests pass (299 tests: 119 web + 180 dc-api)
- [x] Lint passes (no new errors/warnings)
- [x] Pre-existing typecheck failures confirmed unrelated (missing component files from incomplete #138 refactoring)
- [x] No breaking changes from patch version updates

Closes #145

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>