### PR TITLE
fix: update test imports after component reorganization

### DIFF
--- a/web/test/components/editor-sidebar.test.tsx
+++ b/web/test/components/editor-sidebar.test.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { EditorSidebar } from "@/components/editor-sidebar";
+import { EditorSidebar } from "@/components/editor/editor-sidebar";
 
 /**
  * Tests for EditorSidebar — the responsive sidebar wrapper.
@@ -18,7 +18,7 @@ import { EditorSidebar } from "@/components/editor-sidebar";
  */
 
 // Mock the Sidebar and SidebarOverlay components
-vi.mock("@/components/sidebar", () => ({
+vi.mock("@/components/layout/sidebar", () => ({
   Sidebar: ({
     collapsed,
     activeChapterId,

--- a/web/test/components/editor-toolbar.test.tsx
+++ b/web/test/components/editor-toolbar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { EditorToolbar } from "@/components/editor-toolbar";
+import { EditorToolbar } from "@/components/editor/editor-toolbar";
 
 /**
  * Tests for EditorToolbar — the top toolbar for the writing environment.
@@ -14,13 +14,13 @@ import { EditorToolbar } from "@/components/editor-toolbar";
  */
 
 // Mock child components to avoid their dependencies
-vi.mock("@/components/project-switcher", () => ({
+vi.mock("@/components/project/project-switcher", () => ({
   ProjectSwitcher: ({ currentProject }: { currentProject: { id: string; title: string } }) => (
     <div data-testid="project-switcher">{currentProject.title}</div>
   ),
 }));
 
-vi.mock("@/components/save-indicator", () => ({
+vi.mock("@/components/editor/save-indicator", () => ({
   SaveIndicator: ({ status }: { status: { state: string } }) => (
     <div data-testid="save-indicator" data-state={status.state}>
       {status.state}
@@ -28,7 +28,7 @@ vi.mock("@/components/save-indicator", () => ({
   ),
 }));
 
-vi.mock("@/components/drive-status-indicator", () => ({
+vi.mock("@/components/drive/drive-status-indicator", () => ({
   DriveStatusIndicator: ({ connected }: { connected: boolean }) => (
     <div data-testid="drive-status" data-connected={connected}>
       {connected ? "Connected" : "Not connected"}
@@ -36,11 +36,11 @@ vi.mock("@/components/drive-status-indicator", () => ({
   ),
 }));
 
-vi.mock("@/components/export-menu", () => ({
+vi.mock("@/components/project/export-menu", () => ({
   ExportMenu: () => <div data-testid="export-menu">Export</div>,
 }));
 
-vi.mock("@/components/settings-menu", () => ({
+vi.mock("@/components/project/settings-menu", () => ({
   SettingsMenu: () => <div data-testid="settings-menu">Settings</div>,
 }));
 

--- a/web/test/components/editor-writing-area.test.tsx
+++ b/web/test/components/editor-writing-area.test.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
-import { EditorWritingArea } from "@/components/editor-writing-area";
+import { EditorWritingArea } from "@/components/editor/editor-writing-area";
 import type { RefObject } from "react";
-import type { ChapterEditorHandle } from "@/components/chapter-editor";
+import type { ChapterEditorHandle } from "@/components/editor/chapter-editor";
 
 /**
  * Tests for EditorWritingArea — the main writing surface component.
@@ -20,7 +20,7 @@ import type { ChapterEditorHandle } from "@/components/chapter-editor";
 
 // Mock the ChapterEditor component — must handle forwardRef since the real
 // component uses it for the imperative handle
-vi.mock("@/components/chapter-editor", () => ({
+vi.mock("@/components/editor/chapter-editor", () => ({
   ChapterEditor: React.forwardRef(function MockChapterEditor(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     props: any,


### PR DESCRIPTION
## Summary
Fix broken test imports after #154 moved components to feature subdirectories. Tests from #155 referenced flat paths that no longer exist.

## Changes
- Update imports in `editor-toolbar.test.tsx`, `editor-writing-area.test.tsx`, `editor-sidebar.test.tsx` to use feature-grouped paths

## Test Plan
- [x] All 157 web tests pass locally
- [x] Typecheck passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>