### PR TITLE
chore: check in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "Read",
+      "Write",
+      "Edit",
+      "WebFetch",
+      "WebSearch",
+      "Skill",
+      "Glob",
+      "Grep",
+      "Task",
+      "NotebookEdit",
+      "mcp__crane__*",
+      "mcp__apple-notes__*",
+      "mcp__claude_ai_*"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.claude/settings.json` with standard venture permissions so fleet machines get pre-approved tool access when cloning
- Matches permission pattern used across other venture repos (crane-console, ke-console, sc-console, dfg-console)

Closes venturecrane/crane-console#241

🤖 Generated with [Claude Code](https://claude.com/claude-code)