### PR TITLE
docs: Source Documents UX Design Review

### DIFF
--- a/docs/design/source-review/01-research.md
+++ b/docs/design/source-review/01-research.md
@@ -1,0 +1,602 @@
+# Source/Reference Material UX Pattern Catalog
+
+> Industry research for DraftCrane source management redesign
+> Date: 2026-02-19
+
+## Table of Contents
+
+1. [Individual Tool Analyses](#1-individual-tool-analyses)
+2. [Cross-Cutting Pattern Catalog](#2-cross-cutting-pattern-catalog)
+3. [Anti-Patterns](#3-anti-patterns-for-draftcrane)
+4. [Relevance Matrix](#4-relevance-matrix)
+5. [Key Insights for DraftCrane](#5-key-insights-for-draftcrane)
+
+---
+
+## 1. Individual Tool Analyses
+
+### 1.1 Scrivener
+
+**Source/Reference Model:**
+Scrivener treats reference materials as first-class citizens in its project hierarchy. The Binder sidebar contains a dedicated "Research" folder that sits alongside the manuscript's "Draft" folder. Any file type -- PDFs, images, web archives, audio, video, text notes -- can be imported into Research and organized into subfolders. Research items are peers to manuscript items in the navigation hierarchy; they simply live under a different root folder. The mental model is: everything about your project lives in one container, with a clear partition between "what you're writing" and "what you're writing from."
+
+**Key UI Patterns:**
+
+- **Binder (persistent sidebar):** A tree-view sidebar always visible on the left. All project items -- manuscript chapters, research files, character sheets, notes -- appear in a single navigable hierarchy. Users click to open any item in the main editor.
+- **Split Editor:** The editor area can be split horizontally or vertically, allowing two Binder items to be viewed simultaneously. A common workflow is to write in one pane and view a research PDF in the other.
+- **Copyholders:** A "pinned" reference strip attached to the bottom or side of an editor pane. The copyholder stays fixed while you navigate through different documents in the main editor, providing a persistent reference while writing.
+- **Inspector Bookmarks:** The right-hand Inspector panel has a Bookmarks tab with two tiers: Document Bookmarks (specific to the current document) and Project Bookmarks (accessible from anywhere). Bookmarks create a two-way relationship: bookmarking Document A from Document B also bookmarks B from A. Clicking a bookmark can open it inline in the Inspector's preview area, in a Quick Reference panel, or in a split editor.
+- **Quick Reference panels:** Floating windows that display any Binder item. Users can have multiple Quick Reference panels open simultaneously, creating an ad hoc multi-window research layout.
+
+**Strengths:**
+
+- The unified Binder provides a clear mental model: everything lives in one place.
+- Four distinct ways to view references (split editor, copyholder, Inspector bookmark preview, Quick Reference panel) cover different workflow needs -- from a glance at a note to deep side-by-side comparison.
+- Research files are imported into the project, eliminating broken links or external dependency.
+- The copyholder pattern is particularly elegant: a reference that stays put while you navigate.
+
+**Weaknesses:**
+
+- **Steep learning curve.** Scrivener is consistently criticized for overwhelming new users. External training courses sell for 4x the price of the software itself. Users report "opening the program and being completely overwhelmed." The multi-week adoption process is well-documented.
+- **Feature discovery is poor.** Copyholders, Inspector bookmarks, and Quick Reference panels are powerful but not discoverable -- users must know they exist and how to activate them.
+- **The Binder becomes unwieldy at scale.** A nonfiction author with hundreds of research documents can end up with a Binder that's more research than manuscript, making navigation difficult.
+- **The four reference-viewing methods create confusion.** Split Editor vs. Copyholder vs. Inspector vs. Quick Reference -- users must learn when to use which.
+
+**iPad/Touch Compatibility:**
+
+- Scrivener for iOS exists but is significantly limited compared to desktop. Split-screen is available via iPadOS multitasking but is described as "difficult." Quick Reference is available by swiping left on a Binder item, tapping "More," and selecting "Quick Reference" -- a non-obvious gesture chain. The Inspector exists but on a smaller screen it competes with the editor for space. The full Copyholder feature is not available on iPad. Overall, the iOS version is "very limited compared to the full program."
+
+**Relevance to DraftCrane:**
+
+- The Binder as a "everything in one sidebar" concept is strong, but DraftCrane's sources live in Google Drive, not inside the project -- so the "imported research" model doesn't directly map.
+- The copyholder pattern (a pinned reference while navigating) is highly relevant for the editor + source side-by-side use case.
+- Inspector bookmarks' two-way linking (chapter <-> source) is directly analogous to DraftCrane's current "link source to chapter" concept, but Scrivener's naming and UI make the relationship much more intuitive.
+- The complexity and learning curve are exactly what DraftCrane must avoid for Diane and Marcus.
+
+---
+
+### 1.2 Notion
+
+**Source/Reference Model:**
+Notion treats everything as a "page" or a "database entry." There is no distinct concept of "reference material" -- instead, information is structured through linked databases, nested pages, and relational properties. Research materials might be entries in a "Sources" database linked to entries in a "Chapters" database via a relation property. The mental model is a relational database with a rich-text UI on top.
+
+**Key UI Patterns:**
+
+- **Side Peek:** When clicking a database item, it opens in a right-hand side panel (side peek) that shows the full page content alongside the database view. This split view lets you browse a list while reading details. Table, Board, List, and Timeline views default to side peek. Users can switch between Side Peek, Center Peek (modal), and Full Page.
+- **Center Peek:** A focused modal overlay for deeper reading/editing. Gallery and Calendar views default to center peek. Less contextual than side peek but better for concentrated work.
+- **Linked Databases:** A database can be displayed inline on any page, filtered to show only relevant entries. A chapter page could embed a filtered view of the Sources database showing only linked sources.
+- **Page References / Mentions:** Typing `@` followed by a page name inserts a clickable reference inline. This provides lightweight source citation without formal citation infrastructure.
+- **Relation Properties:** Database entries can be formally linked via relation columns. A "Chapter" database could have a "Sources" relation that links to the "Sources" database, creating bidirectional references.
+
+**Strengths:**
+
+- Side peek is an elegant pattern for "browse and preview" -- you never lose your list context while examining details.
+- The database + relation model is powerful for managing source metadata (author, type, status, date, tags) and creating filtered views.
+- Templates provide structure without requiring the user to build from scratch.
+- Inline `@mentions` provide the lightest possible way to reference another document.
+
+**Weaknesses:**
+
+- **The database paradigm is not intuitive for non-technical users.** Setting up relations, creating filtered views, and understanding linked databases requires a conceptual model that many users never grasp. Management consultants and coaches are unlikely to build this infrastructure themselves.
+- **No real writing environment.** Notion is good for notes and planning but weak for sustained long-form writing. Its editor lacks focus-mode, word count goals, and writing-specific features.
+- **Side peek can feel cramped on smaller screens.** On iPad, the side panel + database view leaves limited space for content.
+- **Too many options for opening pages.** Side peek vs. center peek vs. full page creates decision fatigue similar to Scrivener's four reference views.
+
+**iPad/Touch Compatibility:**
+
+- Notion's iPad app is functional but optimized for shorter interactions. Side peek works but on a 10.9" iPad Air, the content area becomes narrow. Touch targets are generally adequate. Notion has invested in mobile performance (2022 "faster mobile apps" release), but the database-heavy workflows feel desktop-oriented. Drag-and-drop between databases is limited on touch.
+
+**Relevance to DraftCrane:**
+
+- Side peek is the strongest pattern to study. A right-hand panel that shows source content while the chapter list or editor stays visible on the left could directly inform DraftCrane's source viewer.
+- The `@mention` pattern for lightweight source references could replace "link source to chapter" with something more intuitive -- typing `@` to reference a source within chapter text.
+- Relation properties are too complex for DraftCrane's audience, but the concept of bidirectional chapter-source links is valid if surfaced through simpler UI.
+- Notion's weakness at long-form writing confirms that DraftCrane's Tiptap editor investment is the right call.
+
+---
+
+### 1.3 Google Docs
+
+**Source/Reference Model:**
+Google Docs historically treated reference materials through the Explore panel -- a right-hand sidebar that combined web search, Google Drive file search, and image search, with the ability to cite web results as footnotes in MLA, APA, or Chicago format. As of January 2024, the Explore panel was deprecated and replaced by Gemini AI integration in the side panel. The current model is: AI-mediated access to document content and web knowledge, plus basic footnote/citation tools built into the editor.
+
+**Key UI Patterns:**
+
+- **Gemini Side Panel (current, 2025-2026):** A right-hand sidebar activated by clicking the Gemini icon. Users can ask Gemini to summarize the current document, generate outlines, brainstorm ideas, refine writing, and ask questions about content in their Drive. Gemini can reference files from Drive and emails from Gmail in its responses. The panel stays open while the user continues editing.
+- **Footnotes and Citations:** Built-in footnote insertion (Ctrl+Alt+F / Cmd+Option+F) places numbered references at the bottom of the page. The deprecated Explore panel could auto-format web citations; this is now manual or requires Zotero/other integrations.
+- **Audio Summaries (Feb 2026):** Gemini can generate spoken summaries of documents with playback controls, speed adjustment, and voice selection. Designed for "catching up on documents while multitasking."
+- **Comments and Suggestions:** The right margin hosts a comments stream and suggested edits, providing contextual annotation alongside the main text.
+
+**Strengths:**
+
+- **Everyone knows Google Docs.** Diane and Marcus already live here. Any pattern that resembles Google Docs reduces learning curve to near zero.
+- The Gemini side panel is a direct precedent for AI + document integration. Users ask questions in natural language and get contextual answers.
+- Footnotes are a familiar citation mechanism for nonfiction writers.
+- Real-time collaboration means Diane's editor/coach can work alongside her -- a pattern DraftCrane may want to support later.
+
+**Weaknesses:**
+
+- **No concept of "project-level" sources.** Google Docs is single-document oriented. There is no way to associate a set of reference documents with a manuscript. Each doc is an island.
+- **Long documents perform poorly.** Google Docs notoriously struggles with book-length manuscripts (100+ pages). Performance degrades, navigation becomes difficult, and there's no chapter structure.
+- **The Explore panel was removed.** Google's own experiment with integrated research (web search + Drive search + cite-as-footnote) was apparently not successful enough to maintain, replaced by the broader Gemini AI approach.
+- **Gemini access requires paid Workspace plans.** As of March 2026, Gemini is bundled with Business and Enterprise plans ($2-4/user/month increase).
+- **No structured source management.** You cannot "attach" a reference document to a Google Doc, create a source library, or generate a bibliography without external tools like Zotero.
+
+**iPad/Touch Compatibility:**
+
+- Google Docs on iPad is solid for editing but the Gemini side panel and advanced features are primarily desktop experiences. The deprecated Explore panel had reduced functionality on mobile (no Drive search, no citation formatting -- only hyperlinks). Footnote insertion works on iPad. Overall, Google Docs is the baseline familiarity for DraftCrane's users on iPad.
+
+**Relevance to DraftCrane:**
+
+- The Gemini side panel is a direct precedent for DraftCrane's planned Research Assistant (#128). Users ask questions, AI responds using document context. This validates the "side panel for AI research" pattern.
+- The Explore panel's failure is instructive: combining web search, Drive search, and citation into one panel may have been too many things in one place.
+- Google Docs' weakness at project-level source management is exactly the gap DraftCrane fills. The opportunity is to provide structure Google Docs lacks while keeping the simplicity Google Docs users expect.
+- The deprecation of Explore in favor of Gemini suggests the industry is moving from "search and browse" to "ask and receive" for research integration.
+
+---
+
+### 1.4 Ulysses
+
+**Source/Reference Model:**
+Ulysses uses a three-pane library metaphor (Library > Group List > Editor) and treats reference materials through two mechanisms: **sheet attachments** (notes, images, keywords attached to individual sheets) and **material sheets** (sheets explicitly marked as non-exportable research). Material sheets live alongside manuscript sheets within the same group (folder) but are visually distinct and excluded from word counts, writing goals, and exports. The mental model is: research lives beside your writing, clearly marked as "not part of the final text."
+
+**Key UI Patterns:**
+
+- **Three-Pane Layout:** Library (folder tree) on the left, sheet list (document list) in the middle, editor on the right. On iPad, users swipe between panes or collapse panes to focus. Keyboard shortcuts toggle between 3-pane, 2-pane, and editor-only views.
+- **Material Sheets:** Any sheet can be toggled to "material" status via a long-press or swipe menu. Material sheets appear in the sheet list with a distinct visual treatment (dimmed or marked). They coexist with manuscript sheets in the same group, maintaining proximity between a chapter and its research without polluting export or statistics.
+- **Attachments Pane:** Each sheet has an attachments area (accessible via a paperclip icon) where users can add notes, images, PDFs, and keywords. A paperclip indicator in the sheet list shows which sheets have attachments.
+- **Split View (iPad):** Ulysses supports iPadOS Split View and Slide Over, allowing two instances of the app side by side. A user can view a material sheet in one instance and write in another.
+- **Keywords:** Color-coded keyword tags that can be assigned to sheets for organization and filtering. Available on both manuscript and material sheets.
+
+**Strengths:**
+
+- **Material sheets are brilliantly simple.** One toggle separates "research" from "manuscript" without requiring a separate folder hierarchy, a different UI, or a mental model shift. Research and writing live side by side.
+- **The attachments pane is lightweight.** Notes and images attached to a sheet are always one tap away but never clutter the writing surface.
+- **iPad-native design.** Ulysses is one of the few writing apps truly built for iPad. The three-pane layout adapts elegantly to different iPad sizes, and swipe gestures for navigation feel natural.
+- **Progressive disclosure through pane collapsing.** Starting in editor-only mode and progressively revealing the sheet list and library gives users control over complexity.
+
+**Weaknesses:**
+
+- **Limited file type support for attachments.** You can attach notes, images, and keywords, but not PDFs, web pages, or arbitrary file types. Research that doesn't fit in a text note or image can't be attached.
+- **No relational linking between sheets.** Unlike Scrivener's bookmarks or Obsidian's wiki-links, Ulysses has no mechanism for creating explicit relationships between sheets. You can't say "this chapter references these three research sheets."
+- **Material sheets don't scale for large research libraries.** With 100+ research documents (Marcus's scenario), the sheet list becomes overwhelmed -- material sheets are mixed in with manuscript sheets, and scrolling through them all is tedious.
+- **No built-in reference viewing alongside editor.** Unlike Scrivener's copyholder or split editor, Ulysses on iPad requires using iPadOS multitasking (Split View) to see a reference alongside writing. This is system-level, not app-level.
+
+**iPad/Touch Compatibility:**
+
+- Ulysses is the gold standard for iPad writing apps. The three-pane layout, swipe navigation, keyboard shortcuts, and iPadOS integration are excellent. Touch targets are appropriate. Material sheet toggling via swipe-left menu is discoverable and quick. Attachment access via paperclip icon meets the 44pt minimum touch target. This is the iPad benchmark DraftCrane should study most closely.
+
+**Relevance to DraftCrane:**
+
+- Material sheets are the single most relevant pattern for DraftCrane. The concept of "this content is related to your project but not part of the manuscript" maps directly to how Drive sources relate to chapters.
+- The three-pane layout (navigation > list > content) is the structural model DraftCrane should consider. On iPad, it adapts gracefully between overview and focused modes.
+- The attachments-pane concept (lightweight metadata/notes per chapter) could replace DraftCrane's "link source to chapter" with something more tangible.
+- Ulysses' weakness at scale (100+ research docs in a flat list) is a key problem DraftCrane must solve for Marcus.
+
+---
+
+### 1.5 Obsidian
+
+**Source/Reference Model:**
+Obsidian treats every piece of content as a plain-text Markdown note in a local "vault" (folder on the filesystem). References between notes are created via wiki-style links (`[[Note Name]]`). The system automatically tracks these links and surfaces them as **backlinks** (what links to this note) and **outgoing links** (what this note links to). Research is not a separate category -- it's just more notes with links between them. The mental model is a knowledge graph where every note is a node and every link is an edge.
+
+**Key UI Patterns:**
+
+- **Backlinks Panel (right sidebar):** A collapsible right-hand sidebar tab shows all notes that link to the current note, divided into "Linked mentions" (explicit `[[wiki-links]]`) and "Unlinked mentions" (notes containing the current note's title as plain text). Each backlink shows surrounding context, allowing quick assessment of relevance.
+- **Transclusion / Embedding:** Using `![[Note Name]]` syntax, users can embed the content of one note inside another. The embedded content renders inline and updates when the source note changes. Block-level transclusion (`![[Note#^block-id]]`) allows embedding specific paragraphs or quotes.
+- **Graph View:** An interactive force-directed graph visualization of all notes and their connections. Users can filter by tags, folders, or search terms. Useful for discovering clusters of related research and finding gaps.
+- **Split Panes / Linked Panes:** The editor supports multiple panes (horizontal, vertical, or floating). "Linked panes" synchronize: clicking a link in one pane opens it in the linked pane, creating a browsing experience where references open beside the current note.
+- **Community Plugins:** Thousands of plugins extend functionality. Research-relevant plugins include Dataview (SQL-like queries across notes), Zotero integration, citation plugins, and kanban boards.
+
+**Strengths:**
+
+- **Backlinks create emergent structure.** Instead of manually organizing research into folders, users link notes naturally and the structure emerges. This reduces upfront organizational overhead.
+- **Transclusion is powerful for nonfiction writing.** Embedding a quote from a research note into a chapter draft, with automatic updates when the source is edited, is exactly the "snippet into manuscript" workflow.
+- **The graph view provides insight.** For a nonfiction author with many sources, seeing the relationship graph can reveal which sources connect to which chapters, which topics are underserved, and where research gaps exist.
+- **The plugin ecosystem is unmatched.** Any missing feature likely has a community plugin.
+
+**Weaknesses:**
+
+- **Requires a technical mental model.** Wiki-link syntax, Markdown, vaults, plugins, YAML frontmatter -- Obsidian assumes comfort with plain-text tooling. Diane "doesn't know what Markdown is."
+- **The graph view is more impressive than useful.** For large vaults, the graph becomes a hairball. It's better for exploration than daily reference management.
+- **Organization requires discipline.** Without folders or tags, a vault of hundreds of notes becomes chaotic. With folders and tags, the user faces the same organizational overhead as any file system.
+- **Feature bloat via plugins.** The power of the plugin ecosystem is also its curse -- new users can spend weeks configuring their setup instead of writing.
+
+**iPad/Touch Compatibility:**
+
+- Obsidian has an iOS/iPadOS app with access to vaults, most core plugins, and community plugins. However, significant limitations exist on touch: users cannot adjust pane sizes without a trackpad or mouse, touch input has had responsiveness issues in settings and plugin browsing, and some community plugins are desktop-only. The app works but the experience is degraded compared to desktop. Graph view on iPad is functional but difficult to navigate with precision via touch.
+
+**Relevance to DraftCrane:**
+
+- Backlinks are conceptually perfect for DraftCrane's source-chapter relationship: if a chapter references a source, the source's backlinks panel would automatically show which chapters reference it (and vice versa). This eliminates the need for manual "link/unlink" actions.
+- Transclusion maps directly to the Research Board snippet insertion workflow (#133). Dragging a snippet from a source into a chapter could use a transclusion-like model where the snippet maintains a reference to its source.
+- The graph view is not appropriate for DraftCrane's audience, but the underlying concept of "show me how my sources relate to my chapters" could be expressed as a simpler visualization.
+- The technical mental model is a hard "no" for DraftCrane's personas. Any backlink or transclusion behavior must happen through UI affordances, never through syntax.
+
+---
+
+### 1.6 Bear
+
+**Source/Reference Model:**
+Bear is a note-taking app that uses wiki-style links (`[[Note Title]]`) and a flat tag-based hierarchy (tags in note body, e.g., `#research/interviews`) instead of folders. Backlinks were added in Bear 2, surfaced in the Info Panel. Bear does not have a distinct concept of "reference materials" -- all notes are equal, differentiated only by tags and links. The mental model is: a flat collection of notes organized by tags and connected by links.
+
+**Key UI Patterns:**
+
+- **Three-Column Layout:** Sidebar (tag tree + navigation) > Note List > Editor. Very similar to Ulysses' three-pane model. On iPad, columns can be collapsed.
+- **Info Panel (right sidebar):** Activated by a toolbar button or swipe gesture on iPad. Contains three tabs: Info (word count, character count, date metadata), Table of Contents (auto-generated from headings), and Backlinks (notes that link to the current note, split into linked mentions and unlinked mentions).
+- **Wiki Links:** `[[Note Title]]` creates a clickable link between notes. Typing `[[` triggers autocomplete with note title suggestions. This is the primary mechanism for connecting research to writing.
+- **Tag-Based Organization:** Tags are inline (`#tag/subtag`) and create a navigable hierarchy in the sidebar. A note can have multiple tags, providing cross-referencing without duplication. Tags like `#book/chapter-3` and `#research/interviews` can co-exist on the same note.
+- **Simplicity-First Design:** Bear deliberately limits features to maintain a clean, focused writing environment. No database views, no relational properties, no split editor, no graph view.
+
+**Strengths:**
+
+- **Radical simplicity.** Bear's design philosophy is "tools stay out of your way so you can just write." The writing experience is distraction-free, and features are revealed through progressive disclosure (Info Panel is hidden by default).
+- **The Info Panel is a model of progressive disclosure.** Collapsed by default, it reveals word counts, table of contents, and backlinks only when the user asks for them. This is exactly the right approach for non-technical users who don't want to see metadata unless they need it.
+- **Tag-based organization is intuitive.** Users don't need to decide where a note "lives" -- it can have multiple tags. This is more flexible than a folder hierarchy for research that spans multiple chapters.
+- **iPad experience is polished.** Bear is designed for Apple platforms with careful attention to iOS/iPadOS. The Info Panel is accessed by swiping, touch targets are appropriate, and the app feels native.
+
+**Weaknesses:**
+
+- **No way to view two notes simultaneously.** Without a split editor, users must switch back and forth between a research note and their writing. This is a fundamental limitation for the "write with reference materials" use case.
+- **Wiki-link syntax is a barrier.** While `[[` autocomplete helps, the underlying Markdown/wiki-link paradigm may confuse users who have never used it.
+- **Limited file attachment support.** Bear handles text and images well but cannot attach or preview PDFs, spreadsheets, or other document types.
+- **Backlinks are informational only.** The backlinks panel shows what links to a note but doesn't provide a way to navigate the relationship graph or manage the connections. There's no "unlink" action or relationship metadata.
+- **Scales poorly for large research collections.** The flat note list, even with tags, becomes unwieldy with hundreds of notes.
+
+**iPad/Touch Compatibility:**
+
+- Bear is excellent on iPad. It was designed as an Apple-native app and the iPad experience is first-class. The Info Panel can be opened with a left-swipe gesture. The keyboard shows main formatting options in a custom toolbar. Apple Pencil support is available for sketching. The three-column layout collapses gracefully to fit different iPad sizes. Bear is the simplicity benchmark for iPad writing apps.
+
+**Relevance to DraftCrane:**
+
+- Bear's Info Panel progressive disclosure model is the strongest pattern for DraftCrane's source metadata. Sources, linked chapters, word counts, and AI analysis results could live in a right-hand panel that's hidden by default and revealed on demand.
+- Tag-based organization (rather than folder hierarchy) is worth considering for source categorization. A source could be tagged `#chapter-3` and `#interviews` without needing to "live" in one place.
+- Bear's deliberate simplicity is the design philosophy DraftCrane should follow. Every feature added to the source management UI should be evaluated against Bear's "does it stay out of your way?" standard.
+- The lack of split-view is a real limitation that DraftCrane should not replicate. Side-by-side source viewing while writing is a core need.
+
+---
+
+### 1.7 Zotero
+
+**Source/Reference Model:**
+Zotero is a dedicated reference manager. Its model is a structured library of bibliographic items (books, articles, web pages, PDFs, etc.), each with rich metadata (author, title, date, journal, DOI, tags, notes). Items are organized into collections (which function like playlists -- an item can be in multiple collections). The library integrates with word processors via plugins that provide a "search > select > insert citation > auto-generate bibliography" pipeline. The mental model is: a curated library of sources with structured metadata, connected to your writing via formal citations.
+
+**Key UI Patterns:**
+
+- **Three-Pane Library:** Left sidebar (collection tree), center panel (item list), right panel (item details/metadata). This is the standard reference-manager layout, closely mirroring email clients.
+- **Word Processor Integration Toolbar:** Zotero adds a toolbar to Word/LibreOffice/Google Docs with buttons for "Add/Edit Citation," "Add/Edit Bibliography," "Document Preferences" (citation style), and "Refresh." The citation insertion flow is: position cursor > click "Add Citation" > type in search box > select from results > citation appears in text.
+- **Red Search Bar for Citation Insertion:** When inserting a citation, Zotero opens a floating search bar (the "citation dialog") where users type an author name, title, or keyword. Results appear as the user types, and clicking a result inserts it. This is fast and keyboard-driven.
+- **Built-in PDF Reader (Zotero 7):** PDFs open in tabs within Zotero's main window. A left sidebar shows page thumbnails. Users can highlight, annotate, and extract annotations into notes. Annotations sync across devices via Zotero's iOS app.
+- **Context Pane:** The right-hand pane shows bibliographic metadata, tags, related items, and notes for the currently selected item. When reading a PDF, the context pane shows the item's metadata alongside the reader.
+- **Google Docs Integration:** The Zotero Connector browser extension adds a "Zotero" menu to Google Docs. The same search-and-insert pipeline works directly in the browser. Citations are stored as special codes that Zotero can update when the user changes citation style or edits source metadata.
+
+**Strengths:**
+
+- **The search-insert-bibliography pipeline is the gold standard for citation.** The flow from "I need to cite something" to "citation appears in my text with a bibliography entry" is seamless. This is the pattern that nonfiction authors need.
+- **Collections allow multi-chapter source organization.** A source can be in the "Chapter 3" collection and the "Leadership Theory" collection simultaneously, without duplication. This maps perfectly to DraftCrane's source-chapter relationship.
+- **Rich metadata management.** Tags, notes, related items, and bibliographic fields provide comprehensive source documentation.
+- **Cross-platform citation style support.** Over 10,000 citation styles means the output works for any publisher's requirements.
+
+**Weaknesses:**
+
+- **The library is a separate application.** Users must switch between Zotero (library management) and their word processor (writing). The integration toolbar bridges this gap but doesn't eliminate context-switching.
+- **The mental model is academic.** "Collections," "bibliographic metadata," "citation style," "DOI" -- this vocabulary and conceptual framework is designed for academics, not management consultants writing their first book.
+- **Setup overhead is significant.** Installing Zotero, the browser connector, the word processor plugin, configuring sync, importing sources -- this is multi-step setup that Diane would not complete.
+- **No iPad writing integration.** The Zotero iOS app is a PDF reader and annotation tool, not a writing tool. There is no way to insert citations from Zotero into a document on iPad.
+
+**iPad/Touch Compatibility:**
+
+- Zotero's iOS app is limited to library browsing, PDF reading, and annotation. Citation insertion only works via desktop word processor plugins. The PDF reader syncs annotations and reading position across devices, which is useful for research on the go. But the core "search > cite > bibliography" workflow is desktop-only.
+
+**Relevance to DraftCrane:**
+
+- The search-and-insert citation pipeline is the single most relevant pattern from Zotero. DraftCrane's Research Assistant (#125-130) should replicate this flow: user searches sources > gets results with snippets > inserts a reference/quote into their chapter.
+- Zotero's collection model (a source belongs to multiple collections) validates the concept that DraftCrane sources should be associated with multiple chapters without duplication.
+- The "red search bar" citation dialog is a specific UI pattern worth adapting: a minimal, focused search that surfaces results from the source library.
+- The desktop-only limitation means DraftCrane has an opportunity to bring this workflow to iPad -- a differentiated capability.
+- The academic vocabulary and setup complexity are anti-patterns to avoid.
+
+---
+
+### 1.8 ChatGPT Projects
+
+**Source/Reference Model:**
+ChatGPT Projects treats files as context for a conversational AI. Users upload documents (PDFs, DOCXs, images, text files) to a project, set custom instructions, and then all conversations within that project have access to those files. The model is "upload and ask" -- files become a knowledge base that the AI draws from when answering questions. There is no manual organization, tagging, or linking of files; the AI handles the retrieval.
+
+**Key UI Patterns:**
+
+- **Project-Level File Uploads:** A dedicated area in the project settings where users upload files. Files are listed with names and types. The upload limit varies by plan: 5 files (Free), 25 files (Plus), 40 files (Pro/Enterprise).
+- **Conversational Query Interface:** Users type natural-language questions in a chat interface. The AI responds using information from uploaded files and its training data. Responses can include direct quotes, summaries, and synthesized insights from across multiple uploaded documents.
+- **Custom Instructions:** Project-level instructions that persist across all conversations within the project. Users can define context ("I'm writing a nonfiction book about leadership") and preferences ("Always cite the source document name when referencing uploaded files").
+- **Project Sharing (Oct 2025):** Shared projects allow team members to access the same files, instructions, and conversation history. The AI draws from the group's collective uploaded knowledge.
+- **Inline File References:** When the AI references an uploaded file, it can name the file and sometimes indicate where in the document the information was found. However, this is inconsistent and depends on the model's interpretation.
+
+**Strengths:**
+
+- **Zero organizational overhead.** Users upload files and ask questions. No folders, tags, collections, links, or metadata to manage. This is the ultimate simplicity for Diane.
+- **Natural language access to source materials.** Instead of browsing folders or scanning PDFs, users ask "What does the Smith interview say about resilience?" and get an answer. This is dramatically more accessible than any manual reference system.
+- **Cross-document synthesis.** The AI can combine information from multiple uploaded documents in a single response, something impossible with manual source browsing.
+- **The pattern is immediately familiar.** Anyone who has used ChatGPT knows how to interact. The learning curve is near zero.
+
+**Weaknesses:**
+
+- **File limits are restrictive.** 5-40 files depending on plan. A nonfiction author with hundreds of Google Docs research files cannot upload them all.
+- **Context window constraints.** Only 128K-200K tokens can be held in active context, meaning approximately 200-300 pages. Large research libraries exceed this, causing the AI to lose context on some sources.
+- **No structured citation.** The AI may name a source file but doesn't provide page numbers, consistent citation formatting, or bibliography generation. For a nonfiction book, this is insufficient.
+- **Opaque retrieval.** Users cannot see which files the AI is drawing from or control its search. There's no equivalent of "search only in these three documents."
+- **No integration with the writing surface.** ChatGPT Projects is a research/Q&A tool, not a writing tool. There's no way to drag an AI response into a manuscript, create a footnote, or maintain source references in a document.
+- **Hallucination risk.** While project-scoped AI reduces hallucination, it doesn't eliminate it. The AI may conflate information from different sources or infer connections that don't exist.
+
+**iPad/Touch Compatibility:**
+
+- ChatGPT works well on iPad via the native app or Safari. The conversational interface is inherently touch-friendly -- it's just a chat. File upload is slightly cumbersome (selecting multiple files from the Files app) but functional. The simplicity of the interaction model makes it one of the most iPad-compatible patterns studied.
+
+**Relevance to DraftCrane:**
+
+- The "upload and ask" model is the foundational pattern for DraftCrane's Research Assistant (#121-137). The planned workflow of "connect Drive sources > ask questions > get cited answers > insert into manuscript" is a more structured version of ChatGPT Projects.
+- The zero-organizational-overhead approach is the right default for Diane. She should be able to ask questions about her sources without organizing them first.
+- ChatGPT's weaknesses (no structured citation, no writing integration, opaque retrieval) define DraftCrane's differentiation opportunity. If DraftCrane can provide the conversational ease of ChatGPT Projects with proper source citations, snippet insertion, and footnote generation, it delivers unique value.
+- The file limit constraint is relevant because DraftCrane connects to Google Drive rather than requiring uploads. This is a structural advantage.
+- Custom instructions per project map to DraftCrane's project-level settings (voice, tone, genre).
+
+---
+
+## 2. Cross-Cutting Pattern Catalog
+
+### 2.1 Source Organization Patterns
+
+| Pattern | Tools | Description | Complexity |
+|---|---|---|---|
+| **Folder/Tree Hierarchy** | Scrivener (Binder), Zotero (Collections) | Sources organized into nested folders. Visual tree in sidebar. | Medium -- requires upfront folder creation |
+| **Tag-Based** | Bear (#tags), Ulysses (Keywords), Obsidian (YAML tags) | Sources tagged with one or more labels. Cross-referenced without duplication. | Low-Medium -- tags are flexible but require naming discipline |
+| **Link-Based / Graph** | Obsidian (wiki-links), Bear (wiki-links) | Sources connected through explicit links. Structure emerges from connections. | Low (creation) / High (comprehension) |
+| **Database/Relational** | Notion (databases + relations) | Sources as database entries with structured metadata and formal relationships. | High -- requires schema design |
+| **Flat Upload** | ChatGPT Projects | Sources uploaded to a bucket with no required organization. | Minimal -- no organization required |
+| **Material Designation** | Ulysses (Material Sheets), Scrivener (Research folder) | Sources marked as "not-manuscript" but coexisting in the project structure. | Low -- one toggle to designate |
+
+### 2.2 Source Access Patterns
+
+| Pattern | Tools | Description | Screen Impact |
+|---|---|---|---|
+| **Persistent Sidebar** | Scrivener (Binder), Zotero (Library), Notion (Sidebar) | Always-visible navigation panel for source browsing. | Takes 20-30% of screen width permanently |
+| **Split Editor / Dual Pane** | Scrivener (Split Editor), Obsidian (Split Panes) | Editor divided into two areas, one for writing and one for reference. | 50/50 screen split, reduces writing area |
+| **Copyholder / Pinned Reference** | Scrivener (Copyholder) | A smaller reference pane pinned to the editor that persists during navigation. | Takes 20-30% of one editor pane |
+| **Right-Hand Panel / Side Peek** | Notion (Side Peek), Bear (Info Panel), Zotero (Context Pane), Google Docs (Gemini Panel) | Contextual panel that opens on the right, showing details of selected item. | Overlays or pushes content; can be dismissed |
+| **Center Modal / Overlay** | Notion (Center Peek) | Focused modal overlay for deep reading of a source. | Covers primary content; focuses attention |
+| **Floating Window** | Scrivener (Quick Reference) | Independent floating window for reference viewing. | Desktop-only; not practical on iPad |
+| **Inline Embedding / Transclusion** | Obsidian (transclusion) | Source content embedded directly in the writing surface. | No additional screen cost; content is inline |
+| **Conversational Interface** | ChatGPT Projects, Google Docs (Gemini) | Natural language Q&A that retrieves and presents source content. | Side panel for chat; content arrives as conversation |
+
+### 2.3 Source-to-Writing Integration Patterns
+
+| Pattern | Tools | Description | Formality |
+|---|---|---|---|
+| **Drag-and-Drop Insertion** | Obsidian (embed link), Notion (@ mention) | Drag a source or snippet from a panel directly into the editor. | Informal -- creates a reference or embed |
+| **Search-Select-Cite Pipeline** | Zotero (citation dialog) | Invoke a search, select from results, citation + bibliography auto-generated. | Formal -- structured citation with bibliography |
+| **@ Mention / Inline Reference** | Notion (@ page mention), Obsidian ([[wiki-link]]) | Type a trigger character to reference another document inline. | Semi-formal -- creates a clickable link |
+| **Copy-Paste with Attribution** | Manual pattern across all tools | User copies from source, pastes into editor, manually adds footnote. | Informal -- relies on user discipline |
+| **AI-Mediated Insertion** | ChatGPT Projects, Google Docs (Gemini) | Ask AI a question, receive answer with source reference, paste or insert into text. | Variable -- depends on AI's citation quality |
+| **Transclusion / Live Embed** | Obsidian (![[note]]) | Embed source content that stays synchronized with the original. | Formal -- content is live-linked |
+| **Snippet Collection to Insertion** | Zotero (annotations to notes), planned DraftCrane Research Board | Collect relevant excerpts from sources, then selectively insert into manuscript. | Two-stage -- collect first, insert later |
+
+### 2.4 AI + Source Patterns
+
+| Pattern | Tools | Description |
+|---|---|---|
+| **Document-Scoped Q&A** | ChatGPT Projects, Google NotebookLM | Upload documents, ask questions, receive answers grounded in uploaded content |
+| **Side Panel AI Assistant** | Google Docs (Gemini), Notion AI | AI assistant in a side panel that can reference the current document and connected files |
+| **Summarization on Demand** | Google Docs (Gemini audio summaries), ChatGPT, NotebookLM | AI generates a summary of a document or set of documents |
+| **AI-Powered Search** | Google Docs (deprecated Explore), Notion AI | AI finds relevant content across connected documents based on a query |
+| **Structured Snippet Extraction** | Google NotebookLM (inline citations), planned DraftCrane (#127) | AI extracts specific passages with source attribution and presents them as structured results |
+| **Contextual Suggestion** | Notion AI (database autofill), Google Docs (Gemini writing suggestions) | AI proactively suggests relevant information or improvements based on context |
+
+### 2.5 Progressive Disclosure Patterns
+
+| Pattern | Tools | Description | Levels |
+|---|---|---|---|
+| **Default Hidden Panel** | Bear (Info Panel), Google Docs (Gemini Panel) | Metadata and tools are hidden until explicitly invoked. Editor takes full width by default. | 2 (hidden / visible) |
+| **Collapsible Panes** | Ulysses (3-pane to 1-pane), Obsidian (sidebar toggle) | Multiple panes can be individually shown or hidden to control information density. | 3+ (each pane toggleable) |
+| **Contextual Surface** | Notion (Side Peek on click), Zotero (Context Pane on selection) | Additional information appears only when a specific item is selected or clicked. | 2 (no selection / selected) |
+| **Mode Switching** | Scrivener (Composition Mode vs. Standard), Ulysses (Editor-only vs. 3-pane) | Distinct modes that offer different levels of UI complexity. | 2-3 (focus / standard / full) |
+| **Conversational Escalation** | ChatGPT Projects | Start with a question, receive a brief answer, ask follow-ups for more depth. | Continuous (user controls depth) |
+| **Nested Sheets / Modals** | DraftCrane current (4 layers of nested sheets) | Each action opens a new layer on top of the previous one. | 4+ (becomes disorienting) |
+
+---
+
+## 3. Anti-Patterns for DraftCrane
+
+### 3.1 Organizational Overhead Barrier
+
+**Pattern:** Requiring users to set up folders, collections, databases, or tagging systems before they can start working with sources.
+
+**Offenders:** Notion (database relations), Zotero (library setup + collections), Scrivener (Research folder hierarchy), Obsidian (vault structure + frontmatter tags).
+
+**Why it fails for DraftCrane:** Diane has 14 years of scattered Google Docs. She needs to *write*, not build an organizational system. Marcus has his own Google Drive folder structure that works for him. Forcing either persona to recreate or remap their organization inside DraftCrane is a deal-breaker. Sources should "just work" once connected to a project, with optional organization available for users who want it.
+
+### 3.2 Technical Mental Model Requirement
+
+**Pattern:** Requiring understanding of Markdown syntax, wiki-link notation, YAML frontmatter, database relations, or file-system concepts.
+
+**Offenders:** Obsidian (`[[wiki-links]]`, `![[transclusion]]`, YAML), Bear (`[[wiki-links]]`, `#tags`), Notion (database relations, formulas, filters).
+
+**Why it fails for DraftCrane:** "Diane doesn't know what Markdown is." Any source management feature that requires typing special characters, understanding linking syntax, or configuring database schemas will not be adopted. Every relationship between chapters and sources must be expressible through standard GUI interactions: tap, drag, select from a list.
+
+### 3.3 Multi-Window / Desktop-Centric Interactions
+
+**Pattern:** Floating windows, multi-monitor layouts, hover-dependent menus, drag-and-drop between separate windows, right-click context menus as primary interaction.
+
+**Offenders:** Scrivener (Quick Reference floating windows, 4 reference-viewing methods), Obsidian (desktop plugin ecosystem, pane resizing), Zotero (separate application + word processor plugin).
+
+**Why it fails for DraftCrane:** iPad Safari is the primary test target. There are no floating windows. There is no hover state. Right-click requires a long-press, which is not discoverable. Any interaction that depends on desktop affordances will fail on iPad.
+
+### 3.4 Deeply Nested Modal Chains
+
+**Pattern:** Opening a panel that opens a sheet that opens another sheet that opens a viewer -- 3+ levels of stacked modals or sheets.
+
+**Offenders:** DraftCrane's current implementation (SourcesPanel > AddSourceSheet > DriveBrowserSheet > SourceViewerSheet -- 4 layers).
+
+**Why it fails for DraftCrane:** Progressive disclosure research indicates that designs exceeding 2 disclosure levels typically have low usability because users get lost moving between levels. On iPad, where the back gesture can accidentally dismiss the wrong layer, deep nesting is especially disorienting. The current 4-layer chain is the core UX problem to solve.
+
+### 3.5 Separate-Application Integration
+
+**Pattern:** Requiring users to install, configure, and switch between a separate application and their writing tool.
+
+**Offenders:** Zotero (separate app + browser extension + word processor plugin), Obsidian + Zotero integration (requires both apps + plugin configuration).
+
+**Why it fails for DraftCrane:** DraftCrane's value proposition is an integrated writing environment. Requiring users to install a separate source manager defeats the purpose. All source management must happen within the DraftCrane interface.
+
+### 3.6 Feature-Count Complexity
+
+**Pattern:** Providing multiple ways to accomplish the same task, requiring users to learn when to use which method.
+
+**Offenders:** Scrivener (4 methods for viewing references), Notion (3 peek modes), Obsidian (sidebar backlinks vs. inline backlinks vs. graph view vs. Dataview queries).
+
+**Why it fails for DraftCrane:** DraftCrane should provide *one clear way* to view a source alongside writing, *one clear way* to link a source to a chapter, and *one clear way* to insert a source reference. Optionality is complexity.
+
+---
+
+## 4. Relevance Matrix
+
+| Pattern | iPad-First | Non-Technical | Google Drive Compat. | AI Integration | Complexity Budget |
+|---|---|---|---|---|---|
+| **Persistent sidebar (Binder)** | Moderate Fit | Strong Fit | Strong Fit | Moderate Fit | Moderate Fit |
+| **Split editor (dual pane)** | Poor Fit | Strong Fit | Strong Fit | Moderate Fit | Moderate Fit |
+| **Copyholder (pinned reference)** | Moderate Fit | Strong Fit | Strong Fit | Moderate Fit | Strong Fit |
+| **Right-hand panel (Side Peek)** | Strong Fit | Strong Fit | Strong Fit | Strong Fit | Strong Fit |
+| **Center modal (overlay)** | Strong Fit | Strong Fit | Strong Fit | Moderate Fit | Strong Fit |
+| **Floating windows** | Poor Fit | Moderate Fit | Moderate Fit | Poor Fit | Poor Fit |
+| **Inline transclusion** | Strong Fit | Poor Fit | Poor Fit | Moderate Fit | Poor Fit |
+| **Conversational AI panel** | Strong Fit | Strong Fit | Strong Fit | Strong Fit | Strong Fit |
+| **Search-select-cite pipeline** | Strong Fit | Moderate Fit | Strong Fit | Strong Fit | Moderate Fit |
+| **@ mention inline reference** | Strong Fit | Moderate Fit | Moderate Fit | Moderate Fit | Strong Fit |
+| **Tag-based organization** | Strong Fit | Moderate Fit | Moderate Fit | Moderate Fit | Moderate Fit |
+| **Material sheet designation** | Strong Fit | Strong Fit | Strong Fit | Moderate Fit | Strong Fit |
+| **Folder/tree hierarchy** | Moderate Fit | Strong Fit | Strong Fit | Moderate Fit | Moderate Fit |
+| **Database/relational model** | Poor Fit | Poor Fit | Poor Fit | Moderate Fit | Poor Fit |
+| **Wiki-link syntax** | Moderate Fit | Poor Fit | Poor Fit | Poor Fit | Poor Fit |
+| **Upload-and-ask (ChatGPT)** | Strong Fit | Strong Fit | Strong Fit | Strong Fit | Strong Fit |
+| **Info panel (progressive disclosure)** | Strong Fit | Strong Fit | Strong Fit | Strong Fit | Strong Fit |
+| **Collapsible panes** | Strong Fit | Strong Fit | Strong Fit | Moderate Fit | Strong Fit |
+| **Snippet collect-then-insert** | Strong Fit | Strong Fit | Strong Fit | Strong Fit | Moderate Fit |
+| **Graph visualization** | Poor Fit | Poor Fit | Poor Fit | Moderate Fit | Poor Fit |
+
+**Top-scoring patterns (5/5 Strong Fit):**
+- Right-hand panel (Side Peek)
+- Conversational AI panel
+- Upload-and-ask
+- Info panel (progressive disclosure)
+
+**Strong patterns (4/5 Strong Fit):**
+- Center modal (overlay)
+- Copyholder (pinned reference)
+- Collapsible panes
+- Material sheet designation
+- Snippet collect-then-insert
+
+---
+
+## 5. Key Insights for DraftCrane
+
+### Insight 1: The Right-Hand Panel Is the Universal Pattern
+
+Every tool studied uses some form of right-hand contextual panel: Scrivener's Inspector, Notion's Side Peek, Google Docs' Gemini panel, Ulysses' attachments, Obsidian's backlinks sidebar, Bear's Info Panel, Zotero's Context Pane. This is the strongest cross-cutting pattern in the research. DraftCrane should adopt a single right-hand panel that serves multiple purposes (source preview, chapter metadata, AI research results) through tabs or contextual switching. On iPad, this panel should slide in from the right and push (not overlay) the editor content, following the pattern established by Bear's Info Panel and Notion's Side Peek.
+
+### Insight 2: "Ask, Don't Browse" Is the Future of Source Access
+
+The trajectory from Google Docs' Explore panel (manual search and browse, deprecated 2024) to Gemini's side panel (conversational Q&A, current) to ChatGPT Projects (upload and ask, current) to NotebookLM (source-grounded Q&A with citations) is clear: the industry is moving from "browse your references" to "ask about your references." DraftCrane's Research Assistant (#128-130) is aligned with this trajectory. The primary source access pattern for Diane should not be "open your source library and find the document" but rather "ask a question and get an answer with a citation." Manual source browsing should still exist for Marcus (who knows exactly which document he wants) but should be secondary.
+
+### Insight 3: Two Disclosure Levels Maximum
+
+Progressive disclosure research and the tool analysis both confirm: UIs that exceed 2 levels of disclosure (hidden > visible, or summary > detail) create navigation confusion. DraftCrane's current 4-layer sheet chain (SourcesPanel > AddSourceSheet > DriveBrowserSheet > SourceViewerSheet) is the clearest example of this anti-pattern. The redesign should collapse this to a maximum of 2 levels: (1) the source list/panel visible alongside the editor, and (2) a source detail view that replaces (not stacks on top of) the list. Bear's Info Panel and Notion's Side Peek both demonstrate this: click to expand the panel (level 1), click an item to see its details (level 2).
+
+### Insight 4: Source-Chapter Relationships Should Be Implicit, Not Managed
+
+Scrivener's Inspector Bookmarks and Obsidian's backlinks both demonstrate that the best source-chapter relationships emerge from use, not from explicit "link/unlink" actions. When an author references a source in their chapter (via citation, snippet insertion, or AI query), the system should automatically record that relationship. When viewing a source, the system should show which chapters reference it (backlinks). When viewing a chapter, the system should show which sources are referenced (outgoing links). The current "link/unlink source to chapter" action should be replaced by these implicit relationships, supplemented by an optional "pin to chapter" action for sources the author wants quick access to while writing a specific chapter.
+
+### Insight 5: Google Drive Integration Is DraftCrane's Structural Advantage
+
+Every tool studied either requires importing files into its own storage (Scrivener, Obsidian, Zotero) or uploading them to a cloud service (ChatGPT Projects, NotebookLM). DraftCrane's Google Drive integration means sources stay where they are -- in the user's Drive, in their existing folder structure. This is a differentiator, but it must be executed without the "link/unlink" confusion of the current design. The connection should feel like "DraftCrane can see your Drive" rather than "you need to link files from Drive into DraftCrane." The model should be closer to ChatGPT Projects' "upload and ask" simplicity but with Drive as the source instead of file uploads. Users select which Drive folders are "in scope" for a project (#122), and then DraftCrane can search, summarize, and cite from those folders automatically.
+
+### Insight 6: The Editor Must Not Shrink Below Usable Width on iPad
+
+Split editor patterns (Scrivener) and persistent sidebars (Notion, Zotero) work on desktop but create critically narrow writing areas on iPad. On a 10.9" iPad Air in portrait mode, the usable width is approximately 820px. A 50/50 split leaves each pane at 410px -- too narrow for comfortable writing. The right-hand panel must be either (a) full-width overlay that temporarily replaces the editor (like a sheet), (b) a push panel that compresses the editor to ~60% width (only acceptable in landscape), or (c) a pattern that doesn't require simultaneous viewing. For Diane on her iPad Pro in landscape, a 60/40 split (editor/panel) gives ~740px for writing -- marginal but workable. In portrait, the panel should replace the editor entirely, with a clear back gesture to return.
+
+### Insight 7: The Snippet Pipeline Is the Killer Feature
+
+Zotero's "search > select > cite" pipeline, ChatGPT Projects' "ask > receive answer > use," and the planned Research Board (#131-133) all point to the same workflow: research produces snippets, snippets are collected, collected snippets are inserted into the manuscript with attribution. This is the workflow that makes DraftCrane more than "Google Docs with chapters." The pipeline is: (1) AI searches sources and returns relevant passages with citations, (2) the user collects interesting passages to a Research Board, (3) the user drags snippets from the Research Board into the chapter editor, (4) the system automatically creates a footnote referencing the source. This combines the best of Zotero (structured citation), ChatGPT (conversational search), and Scrivener (side-by-side reference), adapted for iPad touch interaction and non-technical users.
+
+---
+
+## Sources
+
+### Scrivener
+- [4 Ways to View Reference Materials in Scrivener](https://www.jenterpstra.com/blog/view-reference-materials-in-scrivener)
+- [Splitting the Scrivener Editor](https://www.literatureandlatte.com/blog/see-more-of-your-project-splitting-the-scrivener-editor)
+- [Scrivener's Research Folder](https://www.literatureandlatte.com/blog/use-scriveners-research-folder-to-store-information-about-your-project)
+- [Quick Reference in Scrivener for iOS](https://www.literatureandlatte.com/blog/quick-reference-in-scrivener-for-ios-side-by-side-editing-and-research)
+- [Use Bookmarks in Scrivener Projects](https://www.literatureandlatte.com/blog/use-bookmarks-in-scrivener-projects-to-link-to-internal-and-external-files)
+- [Scrivener Copyholders](https://www.literatureandlatte.com/blog/use-copyholders-to-extend-the-scrivener-editor)
+- [Scrivener Review 2026](https://elephas.app/blog/scrivener-review)
+- [Scrivener Review 2025](https://writergadgets.com/scrivener-review/)
+
+### Notion
+- [How to Link Databases in Notion](https://notiondemy.com/link-databases-in-notion/)
+- [Open Any Page in Peek Mode](https://bensomething.notion.site/Open-Any-Page-in-Peek-Mode-ba4fb02f62e7432c8e596b5038b1f198)
+- [Notion Side Peek Release](https://www.notion.com/releases/2022-07-20)
+- [Efficiently Using Peek Pages in Notion](https://www.sparxno.com/blog/peek-pages-notion)
+- [Notion AI Overview 2026](https://pradeepsingh.com/notion-ai/)
+- [Notion AI for Docs](https://www.notion.com/help/guides/notion-ai-for-docs)
+
+### Google Docs
+- [Google Docs Explore Tool](https://shakeuplearning.com/blog/5-ways-to-use-the-google-docs-explore-tool/)
+- [Gemini in Google Docs](https://workspace.google.com/products/docs/ai/)
+- [Gemini for Google Workspace Guide 2026](https://refractiv.co.uk/news/gemini-google-workspace-guide/)
+- [How to Use AI in Google Docs 2026](https://dupple.com/learn/how-to-use-ai-in-google-docs)
+- [Gemini Audio Summaries for Google Docs](https://winbuzzer.com/2026/02/13/google-gemini-audio-summaries-google-docs-xcxwbn/)
+- [Google Workspace Gemini Sidebar](https://www.computerworld.com/article/3845447/google-workspace-how-to-use-gemini-ai-side-panel.html)
+
+### Ulysses
+- [Ulysses 19 Review - MacStories](https://www.macstories.net/reviews/ulysses-19-brings-cursor-support-external-folders-material-sheets-and-more/)
+- [Ulysses Material Sheets](https://blog.ulysses.app/material-sheets/)
+- [First Steps: Library & Editor](https://help.ulysses.app/en_US/getting-started/first-steps-library-editor)
+- [How to Write a Novel with Ulysses](https://stories.ulysses.app/how-to-write-a-novel-with-ulysses-ii-research-editing-and-export/)
+- [Ulysses Split View Editor](https://thesweetsetup.com/ulysses-15-introduces-split-view-editor-new-image-export-and-previewing-features-and-keyword-management-improvements/)
+
+### Obsidian
+- [Obsidian Backlinks Documentation](https://help.obsidian.md/plugins/backlinks)
+- [Mastering Obsidian Backlinks](https://bluprio.com/blog/mastering-obsidian-backlinks-a-complete)
+- [Connecting and Transcluding Notes in Obsidian](https://thesweetsetup.com/connecting-and-transcluding-notes-in-obsidian/)
+- [Obsidian Graph View Documentation](https://help.obsidian.md/plugins/graph)
+- [Obsidian Review](https://www.lindy.ai/blog/obsidian-review)
+- [Customizing Obsidian on iPad](https://tfthacker.substack.com/p/customizing-obsidian-on-your-ipad-8b71019a276c)
+
+### Bear
+- [Bear Info Panel, ToC, and Backlinks](https://bear.app/faq/how-to-use-the-info-panel-table-of-contents-and-backlinks-in-bear/)
+- [Bear App Review 2026](https://dockshare.io/apps/bear)
+- [Bear: Linked Notes vs Tags](https://www.laroquephoto.com/blog/2024/3/12/bear-days-linked-notes-vs-tags)
+- [What's New in Bear 2](https://bear.app/faq/whats-new-in-bear-2/)
+- [Bear Community: Backlinks and Info Column](https://community.bear.app/t/forum-feedback-backlinks-and-info-column/5926/129)
+
+### Zotero
+- [Zotero Word Processor Integration](https://www.zotero.org/support/word_processor_integration)
+- [Zotero Google Docs Integration](https://www.zotero.org/support/google_docs)
+- [Zotero PDF Reader](https://www.zotero.org/support/pdf_reader)
+- [Zotero at UC Berkeley](https://guides.lib.berkeley.edu/zotero/bibliographies)
+- [Zotero Citations Between Google Docs and Word](https://www.zotero.org/blog/move-zotero-citations-between-google-docs-word-and-libreoffice/)
+
+### ChatGPT Projects
+- [Using Projects in ChatGPT (OpenAI)](https://help.openai.com/en/articles/10169521-using-projects-in-chatgpt)
+- [ChatGPT Project Sharing](https://www.aioperator.com/blog/chatgpt-project-sharing-a-new-feature-that-improves-team-collaboration)
+- [What is ChatGPT Projects](https://elephas.app/blog/what-is-chatgpt-projects-how-it-works-pricing-and-more-2025-cmbadknjf0044yq8md6n8jrlp)
+- [ChatGPT Projects vs NotebookLM](https://elephas.app/blog/chatgpt-projects-vs-notebooklm)
+- [ChatGPT File Upload Limits 2026](https://onefileapp.com/blog/bypass-chatgpt-file-upload-limit-2025)
+
+### UX Research
+- [Progressive Disclosure - NN/g](https://www.nngroup.com/articles/progressive-disclosure/)
+- [Progressive Disclosure - IxDF](https://www.interaction-design.org/literature/topics/progressive-disclosure)
+- [Progressive Disclosure for Mobile Apps](https://uxplanet.org/design-patterns-progressive-disclosure-for-mobile-apps-f41001a293ba)
+
+### Google NotebookLM
+- [NotebookLM Sources](https://support.google.com/notebooklm/answer/14276468)
+- [NotebookLM FAQ](https://support.google.com/notebooklm/answer/16269187?hl=en)
+- [NotebookLM Tutorial - DataCamp](https://www.datacamp.com/tutorial/notebooklm)

--- a/docs/design/source-review/02a-analysis.md
+++ b/docs/design/source-review/02a-analysis.md
@@ -1,0 +1,968 @@
+# Current State Analysis + Mental Model Proposals
+
+> DraftCrane Source/Research UX Design Review
+> Phase 2a: UX Designer Analysis
+> Date: 2026-02-19
+
+## Table of Contents
+
+1. [Current State Analysis](#part-1-current-state-analysis)
+   - [1.1 User Action Path Map](#11-user-action-path-map)
+   - [1.2 Sheet-Stacking Problem](#12-sheet-stacking-problem)
+   - [1.3 Link/Unlink Confusion](#13-linkunlink-confusion)
+   - [1.4 "10-Second Test" Failures](#14-10-second-test-failures)
+   - [1.5 Architecture Signal](#15-architecture-signal)
+2. [Mental Model Proposals](#part-2-three-mental-model-proposals)
+   - [Option A: "Polished Library"](#option-a-polished-library)
+   - [Option B: "Research Companion"](#option-b-research-companion)
+   - [Option C: "Integrated Research Assistant"](#option-c-integrated-research-assistant)
+
+---
+
+## Part 1: Current State Analysis
+
+### 1.1 User Action Path Map
+
+#### Add a source from Google Drive
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Sources" in toolbar menu | EditorToolbar (settings/overflow menu) | 1 |
+| 2 | SourcesPanel slides in from right | SourcesPanel (z-50, max-w-md) | 0 (animation) |
+| 3 | Tap "Add" button in panel header | SourcesPanel header | 1 |
+| 4 | AddSourceSheet slides up from bottom | AddSourceSheet (z-50, max-h-[70vh]) | 0 (animation) |
+| 5 | Tap a connected Google account row | AddSourceSheet account list | 1 |
+| 6 | AddSourceSheet closes, DriveBrowserSheet slides up | DriveBrowserSheet (z-50, max-h-[80vh]) | 0 (animation) |
+| 7 | Navigate into target folder (1 tap per folder level) | DriveBrowserSheet folder list | 1-5 |
+| 8 | Tap checkbox on each Google Doc to select | DriveBrowserSheet doc list | 1+ |
+| 9 | Tap "Add to Sources" button | DriveBrowserSheet footer | 1 |
+
+**Total: 6-12 taps across 4 distinct surfaces (toolbar, panel, sheet, sheet).**
+
+The minimum path for a user who has one Drive account and files at the root level is 6 taps. For Marcus with his 12 subfolders, reaching a deeply nested document could take 10+ taps. Each surface has its own close/dismiss affordance, creating confusion about how to "go back."
+
+#### Add a source from local device
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Open SourcesPanel (via toolbar) | EditorToolbar | 1 |
+| 2 | Tap "Add" button | SourcesPanel header | 1 |
+| 3 | AddSourceSheet slides up | AddSourceSheet | 0 |
+| 4 | Tap "Upload from device" | AddSourceSheet | 1 |
+| 5 | iOS file picker opens | System file picker | 0 |
+| 6 | Navigate to and select file | System file picker | 2-4 |
+| 7 | File uploads, AddSourceSheet auto-closes | AddSourceSheet | 0 |
+
+**Total: 5-7 taps across 3 surfaces (toolbar, panel, sheet + system picker).**
+
+Notably simpler than the Drive path because the system file picker replaces the DriveBrowserSheet. However, the upload only supports `.txt` and `.md` files -- not `.docx` or `.pdf` -- which limits practical utility for Diane, who has Google Docs in Drive, not local text files.
+
+#### View a source while writing
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Open SourcesPanel (via toolbar) | EditorToolbar | 1 |
+| 2 | Tap "View" button on a source row | SourcesPanel source list | 1 |
+| 3 | SourceViewerSheet slides in from right at z-[60] | SourceViewerSheet (overlays SourcesPanel) | 0 |
+
+**Total: 2 taps to reach the content viewer.**
+
+This is the most efficient path in the current design. However, once the viewer is open, the user cannot see the editor at all -- the SourceViewerSheet is full-height, full-width (max-w-lg) at z-[60], overlaying everything. The user must close the viewer to write, then reopen it to check the source. There is no side-by-side capability.
+
+If the user wants to switch to a different source, they must:
+- Close the SourceViewerSheet (1 tap on X, or swipe)
+- The SourcesPanel is now visible again behind it
+- Tap "View" on a different source (1 tap)
+- New SourceViewerSheet opens (0 taps)
+
+So switching between sources while referencing costs 2 taps per switch, but each switch loses scroll position in the previous source.
+
+The tab bar in SourceViewerSheet only appears when multiple sources are linked to the current chapter. If no sources are linked (the likely default state for a new user), there are no tabs, and the user must go back to the panel to switch sources.
+
+#### Link/unlink a source to current chapter
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Open SourcesPanel (via toolbar) | EditorToolbar | 1 |
+| 2 | Find the source in the list | SourcesPanel source list | 0 (scan) |
+| 3 | Tap "Link to [Chapter Title]" button | SourcesPanel, per-source action row | 1 |
+
+**Total: 2 taps.**
+
+Unlinking follows the same path but the button reads "Linked" (toggled state). The cost is low in taps, but the conceptual cost is high -- see section 1.3.
+
+#### Remove a source
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Open SourcesPanel (via toolbar) | EditorToolbar | 1 |
+| 2 | Tap "Remove" on the source row | SourcesPanel source list | 1 |
+
+**Total: 2 taps.** There is no confirmation dialog. The source is removed immediately from the project. This is destructive and irreversible from the UI perspective (the file still exists in Drive, but the DraftCrane association, any chapter links, and cached content are deleted).
+
+#### Import a source as chapter
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Open SourcesPanel (via toolbar) | EditorToolbar | 1 |
+| 2 | Tap "Import as Chapter" on a source row | SourcesPanel source list | 1 |
+| -- | OR from the viewer: | -- | -- |
+| 1 | Open SourcesPanel, then open viewer | EditorToolbar + SourcesPanel | 2 |
+| 2 | Tap "Import as Chapter" in viewer header | SourceViewerSheet header | 1 |
+
+**Total: 2-3 taps.** Both paths work. The import creates a new chapter with the source content and navigates to it, closing the SourcesPanel. This path is reasonably well-designed, though the lack of confirmation before a potentially large content import is worth noting.
+
+---
+
+### 1.2 Sheet-Stacking Problem
+
+#### Z-Index Layer Map
+
+```
+z-index    Surface                    Type              Trigger
+-------    -------                    ----              -------
+z-[60]     SourceViewerSheet          Right slide-in    "View" button in SourcesPanel
+z-50       SourcesPanel               Right slide-in    Toolbar "Sources" action
+z-50       AddSourceSheet             Bottom sheet      "Add" button in SourcesPanel
+z-50       DriveBrowserSheet          Bottom sheet      Account row in AddSourceSheet
+z-50       AccountsSheet              Bottom sheet      "Manage Accounts" in toolbar
+z-50       DriveFilesSheet            Bottom sheet      "Drive Files" in toolbar
+z-50       AIRewriteSheet             Bottom sheet      AI rewrite action
+(below)    Editor + Sidebar + Toolbar  Base layer        Always present
+```
+
+#### What happens when multiple sheets are open
+
+The worst-case stacking scenario occurs during the "Add a source from Drive" flow:
+
+```
+Layer 4 (top):    DriveBrowserSheet (z-50, bottom sheet, max-h-[80vh])
+Layer 3:          AddSourceSheet (z-50, bottom sheet, max-h-[70vh])
+Layer 2:          SourcesPanel (z-50, right panel, max-w-md)
+Layer 1 (base):   Editor + Sidebar + Toolbar
+```
+
+All three source-related surfaces are open simultaneously. Each has its own backdrop (`bg-black/30`), creating a compounding dimming effect on the editor below. The DriveBrowserSheet and AddSourceSheet both use z-50, which means their stacking is determined by DOM order -- the DriveBrowserSheet renders after AddSourceSheet in EditorDialogs, so it visually overlays it.
+
+When the SourceViewerSheet is open alongside the SourcesPanel:
+
+```
+Layer 3 (top):    SourceViewerSheet (z-[60], right panel, max-w-lg)
+Layer 2:          SourcesPanel (z-50, right panel, max-w-md)
+Layer 1 (base):   Editor + Sidebar + Toolbar
+```
+
+The SourceViewerSheet is wider (max-w-lg vs max-w-md) and at a higher z-index, so it completely covers the SourcesPanel. The user cannot interact with the SourcesPanel while the viewer is open. They must close the viewer first.
+
+#### How the user navigates back through layers
+
+There is no unified back navigation. Each surface has its own dismiss mechanism:
+
+- **SourcesPanel:** X button in header, or tap the backdrop, or press Escape
+- **AddSourceSheet:** Tap the backdrop (no explicit close button beyond the backdrop)
+- **DriveBrowserSheet:** X button in header, tap the backdrop, or the "Back" button (for folder navigation, not sheet dismissal)
+- **SourceViewerSheet:** X button in header, tap the backdrop, or press Escape
+
+On iPad, the swipe-from-left-edge gesture in Safari navigates the browser back, not the app's sheet stack. A user swiping to "go back" from the DriveBrowserSheet will navigate away from the editor entirely, losing all sheet state. This is a significant iPad-specific usability failure.
+
+The AddSourceSheet automatically closes when the user selects a Drive account (line 72-75 of add-source-sheet.tsx: `onClose()` is called after `onSelectDriveAccount`). This means the transition from AddSourceSheet to DriveBrowserSheet is actually a close-then-open, not a push. The user cannot easily return to the AddSourceSheet from the DriveBrowserSheet -- they must close the DriveBrowserSheet and re-open AddSourceSheet via the "Add" button.
+
+#### iPad-specific issues
+
+1. **Keyboard interaction.** None of these sheets handle the iPad software keyboard. If the DriveBrowserSheet were to add a search field (a reasonable future enhancement), the keyboard would push the sheet up or obscure the content, depending on how the fixed positioning interacts with the viewport resize.
+
+2. **Touch targets.** The checkbox in DriveBrowserSheet (`h-4 w-4` = 16x16px) is significantly below the 44pt minimum touch target specified in the PRD. Folder navigation buttons in DriveBrowserSheet have sufficient height (`px-3 py-2`) but are not explicitly sized to 44pt. The "Back" button in DriveBrowserSheet (`h-9 w-9` = 36x36px) is also below the 44pt minimum.
+
+3. **Scroll containment.** Each sheet has `overflow-auto` on its content area, but when the sheets stack, touch events for scrolling can leak to underlying sheets. The backdrops intercept clicks but not scroll events. On iPad, inertial scrolling in the foreground sheet can "pass through" to the background panel.
+
+4. **Landscape vs portrait.** The SourcesPanel (`max-w-md` = 28rem = 448px) consumes 55% of screen width on an iPad Air in portrait (820px viewport). In landscape (1180px viewport), it consumes 38% -- more reasonable but still leaves no visible editor. The SourceViewerSheet (`max-w-lg` = 32rem = 512px) is even wider, consuming 62% in portrait and 43% in landscape.
+
+---
+
+### 1.3 Link/Unlink Confusion
+
+#### What "Link to Chapter 3" actually does technically
+
+Calling `linkSource(sourceId)` in `use-chapter-sources.ts` (line 54-71) sends a `POST` to `/chapters/{chapterId}/sources/{sourceId}/link`. The backend creates a row in the `chapter_sources` junction table:
+
+```sql
+INSERT INTO chapter_sources (id, chapter_id, source_id, status, sort_order)
+VALUES (?, ?, ?, 'active', ?)
+```
+
+This creates a many-to-many association between a chapter and a source. The association has a `status` field (active/archived) and a `sort_order` field, but these are not currently exposed in the UI.
+
+The visible effects of linking a source to a chapter are:
+
+1. The source's button changes from "Link to Chapter 3" to "Linked" (blue highlight) in the SourcesPanel.
+2. When the SourceViewerSheet is opened, linked sources appear as tabs in a tab bar, allowing the user to switch between them without returning to the SourcesPanel.
+3. The `GET /chapters/{chapterId}/sources` endpoint returns only linked sources, not all project sources.
+
+Unlinking sends a `DELETE` to `/chapters/{chapterId}/sources/{sourceId}/link`, which removes the junction table row. The source remains in the project; only the chapter association is removed.
+
+#### What mental model it assumes the user has
+
+The link/unlink system assumes the user understands:
+
+1. That sources exist at two levels: project-level (visible in SourcesPanel) and chapter-level (the link relationship).
+2. That "linking" creates a metadata association, not a content connection -- linking a source to a chapter does not insert any content from the source into the chapter.
+3. That the tab bar in the viewer is populated by chapter-level links, so you must link sources before you can tab between them.
+4. That the "Link to Chapter 3" label changes based on which chapter is currently active in the editor -- the same source row shows different link states depending on context outside the SourcesPanel.
+
+This is a database-centric mental model. It assumes the user thinks of sources as entities that can be "associated with" chapters through an explicit relationship. This is the Notion relational-database pattern that the Phase 1 research identified as an anti-pattern for non-technical users.
+
+#### Why this confuses non-technical users
+
+The confusion stems from three sources:
+
+1. **"Link" is an overloaded term.** In a web context, "link" means a URL or hyperlink. In a file-management context, "link" means a shortcut or alias. In a social-media context, "link" means to share. None of these meanings map to "create a metadata association between two entities." The word provides no affordance for what will happen.
+
+2. **The action has no visible outcome.** After tapping "Link to Chapter 3," the button changes to "Linked" -- but nothing else changes. The chapter content is unchanged. The source content is unchanged. The only visible effect is a button label change and, eventually, a tab in the viewer. The action-to-feedback loop is broken.
+
+3. **The context dependency is invisible.** The button says "Link to Chapter 3" because Chapter 3 is the active chapter in the editor. But the SourcesPanel does not show which chapter is active -- the `activeChapterTitle` is passed as a prop and appears only in the button label. If the user doesn't realize that linking is chapter-specific, they may think they're linking the source to the entire project.
+
+#### What would Diane think "Link" means?
+
+Diane would most likely interpret "Link to Chapter 3" as one of:
+
+- "Insert a hyperlink to this source document in Chapter 3" (web mental model)
+- "Move this source into Chapter 3" (file-organization mental model)
+- "Open this source next to Chapter 3" (side-by-side viewing mental model)
+
+All three interpretations lead to an expectation of visible change in the chapter. When tapping "Link" produces only a button label change, Diane would likely:
+
+1. Tap it.
+2. Look at the chapter to see what changed.
+3. See nothing changed.
+4. Assume it didn't work.
+5. Tap it again (which unlinks it).
+6. Give up on the feature.
+
+This is the "invisible action" anti-pattern. The feature requires the user to understand a concept (metadata association) that has no visual representation in their primary workspace (the editor).
+
+---
+
+### 1.4 "10-Second Test" Failures
+
+The PRD mandates: "A management consultant should be able to figure out any screen in 10 seconds without instructions."
+
+#### Failure 1: AddSourceSheet purpose is unclear
+
+When the AddSourceSheet slides up, it shows:
+- A list of connected Google accounts (email addresses with "Browse Google Drive" subtitle)
+- An "Upload from device" option
+- A "Connect another Google account" option
+
+A new user (Diane) who has never connected a Google account sees only "Upload from device" and "Connect another Google account." The sheet title is "Add Source" with subtitle "Select files from Google Drive or upload from your device."
+
+**What fails the test:** The term "source" is not defined anywhere in the UI. Diane does not think of her Google Docs as "sources." She thinks of them as "my notes" or "my research" or "that doc I wrote." The entire SourcesPanel header says "Sources" -- a term borrowed from academic citation workflows (Zotero, bibliography management) that does not match how Diane or Marcus think about their reference materials.
+
+**Time to understand: 15-20 seconds.** The user must infer that "source" means "a Google Doc I want to reference while writing."
+
+#### Failure 2: Link/Unlink button intention
+
+See section 1.3. The "Link to Chapter 3" button fails the 10-second test because:
+- The purpose of linking is not explained.
+- The outcome of tapping is not visible.
+- The chapter-specific context is not obvious.
+
+**Time to understand: Never (without external explanation).** This is not a 10-second failure; it is a comprehension failure. The feature's purpose cannot be deduced from the UI alone.
+
+#### Failure 3: SourceViewerSheet tab bar context
+
+When the SourceViewerSheet opens with tabs (only when linked sources exist for the current chapter), the tab bar shows source titles. But there is no indication of what these tabs represent or why certain sources appear as tabs and others do not.
+
+A user who linked three sources to Chapter 3 and then navigates to Chapter 5 would see different tabs (or no tabs). The reason for the change is invisible -- the tabs are driven by chapter-source links, which are chapter-specific, but the viewer does not explain this.
+
+**Time to understand: 30+ seconds.** The user would need to switch chapters and observe the tab bar changing to understand the relationship.
+
+#### Failure 4: DriveBrowserSheet vs system file picker
+
+DraftCrane implements its own Google Drive browser (DriveBrowserSheet) rather than using the Google Picker API (which `useGooglePicker` wraps but is not used in the current flow). The custom browser shows folders and Google Docs with checkboxes.
+
+A management consultant is familiar with Google Drive's own UI. The DriveBrowserSheet does not match Google Drive's visual language -- it uses DraftCrane's own styling, different icons, a different folder structure presentation. The user must mentally map "this is my Drive, but it looks different."
+
+**Time to understand: 10-15 seconds.** The user recognizes the content (their folders) but must adjust to the unfamiliar presentation.
+
+#### Failure 5: "Import as Chapter" vs "Add as Source"
+
+Both the SourcesPanel and the SourceViewerSheet show "Import as Chapter" buttons. This action converts a source into a chapter -- a fundamentally different operation from "Add to Sources" (which keeps the document as reference material). But the two actions are presented at the same visual weight and proximity.
+
+A user who wants to "use this document" has two buttons that both seem like they accomplish that goal. The difference -- "reference it" vs "turn it into a chapter" -- requires understanding the project's content model.
+
+**Time to understand: 20+ seconds.** The user must understand the difference between a "source" (reference material) and a "chapter" (manuscript content) to choose correctly.
+
+---
+
+### 1.5 Architecture Signal
+
+The `EditorDialogsProps` interface in `editor-dialogs.tsx` spans 133 lines and defines approximately 100 props. Of these, roughly 50 props are source-related (SourcesPanel, AddSourceSheet, DriveBrowserSheet, SourceViewerSheet, AccountsSheet, and their associated state and callbacks).
+
+#### Why this is a problem beyond code quality
+
+The 133-line props interface is not just a code smell. It is a direct measurement of UX complexity. Every prop in that interface represents a piece of state or behavior that the editor page must track, wire, and coordinate. The size of this interface tells us:
+
+**1. The UX has no encapsulated subsystems.**
+
+A well-designed UX creates self-contained interaction units. A source browser should be a self-contained experience: the user enters it, accomplishes their goal, and exits. The implementation should reflect this -- a single component or context provider with internal state.
+
+Instead, the source management UX is shattered across 6 components (SourcesPanel, AddSourceSheet, DriveBrowserSheet, SourceViewerSheet, AccountsSheet, DriveFilesSheet) with all state lifted to the editor page and threaded through EditorDialogs. This means the source management UX is not a subsystem -- it is 50+ tendrils of state entangled with the rest of the editor.
+
+This architectural fragmentation mirrors the UX fragmentation. The user experiences 4 distinct surfaces (panel, add-sheet, browser-sheet, viewer) because the implementation creates 4 distinct components with no shared context. Each surface was built as an independent component, and the "integration" happened by wiring them together through props in the editor page.
+
+**2. The number of boolean state variables reveals modal complexity.**
+
+The source system manages 6 boolean state variables in `useSourceActions`:
+- `isSourcesPanelOpen`
+- `isViewerOpen`
+- `isAddSourceSheetOpen`
+- `isDriveBrowserOpen`
+- (plus `activeSource` and `driveConnectionId`)
+
+Six booleans create a theoretical state space of 64 combinations, most of which are invalid. The code prevents some invalid states (e.g., `closeSourcesPanel` also sets `isViewerOpen` to false), but there is no state machine enforcing valid transitions. The state management is ad hoc, with each `close*` callback manually resetting related states.
+
+This is a design problem, not just a code problem. Each boolean represents a surface the user might see. Six surfaces, each independently open/closeable, means the user cannot form a reliable mental model of "where am I in this flow?" Compare this to a well-designed state machine with 3-4 states: "closed", "browsing sources", "viewing a source", "adding a source."
+
+**3. The props interface width predicts future regression risk.**
+
+Every new feature that touches sources must thread new props through EditorDialogs. The planned Research Assistant (#128-130) and Research Board (#131-133) would each add 10-20 more props to this interface. At the current trajectory, EditorDialogsProps would exceed 200 props, making the editor page essentially unmaintainable.
+
+More critically, the prop-threading architecture makes it impossible to develop source features in isolation. Any change to a source component requires touching the editor page, EditorDialogs, and the relevant hooks. This coupling slows development and increases the risk of regressions in unrelated features.
+
+**4. The architecture reveals an absence of design intent.**
+
+The current source management UX was built incrementally: SourcesPanel was added, then AddSourceSheet was added to handle the "Add" flow, then DriveBrowserSheet was added because the Google Picker API had limitations, then SourceViewerSheet was added for content preview, then chapter-source linking was added. Each addition was a reasonable individual decision, but the cumulative result is a UX with no coherent mental model.
+
+The 133-line props interface is the architectural manifestation of "we added features without designing an experience." The redesign must start from a mental model, not from a feature list.
+
+---
+
+## Part 2: Three Mental Model Proposals
+
+### Option A: "Polished Library"
+
+#### Mental model in one sentence
+
+**"Your sources are a library shelf next to your writing desk -- always there when you need to glance over, organized by project, not by chapter."**
+
+This option preserves the fundamental concept of a project-level source library accessed through a right-hand panel, but eliminates the complexity layers: no chapter linking, no sheet stacking, no multi-step add flow.
+
+#### ASCII layout diagram (landscape iPad, 1180px)
+
+```
++---------------------------+----------------------------------+-------------------+
+|                           |                                  |                   |
+|  SIDEBAR (240px)          |  EDITOR (580px)                  |  SOURCES (360px)  |
+|                           |                                  |                   |
+|  Ch 1  The Problem   820w |  [Chapter Title]                 |  [Search]  [+ Add]|
+|  Ch 2  Why It Matt.. 1.2k |                                  |  ---------------  |
+|> Ch 3  The Framework  640w|  Lorem ipsum dolor sit amet,     |  Interview-S.doc  |
+|  Ch 4  Case Studies  920w |  consectetur adipiscing elit.    |  1,240 words      |
+|  Ch 5  Conclusion    410w |  Sed do eiusmod tempor           |                   |
+|                           |  incididunt ut labore et         |  Q4-Report.doc    |
+|                           |  dolore magna aliqua. Ut enim    |  3,800 words      |
+|                           |  ad minim veniam, quis nostrud   |                   |
+|                           |  exercitation ullamco laboris    |  Client-Notes.doc |
+|                           |  nisi ut aliquip ex ea commodo   |  2,100 words      |
+|                           |  consequat.                      |                   |
+|                           |                                  |  Meeting-Tr.txt   |
+|                           |  Duis aute irure dolor in        |  890 words        |
+|                           |  reprehenderit in voluptate      |                   |
+|                           |  velit esse cillum dolore eu     |                   |
+|                           |  fugiat nulla pariatur.          |                   |
+|                           |                                  |                   |
+|  Total: 4,990 words       |  640 words                       |  4 sources        |
++---------------------------+----------------------------------+-------------------+
+```
+
+**Portrait iPad (820px):** The sources panel is hidden by default. A "Sources" button in the toolbar opens the panel as a full-screen overlay (not a partial sheet). Tapping a source opens its content in the same overlay, replacing the list view with a detail view and a back button.
+
+**Source detail view (replaces the list in the same panel):**
+
+```
++-------------------------------------------+
+|  [< Back]   Interview-Smith.doc    [Close] |
+|  1,240 words  |  Cached 2h ago             |
+|  -------------------------------------------
+|                                            |
+|  The key insight from our conversation     |
+|  was that leadership in distributed teams  |
+|  requires fundamentally different...       |
+|                                            |
+|  [Import as Chapter]                       |
++-------------------------------------------+
+```
+
+#### Tap-count analysis
+
+| Task | Taps | Path |
+|------|------|------|
+| **Task 1:** Add a new source from Google Drive | **3-6** | Tap [+ Add] in panel header (1) > unified Drive browser opens inline in panel: navigate folders (1-3) > check files (1+) > tap "Add" (1) |
+| **Task 2:** View source content while writing | **1** | Tap source row in panel (panel is already visible in landscape) |
+| **Task 3:** Find a specific fact from source materials | **2-4** | Type in search field at top of panel (1) > scan filtered results (0) > tap source (1) > scroll to find fact (manual) |
+| **Task 4:** Save a useful passage for later | **N/A** | Not supported. Option A does not include a snippet/clipboard feature. User must copy-paste manually. |
+| **Task 5:** Insert a sourced quote into the editor | **N/A** | Not supported natively. User must manually copy from viewer, paste into editor, and create a footnote. |
+
+#### Backlog issue coverage
+
+| Issue | Coverage | Notes |
+|-------|----------|-------|
+| #121 Drive auth | Unchanged | Existing auth flow preserved |
+| #122 Drive file selection | Improved | Merged into single inline browser (replaces AddSourceSheet + DriveBrowserSheet) |
+| #123 Local upload | Unchanged | Upload option remains in the add flow |
+| #124 Text extraction | Unchanged | Backend work, independent of UX |
+| #125-127 AI query pipeline | Not addressed | Option A does not include AI research |
+| #128-130 Research Assistant UI | Not addressed | No AI panel |
+| #131-133 Research Board | Not addressed | No snippet collection |
+| #134-137 Spikes | Partially addressed | #137 (preview component) is addressed by the improved viewer |
+
+**Coverage: 4 of 17 issues addressed. Option A is source management only.**
+
+#### Technical complexity
+
+**Components changed:**
+- `SourcesPanel` -- Refactored: remove link/unlink buttons, add search field, add inline Drive browser mode, add inline detail view (replaces SourceViewerSheet)
+- `AddSourceSheet` -- **Removed.** Merged into SourcesPanel's add flow.
+- `DriveBrowserSheet` -- **Removed.** Replaced by inline Drive browser within SourcesPanel.
+- `SourceViewerSheet` -- **Removed.** Replaced by detail view within SourcesPanel.
+- `EditorDialogs` -- Simplified: ~50 source-related props reduced to ~15.
+
+**Hooks changed:**
+- `useSourceActions` -- Simplified: remove `isAddSourceSheetOpen`, `isDriveBrowserOpen` state. Add `viewMode` state (`'list' | 'detail' | 'add'`).
+- `useChapterSources` -- **Removed entirely.** No chapter-level linking.
+
+**API changes:**
+- Remove `POST /chapters/:chapterId/sources/:sourceId/link` endpoint
+- Remove `DELETE /chapters/:chapterId/sources/:sourceId/link` endpoint
+- Remove `GET /chapters/:chapterId/sources` endpoint
+
+**Database changes:**
+- `chapter_sources` table becomes unused (can be deprecated or dropped)
+- No new tables
+
+**Estimated effort:** 1-2 weeks for a single developer.
+
+#### Risk assessment
+
+**Risks for Diane:**
+- Low risk. The simplified panel is more discoverable and the single-surface navigation prevents getting lost.
+- The term "Sources" may still cause confusion. Consider "Reference Docs" or "Research Docs" as alternatives.
+- In portrait mode, the full-screen overlay means Diane cannot see her chapter while viewing a source. She must toggle back and forth.
+
+**Risks for Marcus:**
+- Moderate risk. Marcus has 100+ documents. A flat source list does not scale for him. The search field mitigates this, but Marcus may want folder-level organization within DraftCrane.
+- Removing chapter linking means Marcus loses the ability to organize sources by chapter -- everything is a flat project-level list. For a book with 15 chapters, this could feel disorganized.
+- Marcus's 12 subfolder structure in Drive is navigable through the inline browser, but the flat display after import removes his organizational hierarchy.
+
+#### What gets removed
+
+| Component/Concept | Status |
+|---|---|
+| `AddSourceSheet` component | Removed -- merged into panel |
+| `DriveBrowserSheet` component | Removed -- merged into panel |
+| `SourceViewerSheet` component | Removed -- merged into panel |
+| `useChapterSources` hook | Removed entirely |
+| `chapter_sources` database table | Deprecated |
+| Chapter-source linking concept | Eliminated |
+| Link/Unlink buttons | Eliminated |
+| Source viewer tab bar | Eliminated |
+| 3 backend API endpoints (link, unlink, get chapter sources) | Removed |
+| ~50 props from EditorDialogsProps | Removed |
+
+---
+
+### Option B: "Research Companion"
+
+#### Mental model in one sentence
+
+**"Your research assistant lives in a panel beside your writing -- it holds your source files, answers your questions, and keeps your collected snippets organized."**
+
+This option unifies source management, the future AI Research Assistant, and the future Research Board into a single right-hand panel with three tabs. Sources are project-wide (no chapter linking). The AI can search across all sources. Collected snippets are the bridge between research and writing.
+
+#### ASCII layout diagram (landscape iPad, 1180px)
+
+```
++---------------------------+----------------------------------+-------------------+
+|                           |                                  |  RESEARCH         |
+|  SIDEBAR (240px)          |  EDITOR (540px)                  |  [Sources|Ask|Clips]
+|                           |                                  |  ================ |
+|  Ch 1  The Problem   820w |  [Chapter Title]                 |                   |
+|  Ch 2  Why It Matt.. 1.2k |                                  |  SOURCES TAB:     |
+|> Ch 3  The Framework  640w|  Lorem ipsum dolor sit amet,     |  [Search]  [+ Add]|
+|  Ch 4  Case Studies  920w |  consectetur adipiscing elit.    |  ---------------  |
+|  Ch 5  Conclusion    410w |  Sed do eiusmod tempor           |  Interview-S.doc  |
+|                           |  incididunt ut labore et         |    1,240w  Cached |
+|                           |  dolore magna aliqua.            |  Q4-Report.doc    |
+|                           |                                  |    3,800w  Cached |
+|                           |  Ut enim ad minim veniam,        |  Client-Notes.doc |
+|                           |  quis nostrud exercitation       |    2,100w  Cached |
+|                           |  ullamco laboris nisi ut         |                   |
+|                           |  aliquip ex ea commodo           |                   |
+|                           |  consequat.                      |                   |
+|                           |                                  |                   |
+|  Total: 4,990 words       |  640 words                       |  3 sources        |
++---------------------------+----------------------------------+-------------------+
+```
+
+**"Ask" tab (AI Research Assistant):**
+
+```
++-------------------------------------------+
+|  RESEARCH                                  |
+|  [Sources | *Ask* | Clips]                 |
+|  ==========================================|
+|                                            |
+|  What does Smith say about resilience      |
+|  in distributed teams?                     |
+|                                            |
+|  ---  AI Response  -------------------------
+|  According to the Smith interview          |
+|  (Interview-Smith.doc, p.3):               |
+|                                            |
+|  "Resilience in distributed teams comes    |
+|  from psychological safety, not from       |
+|  process compliance."                      |
+|                                            |
+|  Smith also notes that...                  |
+|  (Q4-Report.doc, p.12)                     |
+|                                            |
+|  [Save to Clips]  [Insert Quote]           |
+|  -------------------------------------------
+|                                            |
+|  [Ask about your sources...]               |
++-------------------------------------------+
+```
+
+**"Clips" tab (Research Board):**
+
+```
++-------------------------------------------+
+|  RESEARCH                                  |
+|  [Sources | Ask | *Clips*]                 |
+|  ==========================================|
+|                                            |
+|  3 clips saved                             |
+|                                            |
+|  "Resilience in distributed teams..."      |
+|  -- Interview-Smith.doc, p.3               |
+|  [Insert]  [Delete]                        |
+|                                            |
+|  "Q4 results showed a 23% increase..."     |
+|  -- Q4-Report.doc, p.12                    |
+|  [Insert]  [Delete]                        |
+|                                            |
+|  "The framework suggests three phases..."  |
+|  -- Client-Notes.doc, p.7                  |
+|  [Insert]  [Delete]                        |
+|                                            |
++-------------------------------------------+
+```
+
+**Portrait iPad (820px):** The Research panel is hidden. A "Research" button in the toolbar opens it as a slide-over panel (right side, 85% width) with a visible editor strip on the left for context. Tapping a source opens its content in the same panel, replacing the current tab content. The user swipes right or taps "Back" to return to the tab view.
+
+**Source detail view (within the Sources tab):**
+
+```
++-------------------------------------------+
+|  RESEARCH                                  |
+|  [< Sources]   Interview-Smith.doc         |
+|  ==========================================|
+|  1,240 words  |  Cached 2h ago             |
+|                                            |
+|  The key insight from our conversation     |
+|  was that leadership in distributed teams  |
+|  requires fundamentally different...       |
+|                                            |
+|  (User can long-press to select text       |
+|   and see a "Save to Clips" action)        |
+|                                            |
+|  [Import as Chapter]                       |
++-------------------------------------------+
+```
+
+#### Tap-count analysis
+
+| Task | Taps | Path |
+|------|------|------|
+| **Task 1:** Add a new source from Google Drive | **3-6** | Panel is open > Sources tab active > tap [+ Add] (1) > inline Drive browser: navigate (1-3) > select (1+) > tap "Add" (1) |
+| **Task 2:** View source content while writing | **1** | Tap source row in Sources tab (panel already visible in landscape) |
+| **Task 3:** Find a specific fact from source materials | **2** | Switch to Ask tab (1) > type question and tap send (1) > AI returns answer with source citation |
+| **Task 4:** Save a useful passage for later | **2** | From AI response: tap "Save to Clips" (1). Or from source viewer: long-press to select text (1) > tap "Save to Clips" in context menu (1) |
+| **Task 5:** Insert a sourced quote into the editor | **1-2** | From Clips tab: tap "Insert" on a clip (1) > clip text + footnote inserted at cursor. Or from AI response: tap "Insert Quote" (1) |
+
+#### Backlog issue coverage
+
+| Issue | Coverage | Notes |
+|-------|----------|-------|
+| #121 Drive auth | Unchanged | Existing auth flow preserved |
+| #122 Drive file selection | Improved | Single inline browser in Sources tab |
+| #123 Local upload | Unchanged | Upload option in add flow |
+| #124 Text extraction | Unchanged | Backend work, independent |
+| #125 AI query API endpoint | **Addressed** | Ask tab sends queries to this endpoint |
+| #126 Chunking strategy | **Addressed** | Required for Ask tab to work |
+| #127 Response parsing | **Addressed** | AI responses displayed in Ask tab |
+| #128 Research panel | **Addressed** | The Research panel IS this component |
+| #129 Query input | **Addressed** | Ask tab input field |
+| #130 File preview | **Addressed** | Source detail view in Sources tab |
+| #131 Collect snippets | **Addressed** | "Save to Clips" action from Ask and viewer |
+| #132 View/manage board | **Addressed** | Clips tab |
+| #133 Drag-to-editor with footnotes | **Addressed** | "Insert" button on clips + auto-footnote |
+| #134 Prompt engineering spike | Partially | Needed for Ask tab quality |
+| #135 Doc parsing spike | Partially | Needed for source ingestion |
+| #136 Chunking strategy spike | Partially | Needed for AI search quality |
+| #137 Preview component spike | **Addressed** | Source detail view |
+
+**Coverage: 14 of 17 issues addressed. Option B provides a unified frame for the entire research feature set.**
+
+#### Technical complexity
+
+**Components created (new):**
+- `ResearchPanel` -- Container with tab navigation (Sources, Ask, Clips)
+- `ResearchSourcesTab` -- Replaces SourcesPanel (source list + inline add + inline detail)
+- `ResearchAskTab` -- AI query interface (input, response display, save/insert actions)
+- `ResearchClipsTab` -- Saved snippets with insert/delete actions
+
+**Components removed:**
+- `SourcesPanel` -- Replaced by ResearchSourcesTab
+- `AddSourceSheet` -- Merged into ResearchSourcesTab add flow
+- `DriveBrowserSheet` -- Merged into ResearchSourcesTab add flow
+- `SourceViewerSheet` -- Merged into ResearchSourcesTab detail view
+
+**Hooks changed:**
+- `useSourceActions` -- Refactored to `useResearchPanel` with tab state, unified source management, and viewer state. State machine with defined transitions: `idle | sources-list | sources-detail | sources-add | ask | clips`.
+- `useChapterSources` -- **Removed entirely.**
+- New: `useAIResearch` -- manages query state, response parsing, and snippet extraction.
+- New: `useResearchClips` -- manages saved snippets (CRUD against new backend endpoint).
+
+**API changes:**
+- Remove chapter-source link/unlink endpoints (3 endpoints)
+- Add `POST /projects/:projectId/research/query` -- AI query endpoint
+- Add `GET /projects/:projectId/clips` -- list saved clips
+- Add `POST /projects/:projectId/clips` -- save a clip (source reference, text, position)
+- Add `DELETE /clips/:clipId` -- delete a clip
+
+**Database changes:**
+- `chapter_sources` table deprecated
+- New: `research_clips` table:
+  ```sql
+  CREATE TABLE research_clips (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    source_id TEXT REFERENCES source_materials(id) ON DELETE SET NULL,
+    content TEXT NOT NULL,
+    source_location TEXT,  -- page/section reference
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+  ```
+
+**Estimated effort:** 4-6 weeks for a single developer. The AI query pipeline (#125-127) is the largest work item and must be built regardless of the UX option chosen. The panel restructuring itself is ~2 weeks.
+
+#### Risk assessment
+
+**Risks for Diane:**
+- The three-tab structure adds cognitive overhead. Diane must learn what "Sources," "Ask," and "Clips" mean and when to use each. However, the tabs are labeled with plain language and the default tab (Sources) is the simplest view.
+- The AI "Ask" feature depends on source ingestion quality (#124, #126). If the AI gives poor answers because source parsing fails (e.g., Google Doc formatting artifacts), Diane will lose trust in the feature.
+- The "Clips" concept introduces a new workflow step. Diane currently uses copy-paste. Switching to "save clip then insert clip" is an extra step. The value proposition must be clear: the clip carries its source attribution automatically.
+
+**Risks for Marcus:**
+- Marcus may want to organize clips by chapter. The flat clips list could become unwieldy for a 15-chapter book with 50+ clips. Consider adding optional chapter tags to clips in a future iteration.
+- The "Ask" tab is powerful for Marcus's "find the right document" use case, but depends on the quality of the AI's document search. If it cannot reliably distinguish between his 4 partial drafts of Chapter 3, the feature frustrates rather than helps.
+
+**General risks:**
+- Scope creep. Implementing the full Ask + Clips flow alongside source management refactoring is a large effort. The risk is that the source management improvements are delayed by the AI pipeline work.
+- The panel width (400px in the layout above) reduces the editor to 540px in landscape. This is marginally acceptable for writing but pushes against the lower limit. In portrait mode, the panel must be a full overlay, which eliminates side-by-side viewing.
+
+#### What gets removed
+
+| Component/Concept | Status |
+|---|---|
+| `SourcesPanel` component | Replaced by `ResearchSourcesTab` |
+| `AddSourceSheet` component | Removed -- merged into Sources tab |
+| `DriveBrowserSheet` component | Removed -- merged into Sources tab |
+| `SourceViewerSheet` component | Removed -- merged into Sources tab |
+| `useChapterSources` hook | Removed entirely |
+| `chapter_sources` database table | Deprecated |
+| Chapter-source linking concept | Eliminated |
+| Link/Unlink buttons | Eliminated |
+| Source viewer tab bar | Eliminated -- replaced by source detail view with back navigation |
+| ~50 props from EditorDialogsProps | Replaced by ~20 props for ResearchPanel |
+
+---
+
+### Option C: "Integrated Research Assistant"
+
+#### Mental model in one sentence
+
+**"You don't manage sources -- you ask questions, and your writing assistant finds the answers in your documents."**
+
+This option eliminates the concept of a "source library" as a primary surface. Sources are added during project setup or through a lightweight settings flow. The primary interaction is through the AI query interface: the user asks questions, the AI searches all connected sources, and the user collects and inserts relevant passages. Source management is infrastructure, not a feature.
+
+#### ASCII layout diagram (landscape iPad, 1180px)
+
+**Default state (no research panel open):**
+
+```
++---------------------------+--------------------------------------------------+
+|                           |                                                  |
+|  SIDEBAR (240px)          |  EDITOR (940px)                                  |
+|                           |                                                  |
+|  Ch 1  The Problem   820w |  [Chapter Title]                                 |
+|  Ch 2  Why It Matt.. 1.2k |                                                  |
+|> Ch 3  The Framework  640w|  Lorem ipsum dolor sit amet, consectetur          |
+|  Ch 4  Case Studies  920w |  adipiscing elit. Sed do eiusmod tempor           |
+|  Ch 5  Conclusion    410w |  incididunt ut labore et dolore magna aliqua.     |
+|                           |                                                  |
+|                           |  Ut enim ad minim veniam, quis nostrud            |
+|                           |  exercitation ullamco laboris nisi ut aliquip     |
+|                           |  ex ea commodo consequat.                         |
+|                           |                                                  |
+|                           |  Duis aute irure dolor in reprehenderit in        |
+|                           |  voluptate velit esse cillum dolore eu fugiat     |
+|                           |  nulla pariatur.                                  |
+|                           |                                                  |
+|                           |                                                  |
+|                           |                            [Research]             |
+|  Total: 4,990 words       |  640 words                                       |
++---------------------------+--------------------------------------------------+
+```
+
+**With Research panel open (activated by [Research] button or Cmd+Shift+R):**
+
+```
++---------------------------+--------------------------+-----------------------+
+|                           |                          |  RESEARCH             |
+|  SIDEBAR (240px)          |  EDITOR (520px)          |  [Clips: 3]    [Gear]|
+|                           |                          |  =====================|
+|  Ch 1  The Problem   820w |  [Chapter Title]         |                       |
+|  Ch 2  Why It Matt.. 1.2k |                          |  What does Smith say  |
+|> Ch 3  The Framework  640w|  Lorem ipsum dolor sit   |  about resilience?    |
+|  Ch 4  Case Studies  920w |  amet, consectetur       |                       |
+|  Ch 5  Conclusion    410w |  adipiscing elit.        |  --- AI Response ---  |
+|                           |                          |  Smith (Interview,    |
+|                           |  Sed do eiusmod tempor   |  p.3) states:         |
+|                           |  incididunt ut labore    |                       |
+|                           |  et dolore magna         |  "Resilience in       |
+|                           |  aliqua.                 |  distributed teams    |
+|                           |                          |  comes from           |
+|                           |  Ut enim ad minim        |  psychological        |
+|                           |  veniam, quis nostrud    |  safety, not from     |
+|                           |  exercitation ullamco.   |  process compliance." |
+|                           |                          |                       |
+|                           |                          |  [Save] [Insert+Cite] |
+|                           |                          |  =====================|
+|                           |                          |  [Ask about sources..]|
+|  Total: 4,990 words       |  640 words               |  6 sources connected  |
++---------------------------+--------------------------+-----------------------+
+```
+
+**Source management (accessed via [Gear] icon in Research panel):**
+
+```
++-------------------------------------------+
+|  RESEARCH > Source Settings                |
+|  [< Back]                          [+ Add]|
+|  ==========================================|
+|                                            |
+|  Connected Sources (6)                     |
+|                                            |
+|  Interview-Smith.doc      [View] [Remove]  |
+|  Q4-Report.doc            [View] [Remove]  |
+|  Client-Notes.doc         [View] [Remove]  |
+|  Leadership-Theory.doc    [View] [Remove]  |
+|  Team-Survey-2025.doc     [View] [Remove]  |
+|  Meeting-Transcript.txt   [View] [Remove]  |
+|                                            |
+|  --- Add more sources from Google Drive    |
+|  --- or upload from your device.           |
+|                                            |
++-------------------------------------------+
+```
+
+**Clips drawer (accessed via [Clips: 3] badge):**
+
+```
++-------------------------------------------+
+|  RESEARCH > Saved Clips (3)               |
+|  [< Back]                                 |
+|  ==========================================|
+|                                            |
+|  "Resilience in distributed teams..."      |
+|  -- Interview-Smith.doc, p.3               |
+|  [Insert+Cite]  [Delete]                   |
+|                                            |
+|  "Q4 results showed a 23% increase..."     |
+|  -- Q4-Report.doc, p.12                    |
+|  [Insert+Cite]  [Delete]                   |
+|                                            |
+|  "The framework suggests three phases..."  |
+|  -- Client-Notes.doc, p.7                  |
+|  [Insert+Cite]  [Delete]                   |
+|                                            |
++-------------------------------------------+
+```
+
+**Portrait iPad (820px):** The [Research] button opens a bottom sheet (max-h-[85vh]) with the conversational interface. Source settings and clips are accessible through navigation within the sheet. The editor is visible as a sliver above the sheet for context.
+
+#### Tap-count analysis
+
+| Task | Taps | Path |
+|------|------|------|
+| **Task 1:** Add a new source from Google Drive | **4-8** | Open Research panel (1) > tap [Gear] for settings (1) > tap [+ Add] (1) > Drive browser: navigate (1-3) > select (1+) > tap "Add" (1) |
+| **Task 2:** View source content while writing | **3** | Open Research panel (1) > tap [Gear] for settings (1) > tap "View" on a source (1) |
+| **Task 3:** Find a specific fact from source materials | **2** | Open Research panel (if closed) (1) > type question and tap send (1) > AI returns answer with citation |
+| **Task 4:** Save a useful passage for later | **1** | From AI response: tap "Save" (1) |
+| **Task 5:** Insert a sourced quote into the editor | **1** | From AI response: tap "Insert+Cite" (1) > quote inserted at cursor with auto-footnote |
+
+#### Backlog issue coverage
+
+| Issue | Coverage | Notes |
+|-------|----------|-------|
+| #121 Drive auth | Unchanged | Existing auth flow preserved |
+| #122 Drive file selection | Addressed | Source settings inline browser |
+| #123 Local upload | Addressed | Upload option in source settings |
+| #124 Text extraction | **Critical dependency** | AI cannot answer without text extraction |
+| #125 AI query API endpoint | **Addressed** | Core feature of the Research panel |
+| #126 Chunking strategy | **Critical dependency** | AI quality depends on chunking |
+| #127 Response parsing | **Addressed** | Response display in Research panel |
+| #128 Research panel | **Addressed** | The Research panel IS this component |
+| #129 Query input | **Addressed** | Conversational input field |
+| #130 File preview | **Addressed** | Source viewer in settings subview |
+| #131 Collect snippets | **Addressed** | "Save" action on AI responses |
+| #132 View/manage board | **Addressed** | Clips drawer |
+| #133 Drag-to-editor with footnotes | **Addressed** | "Insert+Cite" with auto-footnote |
+| #134 Prompt engineering spike | **Critical dependency** | Answer quality is the product |
+| #135 Doc parsing spike | **Critical dependency** | Source ingestion quality |
+| #136 Chunking strategy spike | **Critical dependency** | Search relevance quality |
+| #137 Preview component spike | **Addressed** | Source viewer |
+
+**Coverage: 17 of 17 issues addressed, but 4 are critical dependencies that must be completed before the UX delivers value.** Without high-quality AI responses, this option is a worse source browser than Option A.
+
+#### Technical complexity
+
+**Components created (new):**
+- `ResearchPanel` -- Conversational AI interface with sub-views for settings and clips
+- `ResearchInput` -- Query input field with send button and suggested questions
+- `ResearchResponse` -- AI response display with source citations, save/insert actions
+- `ResearchClips` -- Saved clips list with insert/delete
+- `ResearchSourceSettings` -- Source management (list, add, remove, view)
+
+**Components removed:**
+- `SourcesPanel` -- Replaced by ResearchSourceSettings (secondary surface)
+- `AddSourceSheet` -- Merged into ResearchSourceSettings
+- `DriveBrowserSheet` -- Merged into ResearchSourceSettings
+- `SourceViewerSheet` -- Merged into ResearchSourceSettings
+
+**Hooks changed:**
+- `useSourceActions` -- Refactored to `useResearch` with state machine: `closed | asking | viewing-response | clips | source-settings | source-detail | source-add`.
+- `useChapterSources` -- **Removed entirely.**
+- New: `useAIResearch` -- manages conversation state, streaming responses, citation parsing.
+- New: `useResearchClips` -- manages saved clips.
+- New: `useResearchSuggestions` -- generates contextual question suggestions based on current chapter content and available sources.
+
+**API changes:**
+- Remove chapter-source link/unlink endpoints (3 endpoints)
+- Add `POST /projects/:projectId/research/query` -- AI query with streaming SSE response
+- Add `GET /projects/:projectId/research/suggestions` -- contextual question suggestions
+- Add `GET /projects/:projectId/clips` -- list clips
+- Add `POST /projects/:projectId/clips` -- save clip
+- Add `DELETE /clips/:clipId` -- delete clip
+- Add `POST /chapters/:chapterId/insert-citation` -- insert text + create footnote reference
+
+**Database changes:**
+- `chapter_sources` table deprecated
+- New: `research_clips` table (same as Option B)
+- New: `research_conversations` table (for conversation history):
+  ```sql
+  CREATE TABLE research_conversations (
+    id TEXT PRIMARY KEY,
+    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    query TEXT NOT NULL,
+    response TEXT NOT NULL,
+    source_refs TEXT,  -- JSON array of {sourceId, location} references
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+  ```
+- New: `source_chunks` table (for vector search / chunked source content):
+  ```sql
+  CREATE TABLE source_chunks (
+    id TEXT PRIMARY KEY,
+    source_id TEXT NOT NULL REFERENCES source_materials(id) ON DELETE CASCADE,
+    chunk_index INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    embedding BLOB,  -- vector embedding for similarity search
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+  ```
+
+**Estimated effort:** 8-12 weeks for a single developer. The AI pipeline (ingestion, chunking, embedding, query, response parsing, citation extraction) is the dominant work item at 5-7 weeks. The panel UX is 2-3 weeks. The auto-footnote insertion into Tiptap is 1-2 weeks.
+
+#### Risk assessment
+
+**Risks for Diane:**
+- **High dependency on AI quality.** If the AI gives wrong answers, cites the wrong source, or hallucinates, Diane has no fallback. In Option A and B, she can manually browse sources. In Option C, the browse path is buried 2 taps deep in settings. The primary path IS the AI.
+- **Source addition is deprioritized.** Adding sources requires navigating to settings within the Research panel (2 extra taps). For initial setup, this is acceptable. But if Diane realizes mid-writing that she needs to add another source, the path is longer than in Options A or B.
+- **The conversational paradigm may not match Diane's workflow.** Diane currently writes from a Google Doc open in another tab. Her workflow is "read source, then write." Option C's workflow is "ask a question, read the answer, insert it." This is a fundamentally different mode of working. Diane may not naturally formulate questions about her own documents.
+- **Suggested questions could bridge this gap.** If the system generates good questions ("What does your Smith interview say about team dynamics?"), Diane has a starting point. But this depends on the suggestion quality, which is itself an AI feature.
+
+**Risks for Marcus:**
+- Marcus knows exactly which documents he needs. The "ask and receive" model adds friction for his "I want to open Document X and find Section Y" workflow. He must either navigate to source settings (indirect) or ask the AI to find it (slower than direct access).
+- Marcus may want to browse his sources to re-familiarize himself with what he has. Option C makes browsing a secondary activity, which conflicts with Marcus's organizational nature.
+- The 100+ document scenario is theoretically ideal for AI search (too many docs to browse manually), but the AI must handle the scale reliably. Vector search across 100 documents with hundreds of chunks requires infrastructure that may exceed D1/Workers AI capacity.
+
+**General risks:**
+- **All-or-nothing delivery.** Unlike Options A and B, Option C cannot be partially delivered. A Research panel without working AI is an empty shell. The AI pipeline must be functional before the UX delivers any value.
+- **Performance on Workers.** Streaming SSE responses from Workers AI while simultaneously serving the editor, auto-saving, and handling Drive sync is a significant load. Edge compute constraints may cause latency or timeout issues.
+- **The Tiptap footnote insertion** ("Insert+Cite") requires extending the editor's schema to support footnote nodes. This is a non-trivial Tiptap extension that must handle edge cases (inserting at selection boundaries, undo/redo, export to Google Docs).
+
+#### What gets removed
+
+| Component/Concept | Status |
+|---|---|
+| `SourcesPanel` component | Removed -- sources managed through Research > Settings |
+| `AddSourceSheet` component | Removed -- merged into Research > Settings > Add |
+| `DriveBrowserSheet` component | Removed -- merged into Research > Settings > Add |
+| `SourceViewerSheet` component | Removed -- merged into Research > Settings > View |
+| `useChapterSources` hook | Removed entirely |
+| `chapter_sources` database table | Deprecated |
+| Chapter-source linking concept | Eliminated |
+| Link/Unlink buttons | Eliminated |
+| Source viewer tab bar | Eliminated |
+| "Sources" as a primary concept | Demoted to settings |
+| Manual source browsing as primary interaction | Replaced by AI query |
+| ~50 source props from EditorDialogsProps | Replaced by ~15 Research panel props |
+
+---
+
+## Summary Comparison
+
+| Dimension | Option A: Polished Library | Option B: Research Companion | Option C: Integrated Assistant |
+|-----------|---------------------------|------------------------------|-------------------------------|
+| **Philosophy** | Fix what's broken | Unify sources + AI + clips | AI-first, sources invisible |
+| **Primary interaction** | Browse source list | Browse OR ask | Ask questions |
+| **Source browsing** | Primary | Primary (Sources tab) | Secondary (Settings) |
+| **AI research** | Not included | Included (Ask tab) | Core feature |
+| **Snippet collection** | Not included | Included (Clips tab) | Included (Clips drawer) |
+| **Auto-citation** | Not included | Included (Insert action) | Core feature |
+| **Max sheet depth** | 1 (detail replaces list) | 1 (tab switching, detail replaces tab) | 1 (sub-views within panel) |
+| **Backlog coverage** | 4 of 17 issues | 14 of 17 issues | 17 of 17 issues |
+| **Props removed** | ~50 | ~50 | ~50 |
+| **Props added** | ~15 | ~20 | ~15 |
+| **New backend endpoints** | 0 | 4 | 6 |
+| **New DB tables** | 0 | 1 | 3 |
+| **Dev effort** | 1-2 weeks | 4-6 weeks | 8-12 weeks |
+| **Diane risk** | Low | Medium | High |
+| **Marcus risk** | Medium (flat list) | Low-Medium | Medium (browse friction) |
+| **Dependency risk** | Low | Medium (AI quality) | High (AI is the product) |
+| **Can ship incrementally?** | Yes | Yes (Sources tab first, Ask/Clips later) | No (AI must work first) |
+
+### Recommended Sequencing
+
+These options are not mutually exclusive in time. A phased approach:
+
+1. **Ship Option A now** (1-2 weeks). Fix the immediate UX problems: eliminate sheet stacking, remove chapter linking confusion, simplify the add flow. This unblocks users today.
+
+2. **Build toward Option B** (4-6 weeks after). Add the Ask and Clips tabs to the panel established in step 1. The Sources tab from Option A becomes the Sources tab of Option B with minimal rework.
+
+3. **Evaluate Option C's AI-primary model** after the Ask tab has usage data. If users prefer asking over browsing, progressively shift the UX toward Option C by making the Ask tab the default and demoting source browsing. If users prefer browsing, stay with Option B.
+
+This sequencing delivers value immediately (Option A), builds toward the full vision (Option B), and lets real user behavior determine whether the ambitious AI-first model (Option C) is warranted.

--- a/docs/design/source-review/02b-user-reactions.md
+++ b/docs/design/source-review/02b-user-reactions.md
@@ -1,0 +1,360 @@
+# Phase 2b: User Persona Reactions
+
+> DraftCrane Source/Research UX Design Review
+> Persona-based evaluation of three mental model proposals
+> Date: 2026-02-19
+
+---
+
+## Option A: "Polished Library"
+
+### Diane Mercer's Reactions
+
+**1. "If I opened DraftCrane and saw this, what would I think it does?"**
+
+Okay, so I've got my chapters on the left -- that makes sense, that's like a table of contents. The writing area in the middle, fine, that's my document. And then there's this panel on the right that says "Sources" with a search box and an "Add" button.
+
+My first thought: "Sources? Like a bibliography?" I haven't written a bibliography since grad school. I'd wonder if this is something I'm supposed to fill in for proper citations. It takes me a few seconds to realize these are my Google Docs -- my workshop notes, my interview transcripts, the stuff I'm writing *from*. The word "Sources" doesn't connect to how I think about my files. I think of them as "my notes" or "my stuff." I'd probably figure it out after 15 seconds, but that initial flash of "is this for academics?" would make me feel like maybe this tool isn't for someone like me.
+
+The layout itself, though -- three columns, everything visible at once -- that I understand immediately. It looks like a workspace. Left is navigation, middle is where I write, right is... reference material, I guess. That part is intuitive. I've used enough apps to get the three-column thing.
+
+**2. "Can I figure out how to find something in my research materials without instructions?"**
+
+I see the search box at the top of the right panel. Okay. I'd tap it and type "managers who receive coaching" or maybe just "coaching stats." If my docs are already in that panel, I'd expect the search to filter the list down to relevant files.
+
+Here's where I'd get stuck: Does the search look *inside* the documents? Or does it just match file names? Because my Google Doc titles are useless -- things like "Workshop Notes March 2024" and "Client Debrief - Consolidated." The stat I'm looking for could be in any of them. If the search only matches titles, I'm stuck scrolling through every document one by one, opening each, reading, closing, opening the next. That's basically what I do now in Google Drive.
+
+If the search looks inside the documents and shows me where the match is -- *that* would be the moment I'd say "oh, this is actually useful." But the design doesn't make it obvious which kind of search this is. I'd try it and see. If it only matches titles, I'd be disappointed but not surprised. That's how most things work.
+
+**3. "If I'm writing Chapter 4 and need to check a fact from an old workshop doc, what do I do?"**
+
+I'm in the zone. I just wrote a paragraph about psychological safety and I want to verify that stat -- was it 67% or 76% of teams that reported improvement? I glance right. The sources panel is already there. Good, I don't have to go find it.
+
+I scan the file names. "Workshop Notes March 2024" -- maybe that one? I tap it. The list disappears and shows me the document content with a "Back" button at the top. Now I'm scrolling through the whole document looking for that stat.
+
+This is the pain point: I'm reading through a 3,000-word document looking for one number. There's no way to search within this document view. I'm just scrolling and scanning. Meanwhile, my chapter has disappeared because the source content replaced the list, and on my iPad in portrait mode, the source viewer takes up the whole screen. I can't see what I was writing. I'm going to lose my train of thought.
+
+I'd find the stat eventually -- or maybe I wouldn't, maybe it's in a different document, and now I need to tap "Back," pick a different file, and start the scroll-and-scan again. By the time I find it, the paragraph I was writing has gone cold. This is better than switching between Safari tabs, but honestly? Not by a lot.
+
+**4. "Does this feel like one more thing to learn, or like it's helping me?"**
+
+It feels... neutral. Like, it's not *complicated*. I can see what everything does. There's no jargon I don't understand (except "Sources," which I'd get over). It's clean. I wouldn't need anyone to explain it to me.
+
+But it also doesn't feel like it's *doing* anything for me. It's a file browser next to my writing. I already have a file browser -- it's called Google Drive. The difference is that this one is right there instead of in another tab. Is that enough to change my workflow? Honestly, maybe. Not having to switch tabs is genuinely helpful. But I was hoping for more. When I heard "writing tool with AI," I imagined something that would help me *find* things, not just show me a list of files.
+
+It reduces one annoyance (tab switching) without solving the real problem (I can't find anything in my own notes).
+
+**5. "What would make me go back to copy-pasting between Google Docs and ChatGPT?"**
+
+If I have to manually scroll through every document to find what I'm looking for, I'll go back to ChatGPT within a week. ChatGPT is messy -- I have to paste my doc content in, it loses context between sessions, and I can't keep track of what I've asked before. But at least I can *ask it a question* and get an answer. "Find the stat about coaching effectiveness in my workshop notes" -- ChatGPT does that. This panel doesn't.
+
+The other breaking point: portrait mode on my iPad. If viewing a source means I lose my editor entirely, and I have to tap back and forth constantly, that's actually *worse* than having two Safari tabs side by side in Split View. At least with Split View, I can see both at once.
+
+---
+
+### Marcus Chen's Reactions
+
+**1. "If I opened DraftCrane and saw this, what would I think it does?"**
+
+Three-column layout. Chapter navigation on the left with word counts -- nice, I can see my progress at a glance. Editor in the middle. Sources panel on the right with search and add. This is structured. I get it immediately.
+
+My concern isn't understanding it -- it's scale. I have 12 subfolders in Google Drive with 3 to 15 documents each. That's potentially 80-100 source documents. This panel shows a flat list. Where's my folder structure? Where's the organizational hierarchy I spent weeks building in Drive?
+
+I'd see four documents in the panel and think, "Okay, where are the rest?" Then I'd hit "Add" and start browsing my Drive through DraftCrane's file picker. But once I add them, they all land in a flat list. My "Interviews" subfolder and my "Frameworks" subfolder and my "Case Studies" subfolder -- all merged into one alphabetical list. That undoes the organizational work I've already done.
+
+The search box mitigates this somewhat. If I can search by document name, I can find things fast. But browsing -- just looking at what I have, reminding myself of the landscape -- becomes harder, not easier.
+
+**2. "Can I figure out how to find something in my research materials without instructions?"**
+
+I'd use the search box. I'm comfortable with search. I'd type "coaching ROI" or "managers coaching stats" and expect results.
+
+If search works across document content (not just titles), I'd find it quickly. My documents have reasonably descriptive content even if the titles aren't always helpful. I'd tap the result, read the relevant section, and go back.
+
+If search is title-only, I'd mentally map the stat to the right subfolder in my head -- "that was from the Deloitte report, which is in my External Research folder" -- then scan the flat list for "Deloitte" something. I'd find it because I remember my own organizational system. But the flat list makes this slower than navigating my Drive folder structure directly.
+
+The real problem is when I'm not sure which document has the information. With 80+ sources in a flat list, I can't just scan. I need either good search or some organizational structure within DraftCrane.
+
+**3. "If I'm writing Chapter 4 and need to check a fact from an old workshop doc, what do I do?"**
+
+I look at the Sources panel. In landscape on my iPad Air, I can see it alongside the editor. Good. I tap the document I think has the stat. The detail view replaces the list. I scroll through it.
+
+This is... workable. Not great, but workable. The document is right there. I can read it. I can see my editor has been pushed to the left but is still partially visible (in landscape, at least). I find the stat, confirm it's 67%, go back to the list, and get back to writing.
+
+The friction is manageable for me because I'm organized. I usually know which document to look in. But I'd want a way to jump back to exactly where I was in the source viewer if I need to check a second fact from the same document. If tapping "Back" loses my scroll position and I have to re-find my place, that's irritating.
+
+**4. "Does this feel like one more thing to learn, or like it's helping me?"**
+
+It feels like a minor improvement. I currently use a system of subfolders and a master index Google Sheet to track which documents go with which chapters. This replaces the "open in another tab" part of my workflow, which saves time. But it doesn't replace my index sheet. It doesn't help me see the relationship between sources and chapters.
+
+The removal of chapter linking actually concerns me. I *want* to associate specific sources with specific chapters. That's how I organize my thinking. In the current design, the "link" feature was confusing (I'll grant that), but the underlying need -- "Chapter 4 draws from these 5 documents, Chapter 7 draws from these 3" -- is real. Flattening everything to one project-level list loses that structure.
+
+I'd use this, but I'd probably also keep my Google Sheet index alongside it. Which means DraftCrane isn't fully replacing my existing system -- it's just adding a slightly better file viewer.
+
+**5. "What would make me go back to copy-pasting between Google Docs and ChatGPT?"**
+
+If I can't organize my sources at all -- no folders, no tags, no chapter associations -- I'll revert to my Drive folder system within a month. The flat list doesn't scale for my project. I have 12 chapters planned and 100+ documents. I need to be able to filter, group, or at minimum tag my sources.
+
+The other deal-breaker: if adding sources from Drive is a pain. I have deep folder structures. If the inline Drive browser requires 8 taps to reach a document in my "Interviews / Executive Coaching / 2024" subfolder, and I have to do that 50 times to populate my source library, I'll give up after the third document and just keep using Drive directly.
+
+---
+
+## Option B: "Research Companion"
+
+### Diane Mercer's Reactions
+
+**1. "If I opened DraftCrane and saw this, what would I think it does?"**
+
+Three columns again, but the right panel says "Research" at the top with three tabs: Sources, Ask, Clips. Let me look at each.
+
+"Sources" -- okay, same as before, that's my documents. "Ask" -- wait. Ask? Like... I can ask it questions? I'd tap on that tab out of curiosity. I see a text field that says "Ask about your sources..." Oh. *Oh.* Like ChatGPT, but it already knows my stuff? I wouldn't have to paste anything in?
+
+That's the moment. That single text field would make me understand what this tool is for. It's not just a file organizer. It's a research assistant that can actually *look through* my documents and find things. I'd immediately type something: "What did I write about psychological safety?" And if it came back with an answer citing my workshop notes -- with the actual document name and a quote -- I would feel something I don't often feel with new software: genuine excitement.
+
+"Clips" -- I'm not sure what that means at first. Clips of what? Video clips? I'd tap on it and see it's empty. "0 clips saved." Okay, I don't know what this is yet but I'll come back to it.
+
+Two out of three tabs make immediate sense. That's a strong start.
+
+**2. "Can I figure out how to find something in my research materials without instructions?"**
+
+I'd go straight to the "Ask" tab. "Find the stat about managers who receive coaching." If the AI finds it and tells me "In your document 'Workshop Notes March 2024,' page 3: '67% of managers who receive structured coaching show measurable improvement in team outcomes within 6 months'" -- I would actually tear up a little. I've been looking for that number for three weeks across 30 documents.
+
+The Sources tab also has search, so if I wanted to browse manually, I could. But why would I? The Ask tab is faster and smarter. It searches *inside* all my documents at once. That's the thing I couldn't do before.
+
+Where I might get stuck: if the AI gives me a wrong answer or can't find it. "I couldn't find information about that in your sources." Then I'd have to fall back to the Sources tab and manually browse. But at least I have the fallback. I'm not worse off than Option A -- I just have an extra tool that might save me time.
+
+**3. "If I'm writing Chapter 4 and need to check a fact from an old workshop doc, what do I do?"**
+
+I tap the "Ask" tab (if I'm not already there) and type: "What's the stat about psychological safety and team performance?" The AI responds with the quote, the document name, and where in the document it found it.
+
+I verify the number. I go back to my chapter and keep writing. Total interruption: maybe 20 seconds. My flow barely breaks.
+
+And then -- *and then* -- I see the "Save to Clips" button on the AI's response. I tap it because why not. Now that quote is saved somewhere. Later, when I'm writing Chapter 7 and need the same stat, I go to the Clips tab and it's right there. I don't have to re-ask. I don't have to remember which chapter I was in when I found it.
+
+That's when the "Clips" tab makes sense to me. It's my collection of useful quotes. Like sticky notes in a real book. I finally understand the three tabs: Sources is my bookshelf. Ask is my research assistant. Clips is my sticky notes. That metaphor clicks.
+
+**4. "Does this feel like one more thing to learn, or like it's helping me?"**
+
+This feels like it's helping me. Genuinely. The Ask tab alone is worth switching from my current Google Docs + ChatGPT setup. Right now, I open ChatGPT, paste in 2,000 words from one document, ask a question, get an answer, then realize the stat I need is in a *different* document, paste that one in, ask again... it's exhausting. This does all of that automatically because it already has my documents.
+
+The three tabs are more to learn than Option A's single panel. But the tabs are labeled with normal words and each does one clear thing. I don't feel overwhelmed. I feel like I have tools I'll actually use. The Sources tab is there if I want to browse, but honestly, I think I'd live in the Ask tab.
+
+The Clips tab is the one that might not stick immediately. Saving clips is an extra step in my workflow that I don't currently do. Right now I just copy-paste. But if the "Insert" button on a clip puts the quote into my chapter *and* adds a footnote automatically? That's worth the extra step. I hate doing footnotes manually.
+
+**5. "What would make me go back to copy-pasting between Google Docs and ChatGPT?"**
+
+If the AI gives bad answers. Full stop. If I ask "Find the coaching stat" and it says "I found a reference to coaching in your document" but gives me the wrong number, or cites the wrong document, or just makes something up -- I will never trust it again. And I'll go right back to ChatGPT, where at least I can paste in the exact document and know it's reading the right thing.
+
+The second risk: if it's slow. ChatGPT responds in a few seconds. If the Ask tab takes 10 seconds to search my sources, I'll feel like I'm waiting instead of working. The whole point is that this is faster than my current method.
+
+The third, smaller risk: if adding my documents to DraftCrane is complicated. If I have to connect my Google account, navigate through folders, select files one by one, wait for each to process... I'll do it for the first 5 documents and then decide the rest aren't worth the effort. Then the AI can only search 5 of my 30 documents, which makes it unreliable. Initial setup friction could undermine the whole thing.
+
+---
+
+### Marcus Chen's Reactions
+
+**1. "If I opened DraftCrane and saw this, what would I think it does?"**
+
+Research panel with three tabs. I see Sources, Ask, Clips. The Sources tab looks like a cleaned-up version of a file manager. The Ask tab is a chat interface for querying my documents. Clips is a snippet collection.
+
+I immediately understand the architecture here: this is a unified research workspace. Sources are the raw materials. Ask is the query interface. Clips are the curated outputs. That's a pipeline: raw material goes in, useful excerpts come out. I like pipelines. This makes structural sense to me.
+
+My first question is about the Ask tab's capabilities. Can I ask it to compare information across documents? "What do Document A and Document B say differently about leadership resilience?" If it can do that, this solves my core problem -- I have too many documents saying overlapping things, and I need to consolidate.
+
+My second question: can I see which sources the AI is drawing from? In ChatGPT Projects, I sometimes get answers where I can't tell if the AI is using my documents or making things up. If the Ask tab shows me "Based on Interview-Smith.doc (p.3) and Q4-Report.doc (p.12)," with clickable links to those passages, that's significantly better than ChatGPT.
+
+**2. "Can I figure out how to find something in my research materials without instructions?"**
+
+Two paths available to me, and I'd use both depending on context.
+
+If I know *which* document has the information -- say, I know the coaching stat is in my Deloitte report -- I'd go to the Sources tab, search for "Deloitte," open it, and find the stat manually. This is the direct path.
+
+If I don't know which document has it, or if it might be in several documents, I'd go to the Ask tab. "Which of my documents discusses coaching ROI statistics?" The AI could tell me it's mentioned in three documents and give me the relevant passages from each. That's something I literally cannot do today without opening each document individually.
+
+Where I'd want more: after the AI shows me the results, I'd want to tap on a citation and go directly to that spot in the source document. If "Interview-Smith.doc, p.3" is a link that opens the source viewer scrolled to page 3, that's seamless. If it's just text and I have to manually open the document and scroll, that breaks the efficiency gain.
+
+**3. "If I'm writing Chapter 4 and need to check a fact from an old workshop doc, what do I do?"**
+
+I'd use the Ask tab. "What's the psychological safety stat from the team effectiveness research?" The AI returns the answer with citations. I verify the number, see it matches my recollection, and keep writing.
+
+But here's what I'd really want to do next: save that clip *tagged to Chapter 4*. When I'm later reviewing Chapter 4, I want to see all the clips I collected for it. The flat Clips tab is fine for now, but as my book grows and I have 50+ clips across 15 chapters, I'll need to filter by chapter.
+
+The workflow for me would be: Ask a question, get a result, save it to Clips, tag it "Chapter 4," and then later when I'm editing Chapter 4, pull up all the Chapter 4 clips to make sure I've incorporated all my research. That's the organizational structure I need. The current Clips design doesn't show this level of organization, but the infrastructure seems like it could support it in a future iteration.
+
+**4. "Does this feel like one more thing to learn, or like it's helping me?"**
+
+This feels like it's solving the right problem. My problem isn't finding my files -- I know where they are. My problem is that I have *too many* files and I need help synthesizing across them. The Ask tab directly addresses that. "What have I collected about leadership resilience across all my documents?" -- that question currently takes me 90 minutes to answer by opening documents one at a time. If the AI can answer it in 10 seconds, this tool pays for itself in the first session.
+
+The three-tab structure adds a small learning curve, but each tab maps to a distinct workflow I actually have: browse files (Sources), ask questions (Ask), collect useful bits (Clips). These aren't abstract concepts -- they're things I already do, just scattered across Google Drive, ChatGPT, and Apple Notes. Having them in one panel next to my editor is a real consolidation.
+
+The only cognitive overhead I see is managing the Clips. When do I save a clip versus just remembering the information? How many clips is too many? Should I organize them? This is the kind of organizational anxiety that slows me down with any system. But at least the clips are optional -- I can use the Ask tab without ever saving anything.
+
+**5. "What would make me go back to copy-pasting between Google Docs and ChatGPT?"**
+
+If the AI can't handle the scale of my research. I have 100+ documents. If the Ask tab works great with 10 documents but gives vague, unreliable answers when I've loaded all 100, that's a fundamental failure. The whole point is that it handles scale I can't handle manually.
+
+Second: if there's no way to organize clips by chapter as the collection grows. With 15 chapters and potentially 100+ clips, a flat list becomes as unusable as a flat source list. I need at least basic filtering.
+
+Third: if the citation links are decorative rather than functional. If the AI says "according to Interview-Smith.doc" but I can't tap that to verify, I'll never fully trust the answers. And if I can't trust the answers, I'll go back to verifying manually -- which means I'm back to opening individual documents, which means DraftCrane is just a worse version of Google Drive.
+
+---
+
+## Option C: "Integrated Research Assistant"
+
+### Diane Mercer's Reactions
+
+**1. "If I opened DraftCrane and saw this, what would I think it does?"**
+
+Okay, this is different. I see my chapters on the left, a big open editor in the middle, and... that's it. There's a "Research" button at the bottom right corner of the editor, but nothing else. The right side of the screen is just more editor space.
+
+My first thought: "Wait, where are my documents? Where's my research?" I'd stare at this for a few seconds feeling like something is missing. In Options A and B, I could see my source files right away. Here, I see a blank writing space and one button.
+
+I'd tap "Research." A panel slides in. And instead of showing me a list of files, it shows me... a text field. "Ask about your sources..." There's a small gear icon in the top right and a "Clips: 0" badge. That's it.
+
+This is either brilliant or terrifying, and I'm not sure which. On one hand, it's radically simple. There's nothing to figure out -- just type a question. On the other hand, I feel disoriented. Where are my files? Did they get imported? Are they connected? The panel doesn't tell me. I have to trust that somewhere behind this text field, my documents are there and the AI knows about them.
+
+I think I'd tap the gear icon out of anxiety. I'd see my connected sources listed there -- six documents. Okay, they're there. I can breathe. But I shouldn't *have* to check. The main interface should give me some confidence that my stuff is connected without making me look for it.
+
+**2. "Can I figure out how to find something in my research materials without instructions?"**
+
+The interface basically forces me to use the AI. There's no browse-first option visible. So I'd type: "Find the stat about managers who receive coaching."
+
+If the AI nails it -- gives me the exact quote with the document name -- this is the fastest, most intuitive experience of all three options. I didn't have to browse. I didn't have to remember which file it was in. I just asked, like I would ask a research assistant.
+
+But if the AI fumbles -- gives me a vague answer, cites the wrong document, or says "I couldn't find that" when I *know* it's in my notes -- I'm stuck. How do I search manually? I'd have to tap the gear icon, find the right document, tap "View," and then scroll through it. That's 3 taps just to get to the same starting point that Option A gives me for free.
+
+There's a psychological issue here too. In Options A and B, I can *see* my documents. I feel in control. Here, I'm delegating control to the AI. That's fine when the AI is right. When it's wrong, I feel helpless. I'm the kind of person who wants to verify things myself. If the AI says "the stat is 67%," I want to open the document and see it with my own eyes. Option C makes that verification harder than it needs to be.
+
+**3. "If I'm writing Chapter 4 and need to check a fact from an old workshop doc, what do I do?"**
+
+I tap "Research" to open the panel (if it's not already open). I type my question. The AI responds. I verify the answer and keep writing.
+
+In the happy path, this is the most seamless experience. Open panel, ask, get answer, close panel, keep writing. Three taps and a few seconds. My flow barely pauses.
+
+But the unhappy path is worse than the other options. If the AI misunderstands my question, or gives me a result from the wrong document, I have to either rephrase and ask again (adding time and frustration), or bail out to the source settings to browse manually (which is buried behind the gear icon, behind a "View" button, and requires me to know which document to look in). The backup path has more friction than Option A's *primary* path.
+
+And there's another scenario: what if I'm not looking for a specific fact? What if I want to re-read an entire section of my workshop notes to refresh my memory? "I want to read the part about team dynamics from my March notes." The AI would give me a summary or an excerpt. But I don't want a summary -- I want to read my own words. Getting to the full document view requires navigating through settings, which feels wrong. Reading my own source documents shouldn't feel like going into the settings menu.
+
+**4. "Does this feel like one more thing to learn, or like it's helping me?"**
+
+When it works, it feels like magic. It feels like having a human research assistant who's read all my notes. I ask, they answer, I write. That's the dream.
+
+When it doesn't work -- when the AI is slow, or wrong, or I need to do something the AI can't do (like browse my documents) -- it feels like I'm fighting the tool. The AI is standing between me and my own files. I have to go through it to get to my stuff.
+
+This is the most opinionated of the three designs. It has a strong opinion about how I should work: "Don't browse, ask." For someone like me, who's used to having my documents visible and accessible, that opinion might be wrong. I'm not an "ask questions" person yet -- I'm a "look through my stuff" person. Option C is trying to change my workflow, not accommodate it.
+
+I could see myself growing into this over time. If the AI is consistently good, I'd eventually stop wanting to browse and start asking for everything. But there's a trust-building period, and during that period, I'd want the browsing to be easier than 2 taps into a settings submenu.
+
+**5. "What would make me go back to copy-pasting between Google Docs and ChatGPT?"**
+
+One bad AI answer. Honestly, one is probably enough in the first week. If I'm relying entirely on the AI to find things in my documents and it gets something wrong -- wrong stat, wrong document attribution, a hallucinated quote that sounds real but isn't in any of my docs -- I will immediately lose trust in the entire system.
+
+With Options A and B, a bad AI answer isn't catastrophic because I have manual browsing as a primary feature. I can verify. I can look things up myself. With Option C, the AI *is* the product. If the AI fails, the product fails.
+
+The second trigger: if initial setup is confusing. Option C buries source management in settings. If I connect my Google Drive and add some documents but can't see them prominently -- just a "6 sources connected" note at the bottom of the Research panel -- I won't feel confident that my sources are properly ingested. Did it actually read them? Does it understand them? I need some kind of confirmation that's more reassuring than a number at the bottom of a panel.
+
+---
+
+### Marcus Chen's Reactions
+
+**1. "If I opened DraftCrane and saw this, what would I think it does?"**
+
+Clean writing space. Chapters on the left, big editor in the middle. A "Research" button tucked in the corner. This is a writing-first design. The statement it makes is: "Your primary activity here is writing. Research is available when you need it."
+
+I appreciate the philosophy but I'm suspicious of it. I *want* to see my research landscape. I want to know which sources are connected, how many there are, whether they've been updated since I last looked. Option C hides all of that behind a gear icon inside a panel I have to actively open. That's three levels deep from my default view.
+
+When I open the Research panel, I see the conversational interface. No tabs. Just a text field and some response history. This is clearly modeled after ChatGPT, and I get it -- type a question, get an answer from my documents. But my relationship with my research isn't primarily conversational. I don't always have a question. Sometimes I want to survey the territory. "Let me look at my Chapter 5 sources and see what I have to work with." Option C doesn't support that workflow naturally.
+
+The Clips badge and the gear icon are the secondary features. I understand what they do -- saved snippets and source management. But they feel like afterthoughts in this design, tucked into small UI elements. Clips especially feel like they deserve more prominence if they're supposed to be the bridge between research and writing.
+
+**2. "Can I figure out how to find something in my research materials without instructions?"**
+
+I'd type in the Ask field: "Which documents mention coaching ROI?" The AI would (hopefully) list the relevant documents with excerpts.
+
+This actually works well for my use case -- I have too many documents to browse manually, so having AI search across all 100+ of them is genuinely useful. The conversational interface is the right tool for the "needle in a haystack" problem.
+
+But I'd run into an issue with precision. I might ask "What data do I have on executive coaching effectiveness?" and get results that blend my interview notes with published research with my own draft content. I'd want to be able to say "Only search in documents from my External Research folder" or "Exclude my draft chapters." Without scoping controls, the AI is searching everything, and for someone with 100+ documents including drafts, notes, research, and outlines, "everything" is too broad.
+
+The manual fallback (gear icon, source list, view) is fine but slow. For my "I know exactly which document I want" use case, it's 3 taps to start reading versus 1 tap in Option B. That matters when I'm in flow.
+
+**3. "If I'm writing Chapter 4 and need to check a fact from an old workshop doc, what do I do?"**
+
+I open the Research panel and ask. The AI gives me an answer with a citation. I check the citation, verify it, and keep writing.
+
+For fact-checking, this is the optimal flow. I'm not the person who needs to see the full source document to verify a number -- I trust the citation if it shows me the exact passage and tells me where it came from. So for quick fact-checks, Option C is the fastest of the three.
+
+But there's a different scenario that concerns me more: "I'm writing Chapter 4 and I want to review the source material I haven't used yet, to see if there's anything I'm missing." This is a browsing task, not a question-answering task. I don't have a specific query -- I want to survey. Option C makes surveying my unused sources difficult. I'd have to go to settings, scan the source list, open documents one by one, and manually track what I've used versus what I haven't. None of that is supported by the AI-first paradigm.
+
+**4. "Does this feel like one more thing to learn, or like it's helping me?"**
+
+For the question-answering workflow, this is the most helpful option. No question. The AI searching across 100+ documents and giving me cited answers is the capability I need most. If I could only choose one feature, it would be this.
+
+But the rest of my workflow -- organizing, surveying, planning which sources go with which chapters, tracking what I've used -- gets worse. Option C took the thing I'm good at (organizing) and said "you don't need to do that anymore." But I do. Organization isn't overhead for me; it's how I think. Removing my ability to browse, sort, and associate sources by chapter doesn't free me -- it constrains me.
+
+The trade-off is clear: Option C is the best tool for "finding" and the worst tool for "organizing." Since I need both, this design serves only half my workflow.
+
+**5. "What would make me go back to copy-pasting between Google Docs and ChatGPT?"**
+
+If I can't browse and organize my sources effectively. The gear icon is not an organizational interface -- it's a flat list with "View" and "Remove" buttons. No folders, no tags, no chapter associations, no metadata about when I last accessed a source or whether its content has been used in a chapter. For someone managing a 15-chapter book with 100+ source documents, this is like managing a library with a single shelf and no catalog.
+
+Also: if the AI responses are too slow for the conversational back-and-forth that Option C depends on. In ChatGPT, I've internalized a 3-5 second response time. If DraftCrane's AI takes 10+ seconds because it's searching across many documents on Cloudflare Workers, the conversational flow breaks and I'm just staring at a loading spinner. At that point, I'd rather have a source list I can browse immediately.
+
+The biggest strategic risk for me: Option C is an all-or-nothing bet on AI. If the AI is excellent, it's the best option. If the AI is mediocre -- and realistically, AI searching across 100+ heterogeneous Google Docs of varying formats, lengths, and topics will have quality issues -- then I've given up manual tools (demoted to settings) in exchange for an unreliable AI, and I've lost both ways.
+
+---
+
+## Verdicts
+
+### Diane's Pick
+
+Option B. Here's why.
+
+I came into this expecting to love Option C -- the "just ask" model sounded like exactly what I need. And it is, in the happy path. But I know myself. I'm the person who will not trust the AI fully on day one. I need to be able to check its work. I need to see my documents with my own eyes sometimes. Option C makes that hard. It's like hiring a research assistant but then locking the filing cabinet.
+
+Option B gives me the AI I want (the Ask tab) *and* the filing cabinet I need (the Sources tab). When the AI gives me an answer, I can tap through to the source document and verify it myself. When I don't have a specific question, I can browse my files. When I find something useful, I can save it to Clips and insert it later with a proper footnote.
+
+Option A is fine but boring. It's a file browser. I already have a file browser. I didn't switch to DraftCrane for a slightly better file browser.
+
+Option B respects that I'm still learning to trust AI with my own material. It gives me the power tools without taking away the hand tools. That's what I need right now.
+
+### Marcus's Pick
+
+Option B, but with a strong asterisk.
+
+Option B is the right architecture. Three tabs: browse, ask, collect. That maps to my actual workflow: survey my research, query across documents, gather what I need. The Sources tab gives me direct access. The Ask tab gives me AI search across 100+ documents. The Clips tab gives me a staging area between research and manuscript.
+
+My asterisk: the flat source list and the flat clips list won't scale for my project. I need at least basic filtering -- by chapter tag, by document type, by "used/unused" status. Option B as designed is a strong start, but without organizational features in the Sources and Clips tabs, I'll outgrow it by Chapter 6.
+
+I rejected Option A because it doesn't include AI search, and AI search is the feature that solves my core problem of having too many documents to manage manually. I rejected Option C because it demotes source browsing to a settings submenu, and I need browsing to be a first-class activity. I'm an organizer. Taking away my ability to see, sort, and structure my sources is taking away how I think.
+
+Option B is the one that respects both my need for AI power *and* my need for structural organization. It treats sources, querying, and collection as equally important activities. That's correct.
+
+### Consensus and Conflicts
+
+**Where the personas agree:**
+
+1. Both choose Option B. The three-tab model (Sources, Ask, Clips) maps to a workflow both personas actually have, even though they arrive at it differently -- Diane through frustration with finding things, Marcus through frustration with organizing things.
+
+2. Both value the AI query feature (Ask tab) as the primary differentiator from their current workflow. Neither persona is excited about a better file browser alone (Option A). Both see "ask a question about my documents" as the breakthrough capability.
+
+3. Both are suspicious of Option C's all-in bet on AI. Neither persona fully trusts AI with their own material yet. Both want the ability to manually browse and verify. Option C's demotion of source browsing to a settings submenu makes both personas uncomfortable, though for different reasons (Diane fears loss of control; Marcus fears loss of organizational visibility).
+
+4. Both identify the same failure mode: bad AI answers are the death of the product. If the AI misattributes, hallucinates, or fails to find information that clearly exists in the sources, both personas will abandon DraftCrane and return to their current (painful but familiar) workflows.
+
+**Where the personas conflict:**
+
+1. **Source organization.** Diane doesn't care about organizing sources -- she just wants to find things. Marcus needs folders, tags, or chapter associations to manage 100+ documents. Option B as designed serves Diane well (flat list + search + AI is enough for 30 documents) but will frustrate Marcus as his library grows. The design must plan for organizational features (even if they ship later) without cluttering Diane's simpler experience.
+
+2. **Browsing vs. asking.** Diane would live primarily in the Ask tab and rarely browse Sources manually. Marcus would split his time roughly evenly between Sources and Ask, using browsing for survey and planning, and asking for needle-in-haystack queries. Option B's equal treatment of all three tabs accommodates both, but the default tab may need to be personalized (Diane defaults to Ask, Marcus defaults to Sources) or the design needs to be neutral enough that both feel at home.
+
+3. **Clips complexity tolerance.** Diane wants Clips to be dead simple: save a quote, insert it later, done. Marcus wants Clips to be organizable: tag by chapter, filter, sort, track which clips have been inserted. These are fundamentally different views of the same feature. The design must start simple (Diane's version) with organizational features available but not required (Marcus's version).
+
+**What this tells us about the design:**
+
+The strongest signal from both personas is that Option B's architecture is right, but the execution must thread a needle between Diane's simplicity needs and Marcus's organizational needs. The three-tab model is the correct skeleton. The work ahead is:
+
+- Making the Sources tab scale from 10 documents (Diane) to 100+ documents (Marcus) without becoming overwhelming at either end.
+- Ensuring the Ask tab's AI quality is high enough to justify the product's existence. Both personas identified AI quality as the single biggest risk.
+- Building Clips as a simple save-and-insert feature first (for Diane), with chapter tagging and filtering as a fast follow (for Marcus).
+- Making the initial source-adding experience frictionless enough that both personas will add their complete document libraries, not just the first 5 files.
+
+Option B also carries a strategic advantage: it can be shipped incrementally. The Sources tab can ship first (essentially Option A within the new panel structure), then the Ask tab adds AI capability, then the Clips tab completes the pipeline. Each increment delivers standalone value. Option C cannot be shipped incrementally -- without AI, it's an empty panel. This phasing aligns with both personas' need to build trust over time rather than placing a single large bet on AI quality at launch.

--- a/docs/design/source-review/03a-detailed-design.md
+++ b/docs/design/source-review/03a-detailed-design.md
@@ -1,0 +1,2094 @@
+# Phase 3a: Detailed Interaction Design
+
+> DraftCrane Source/Research UX Redesign
+> Option B: "Research Companion" (with modifications from user feedback)
+> Date: 2026-02-19
+
+---
+
+## Table of Contents
+
+1. [Information Architecture](#1-information-architecture)
+2. [Interaction Flows](#2-interaction-flows)
+3. [Panel Layout Specifications](#3-panel-layout-specifications)
+4. [Component Inventory](#4-component-inventory)
+5. [State Model Changes](#5-state-model-changes)
+6. [API Changes](#6-api-changes)
+7. [Data Model Changes](#7-data-model-changes)
+8. [Backlog Issue Mapping](#8-backlog-issue-mapping)
+9. [Implementation Phases](#9-implementation-phases)
+
+---
+
+## 1. Information Architecture
+
+### Panel/Screen Inventory
+
+The redesigned system has three primary surfaces and two secondary surfaces.
+
+**Primary surfaces (always available):**
+
+| Surface | Type | Purpose |
+|---------|------|---------|
+| **Chapter Sidebar** | Persistent left panel | Chapter navigation, word counts (unchanged) |
+| **Editor** | Central content area | Tiptap rich text editor (unchanged) |
+| **Research Panel** | Toggleable right panel | Three-tab container for Sources, Ask, and Clips |
+
+**Secondary surfaces (within the Research Panel):**
+
+| Surface | Type | Purpose |
+|---------|------|---------|
+| **Source Detail View** | Inline replacement within Sources tab | Full source content viewer |
+| **Source Add Flow** | Inline replacement within Sources tab | Drive browser + local upload |
+
+**Confirmation dialogs (modal):**
+
+| Surface | Type | Purpose |
+|---------|------|---------|
+| **Remove Source Confirmation** | Center dialog | Confirm destructive source removal |
+
+### Navigation Model
+
+The Research Panel uses a **flat tab + inline drill-down** navigation model. There are exactly two levels of depth:
+
+```
+Level 0: Research Panel closed (editor takes full width)
+Level 1: Research Panel open with active tab
+          - Sources tab (source list with search/filter)
+          - Ask tab (AI query interface)
+          - Clips tab (saved snippet board)
+Level 2: Sources tab only -- drill-down views
+          - Source Detail View (replaces source list inline)
+          - Source Add Flow (replaces source list inline)
+```
+
+Moving between Level 1 tabs is a single tap. Moving from Level 2 back to Level 1 is a single tap on the back button. No surface ever stacks on top of another. The maximum depth from the user's perspective is always 2 (panel open, then detail or add view).
+
+```
+                                          +------------------+
+                                          |  Research Panel   |
+                 +--- Sources tab ------> |  [Source List]    |
+                 |     |                  |                   |
+Toolbar -------->+     +-- Detail view -> |  [Source Content] |
+[Research btn]   |     |                  |                   |
+                 |     +-- Add flow ----> |  [Drive Browser]  |
+                 |                        |                   |
+                 +--- Ask tab ----------> |  [Query + Results]|
+                 |                        |                   |
+                 +--- Clips tab --------> |  [Saved Snippets] |
+                                          +------------------+
+```
+
+### What Gets Removed
+
+**Components eliminated:**
+
+| Component | File | Reason |
+|-----------|------|--------|
+| `SourcesPanel` | `web/src/components/drive/sources-panel.tsx` | Replaced by `ResearchPanel` > `SourcesTab` |
+| `AddSourceSheet` | `web/src/components/drive/add-source-sheet.tsx` | Merged into `SourceAddFlow` within Sources tab |
+| `DriveBrowserSheet` | `web/src/components/drive/drive-browser-sheet.tsx` | Merged into `SourceAddFlow` within Sources tab |
+| `SourceViewerSheet` | `web/src/components/drive/source-viewer-sheet.tsx` | Replaced by `SourceDetailView` within Sources tab |
+
+**Concepts eliminated:**
+
+| Concept | Reason |
+|---------|--------|
+| Chapter-source linking | Both personas found it confusing. Sources are project-level. Implicit references tracked when snippets are inserted into chapters. |
+| Link/Unlink buttons | Eliminated with chapter-source linking. |
+| Source viewer tab bar (chapter-scoped) | Eliminated. Navigation between sources is via the Sources tab list, not chapter-specific tabs. |
+| Sheet stacking (z-50/z-60 layering) | Eliminated. All source interactions occur within the Research Panel's single surface area. |
+| `chapter_sources` junction table (as active feature) | Table deprecated; no new writes. Data preserved for potential rollback. |
+| "Sources" as standalone toolbar action | Replaced by "Research" panel toggle that contains Sources as a tab. |
+
+**Props eliminated from EditorDialogs (~50 source-related props):**
+
+All source-specific props are removed from `EditorDialogsProps`. The Research Panel is a self-contained component that manages its own state via a context provider. EditorDialogs receives at most 3 props related to research: `isResearchPanelOpen`, `onCloseResearchPanel`, and `projectId`.
+
+### What Gets Added
+
+**Components added:**
+
+| Component | Type | Purpose |
+|-----------|------|---------|
+| `ResearchPanel` | Container | Tab navigation shell (Sources, Ask, Clips) with panel open/close |
+| `SourcesTab` | Tab content | Source list with search, filter, and inline add/detail |
+| `AskTab` | Tab content | AI natural-language query interface |
+| `ClipsTab` | Tab content | Saved snippet board with insert actions |
+| `SourceCard` | List item | Individual source row in the source list |
+| `SourceAddFlow` | Inline view | Drive browser + local upload, replacing source list inline |
+| `SourceDetailView` | Inline view | Full source content viewer, replacing source list inline |
+| `QueryInput` | Input | Search/ask text field with submit and loading states |
+| `ResultCard` | List item | AI search result with source citation, save, and insert actions |
+| `ClipCard` | List item | Saved snippet with insert and delete actions |
+| `SnippetInsertButton` | Action button | Insert clip text + auto-footnote into editor at cursor |
+| `ResearchPanelProvider` | Context provider | Encapsulates all research panel state, eliminating prop threading |
+
+**Concepts added:**
+
+| Concept | Description |
+|---------|-------------|
+| Research Panel | A unified right-hand panel containing all research functionality across three tabs |
+| Clips | Saved text snippets with source attribution, collected from AI results or manual selection |
+| AI query against sources | Natural-language search across all project sources with cited results |
+| Auto-footnote insertion | Inserting a clip creates a footnote referencing the source document |
+| Source text search | Full-text search within the Sources tab (searches source titles and cached content) |
+| Remove confirmation dialog | Destructive source removal now requires explicit confirmation |
+
+---
+
+## 2. Interaction Flows
+
+### Flow 1: Add Source from Google Drive
+
+**Precondition:** User has at least one Google account connected. Research Panel is open with Sources tab active.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap [+ Add] button in Sources tab header | Sources tab | 1 |
+| 2 | Source Add Flow replaces the source list inline. Shows connected accounts with "Browse Drive" and "Upload from device" options. | Source Add Flow | 0 (transition) |
+| 3 | Tap a connected Google account row | Source Add Flow (account list) | 1 |
+| 4 | Inline Drive browser appears (replaces account list within same view). Shows root of user's Drive. | Source Add Flow (Drive browser) | 0 (transition) |
+| 5 | Navigate into target folder | Source Add Flow (Drive browser) | 1-3 per folder level |
+| 6 | Tap checkbox on each Google Doc to select | Source Add Flow (Drive browser) | 1 per file |
+| 7 | Tap "Add Selected" footer button | Source Add Flow (Drive browser) | 1 |
+| 8 | Sources are added. View transitions back to source list showing new sources with "Processing..." status. | Sources tab | 0 (transition) |
+
+**Total: 4-8 taps across a single surface (Sources tab with inline flow).**
+
+**Key moments:**
+
+```
+STEP 1: Sources tab with [+ Add] button
++-----------------------------------+
+|  RESEARCH                         |
+|  [Sources]  Ask  Clips     [x]   |
+|  ================================ |
+|  [Search sources...]   [+ Add]   |
+|  -------------------------------- |
+|  Interview-Smith.doc              |
+|    1,240 words  |  Cached 2h ago |
+|  Q4-Report.doc                    |
+|    3,800 words  |  Cached 1d ago |
+|                                   |
+|  2 sources                        |
++-----------------------------------+
+
+STEP 2-3: Source Add Flow (account selection)
++-----------------------------------+
+|  RESEARCH                         |
+|  [< Sources]  Add Source          |
+|  ================================ |
+|                                   |
+|  FROM GOOGLE DRIVE                |
+|  +-------------------------------+|
+|  | scott@email.com               ||
+|  | Browse Google Drive       [>] ||
+|  +-------------------------------+|
+|  +-------------------------------+|
+|  | work@company.com              ||
+|  | Browse Google Drive       [>] ||
+|  +-------------------------------+|
+|                                   |
+|  FROM DEVICE                      |
+|  +-------------------------------+|
+|  | Upload file (.txt .md .docx   ||
+|  |   .pdf)                   [>] ||
+|  +-------------------------------+|
+|                                   |
+|  Connect another Google account   |
++-----------------------------------+
+
+STEP 4-7: Drive browser (inline)
++-----------------------------------+
+|  RESEARCH                         |
+|  [< Back]  scott@email.com       |
+|  ================================ |
+|  [Search files...]               |
+|  -------------------------------- |
+|  [folder] Research/               |
+|  [folder] Interviews/             |
+|  [folder] External Data/          |
+|  -------------------------------- |
+|  [ ] Workshop Notes March 2024    |
+|  [x] Interview-Smith.doc          |
+|  [x] Client-Notes.doc             |
+|  [ ] Draft-Chapter3-v2.doc        |
+|                                   |
+|  [  Add 2 Selected  ]            |
++-----------------------------------+
+```
+
+**Error states:**
+- **No Google accounts connected:** Source Add Flow shows only "Upload from device" and a prominent "Connect Google Account" button. Tapping it initiates the OAuth flow.
+- **Drive API error:** An inline error banner appears within the Drive browser: "Could not access Google Drive. Please try again." with a "Retry" button. The user can tap [< Back] to return to account selection.
+- **File already added:** The Drive browser shows files already in the project with a checkmark badge and disables their checkbox. Tooltip: "Already in your sources."
+- **Network failure during add:** The source list shows the new sources with status "Error -- could not process." The user can tap "Retry" on the source card or "Remove" to discard.
+
+**iPad-specific considerations:**
+- All touch targets in the Drive browser are minimum 44pt height.
+- Checkboxes use a 44x44pt tap area (visually 24x24px icon centered in the tap area).
+- Folder rows are full-width tap targets (entire row navigates).
+- The [< Back] button uses a 44x44pt tap area.
+- The "Add Selected" footer button is 48pt height, full width, sticky at bottom.
+- In portrait mode, the Research Panel is an overlay (see Section 3), so the Drive browser fills the overlay width.
+
+---
+
+### Flow 2: Add Source from Local Device
+
+**Precondition:** Research Panel is open with Sources tab active.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap [+ Add] button in Sources tab header | Sources tab | 1 |
+| 2 | Source Add Flow appears. | Source Add Flow | 0 |
+| 3 | Tap "Upload file" row | Source Add Flow | 1 |
+| 4 | iOS/iPadOS file picker opens (system UI) | System file picker | 0 |
+| 5 | Navigate to and select file(s) | System file picker | 2-4 |
+| 6 | File picker closes. Upload begins. Source Add Flow transitions back to Sources tab showing new source with "Processing..." spinner. | Sources tab | 0 |
+
+**Total: 4-7 taps across 2 surfaces (Sources tab + system file picker).**
+
+**Key moment:**
+
+```
+STEP 3: Upload option
++-----------------------------------+
+|  RESEARCH                         |
+|  [< Sources]  Add Source          |
+|  ================================ |
+|                                   |
+|  FROM DEVICE                      |
+|  +-------------------------------+|
+|  | Upload file                   ||
+|  | .txt  .md  .docx  .pdf   [>] ||
+|  +-------------------------------+|
+|                                   |
+|  FROM GOOGLE DRIVE                |
+|  +-------------------------------+|
+|  | scott@email.com           [>] ||
+|  +-------------------------------+|
+|                                   |
++-----------------------------------+
+
+STEP 6: Processing state
++-----------------------------------+
+|  RESEARCH                         |
+|  [Sources]  Ask  Clips     [x]   |
+|  ================================ |
+|  [Search sources...]   [+ Add]   |
+|  -------------------------------- |
+|  Workshop-Transcript.pdf          |
+|    [spinner] Processing...        |
+|  Interview-Smith.doc              |
+|    1,240 words  |  Cached 2h ago |
+|  Q4-Report.doc                    |
+|    3,800 words  |  Cached 1d ago |
+|                                   |
+|  3 sources                        |
++-----------------------------------+
+```
+
+**Error states:**
+- **Unsupported file type:** The system file picker is configured to accept only `.txt`, `.md`, `.docx`, and `.pdf`. If the user somehow selects an unsupported file, the API returns an error and the source card shows "Unsupported file format" with a "Remove" action.
+- **File too large:** API returns 413. Source card shows "File too large (max 5MB)" with "Remove" action.
+- **Upload fails (network):** Source card shows "Upload failed" with "Retry" and "Remove" actions.
+- **Text extraction fails:** Source card shows "Could not extract text" with status "error." User can remove and re-upload.
+
+**iPad-specific considerations:**
+- The system file picker is a native iPadOS component. It handles its own touch targets and accessibility.
+- The "Upload file" row is 56pt minimum height with full-width tap target.
+- Accepted file types are passed to the `accept` attribute of the hidden file input: `.txt,.md,.docx,.pdf,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document`.
+
+---
+
+### Flow 3: View a Source While Writing
+
+**Precondition:** Research Panel is open with Sources tab active. At least one source exists.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap a source card in the source list | Sources tab | 1 |
+| 2 | Source Detail View replaces the source list inline. Content loads with a progress indicator. | Source Detail View | 0 (transition) |
+| 3 | User reads source content. In landscape, the editor remains visible to the left. | Source Detail View + Editor | 0 (reading) |
+| 4 | User taps [< Sources] back button to return to the list | Source Detail View header | 1 |
+
+**Total: 2 taps (1 to open, 1 to return). 1 tap if user stays in the viewer.**
+
+**Key moments:**
+
+```
+STEP 1: Tap a source card
++--------+---------------------------+-------------------+
+| Sidebar| Editor                    |  RESEARCH         |
+|        |                           |  [Sources] Ask Clips
+|        | Chapter 4: Case Studies   |  ================ |
+|        |                           |  [Search]  [+ Add]|
+|        | Lorem ipsum dolor sit     |  ---------------  |
+|        | amet, consectetur...      | >Interview-S.doc< |
+|        |                           |    1,240w  Cached |
+|        |                           |  Q4-Report.doc    |
+|        |                           |    3,800w  Cached |
++--------+---------------------------+-------------------+
+
+STEP 2: Source Detail View (inline replace)
++--------+---------------------------+-------------------+
+| Sidebar| Editor                    |  RESEARCH         |
+|        |                           |  [< Sources]      |
+|        | Chapter 4: Case Studies   |  Interview-S.doc  |
+|        |                           |  1,240w | 2h ago  |
+|        | Lorem ipsum dolor sit     |  ================ |
+|        | amet, consectetur...      |                   |
+|        |                           |  The key insight   |
+|        | adipiscing elit. Sed do   |  from our conver-  |
+|        | eiusmod tempor incididunt |  sation was that   |
+|        | ut labore et dolore magna |  leadership in     |
+|        | aliqua.                   |  distributed teams |
+|        |                           |  requires funda-   |
+|        |                           |  mentally differ-  |
+|        |                           |  ent approaches... |
+|        |                           |                    |
+|        |                           |  [Import as Ch.]   |
++--------+---------------------------+-------------------+
+```
+
+**Error states:**
+- **Content not yet cached:** A loading spinner shows while content is fetched from Google Drive and cached. If the Drive API fails, an error message appears: "Could not load content. The source may have been deleted from Google Drive." with "Retry" and "Back" actions.
+- **Source archived (account disconnected):** The source card shows "Account disconnected" in the list. Tapping it opens the detail view with a message: "This source's Google account has been disconnected. Reconnect to view content." with a "Reconnect" link.
+- **Content very long:** The detail view is a scrollable container. For sources exceeding 10,000 words, a "Search within document" field appears at the top of the content area.
+
+**iPad-specific considerations:**
+- In landscape mode (1024pt+), the editor remains visible alongside the Research Panel. The user can see their writing while reading a source -- this is the core improvement over the current full-overlay SourceViewerSheet.
+- In portrait mode, the Research Panel is an overlay. The user cannot see the editor while viewing a source. The [< Sources] back button is the primary navigation to return to the source list, and closing the panel returns to the editor.
+- The source content area supports text selection via long-press. Selected text shows a contextual action: "Save to Clips" (in addition to the system Copy action). This uses the native `Selection` API with a custom floating toolbar.
+- Scroll position within the source content is preserved when switching tabs (Sources to Ask to Clips and back). It is lost when navigating back to the source list.
+
+---
+
+### Flow 4: Search Sources with Natural Language Query
+
+**Precondition:** Research Panel is open. At least one source exists with cached content.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap the "Ask" tab | Research Panel tab bar | 1 |
+| 2 | Ask tab shows the query input at the bottom and any previous conversation above | Ask tab | 0 |
+| 3 | Tap the query input field. Keyboard appears. | Ask tab | 1 |
+| 4 | Type a natural-language question. E.g., "What did my workshop notes say about psychological safety?" | Ask tab | 0 (typing) |
+| 5 | Tap the Send button (or press Return on external keyboard) | Ask tab | 1 |
+| 6 | Loading indicator appears. The query scrolls up and a streaming response begins appearing below it. | Ask tab | 0 (waiting) |
+| 7 | AI response completes. Result cards appear with cited passages and source references. | Ask tab | 0 |
+
+**Total: 3 taps + typing.**
+
+**Key moments:**
+
+```
+STEP 2: Ask tab (empty state -- first visit)
++-----------------------------------+
+|  RESEARCH                         |
+|  Sources  [Ask]  Clips     [x]   |
+|  ================================ |
+|                                   |
+|  Ask about your sources           |
+|                                   |
+|  Try asking:                      |
+|  "What data do I have on..."      |
+|  "Summarize my notes about..."    |
+|  "Find quotes about..."           |
+|                                   |
+|                                   |
+|                                   |
+|                                   |
+|  ================================ |
+|  [Ask about your sources...] [->] |
++-----------------------------------+
+
+STEP 6-7: AI response with results
++-----------------------------------+
+|  RESEARCH                         |
+|  Sources  [Ask]  Clips     [x]   |
+|  ================================ |
+|                                   |
+|  You: What did my workshop notes  |
+|  say about psychological safety?  |
+|                                   |
+|  -------------------------------- |
+|  AI: I found 2 relevant passages: |
+|                                   |
+|  +-------------------------------+|
+|  | "Psychological safety was the ||
+|  | strongest predictor of team   ||
+|  | performance, with 67% of     ||
+|  | teams reporting measurable    ||
+|  | improvement."                 ||
+|  |                               ||
+|  | Workshop Notes March 2024     ||
+|  | [Save to Clips] [Insert]     ||
+|  +-------------------------------+|
+|                                   |
+|  +-------------------------------+|
+|  | "Teams with high psychologi-  ||
+|  | cal safety scores showed 2.3x ||
+|  | faster decision-making..."    ||
+|  |                               ||
+|  | Q4-Report.doc                 ||
+|  | [Save to Clips] [Insert]     ||
+|  +-------------------------------+|
+|                                   |
+|  ================================ |
+|  [Ask a follow-up...]       [->] |
++-----------------------------------+
+```
+
+**Error states:**
+- **No sources in project:** The Ask tab shows an empty state: "Add source documents first. The Ask tab searches across your source materials." with a "Go to Sources" link that switches to the Sources tab.
+- **No cached content:** "Your sources haven't been processed yet. Content is being extracted -- try again in a moment." (This occurs when sources are added but text extraction hasn't completed.)
+- **AI query fails (API error):** The response area shows: "Something went wrong. Please try again." with a "Retry" button that resubmits the same query.
+- **AI returns no results:** "I couldn't find relevant information about that in your sources. Try rephrasing your question or check that the relevant source documents have been added."
+- **AI response is slow (>5s):** A skeleton loader with pulsing lines appears below the query. A subtle "Searching across N sources..." message provides feedback.
+- **Streaming interrupted:** Partial response displays with a "Response was interrupted. Tap to retry." message appended.
+
+**iPad-specific considerations:**
+- The query input is positioned at the bottom of the Ask tab, above the keyboard when active. This follows the iMessage/chat pattern familiar to all iPad users.
+- When the software keyboard appears, the conversation area scrolls up to keep the latest content visible. Uses `visualViewport` API to detect keyboard height.
+- The Send button is 44x44pt minimum. It is disabled (grayed) when the input is empty.
+- Suggested queries in the empty state are tappable full-width rows (44pt height each). Tapping one populates the input and auto-submits.
+- External keyboard shortcut: Cmd+Return submits the query (matching the convention in chat apps).
+- Result cards have 44pt minimum touch targets on all action buttons.
+
+---
+
+### Flow 5: Save a Snippet from Search Results
+
+**Precondition:** User has received AI search results in the Ask tab.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Save to Clips" on a result card | Ask tab (result card action) | 1 |
+| 2 | Button changes to a checkmark with "Saved" label. The Clips tab badge increments. | Ask tab | 0 (feedback) |
+
+**Total: 1 tap.**
+
+**Alternative flow -- save from Source Detail View:**
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Long-press on text in the source content to select | Source Detail View | 1 (long-press) |
+| 2 | Adjust selection handles if needed | Source Detail View | 0-2 (drag) |
+| 3 | Floating toolbar appears with "Save to Clips" action | Source Detail View | 0 |
+| 4 | Tap "Save to Clips" | Floating toolbar | 1 |
+| 5 | Toast notification: "Saved to Clips" with brief animation. Clips tab badge increments. | Source Detail View | 0 |
+
+**Total: 2-3 taps/gestures.**
+
+**Key moments:**
+
+```
+STEP 1-2: Save from AI result
++-----------------------------------+
+|  +-------------------------------+|
+|  | "Psychological safety was the ||
+|  | strongest predictor of team   ||
+|  | performance, with 67% of     ||
+|  | teams reporting measurable    ||
+|  | improvement."                 ||
+|  |                               ||
+|  | Workshop Notes March 2024     ||
+|  | [check] Saved    [Insert]    ||
+|  +-------------------------------+|
+|                                   |
+|  Sources  Ask  [Clips (3)]  [x]  |
+|  ================================ |
+```
+
+**Error states:**
+- **Clip already saved:** If the same passage (matched by content + source) is already saved, the button shows "Already saved" and does nothing on tap. No error -- just a no-op with feedback.
+- **Clips API fails:** Toast notification: "Could not save clip. Please try again." The button reverts to "Save to Clips."
+- **Offline:** "You appear to be offline. Clip will be saved when you reconnect." (Uses optimistic local save with sync on reconnect.)
+
+**iPad-specific considerations:**
+- Long-press text selection on iPad requires careful handling. The floating toolbar must appear above the selection, not behind the Research Panel header. Position is calculated relative to the selection rect and the panel's scroll offset.
+- The floating toolbar uses `position: fixed` with dynamic top/left based on `getSelection().getRangeAt(0).getBoundingClientRect()`.
+- "Save to Clips" in the floating toolbar has a 44pt minimum height.
+- Haptic feedback (if available) on successful save: `navigator.vibrate?.(10)` or UIKit haptic via WKWebView bridge (not available in Safari -- skip gracefully).
+
+---
+
+### Flow 6: Insert a Snippet into the Editor
+
+**Precondition:** User has at least one saved clip. Editor has an active chapter with cursor positioned.
+
+**Path A: Insert from Clips tab**
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Clips" tab | Research Panel tab bar | 1 |
+| 2 | Tap "Insert" button on a clip card | Clips tab | 1 |
+| 3 | Clip text is inserted at the current cursor position in the editor. A footnote is automatically created referencing the source document. Brief success toast: "Inserted with footnote." | Editor + Clips tab | 0 |
+
+**Total: 2 taps.**
+
+**Path B: Insert directly from AI result**
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Insert" button on a result card in the Ask tab | Ask tab | 1 |
+| 2 | Text is inserted at cursor with auto-footnote. Brief success toast. | Editor + Ask tab | 0 |
+
+**Total: 1 tap.**
+
+**Key moments:**
+
+```
+BEFORE INSERT: Editor with cursor at position
++--------+---------------------------+-------------------+
+| Sidebar| Editor                    |  RESEARCH         |
+|        |                           |  Sources Ask [Clips]
+|        | Chapter 4: Case Studies   |  ================ |
+|        |                           |  3 clips saved    |
+|        | Teams that invest in      |                   |
+|        | coaching see measurable   |  "Psychological   |
+|        | returns. |                |  safety was the   |
+|        |                           |  strongest..."    |
+|        |                           |  -- Workshop Notes|
+|        |                           |  [Insert] [Delete]|
++--------+---------------------------+-------------------+
+
+AFTER INSERT: Text + footnote added at cursor
++--------+---------------------------+-------------------+
+| Sidebar| Editor                    |  RESEARCH         |
+|        |                           |  Sources Ask [Clips]
+|        | Chapter 4: Case Studies   |  ================ |
+|        |                           |  3 clips saved    |
+|        | Teams that invest in      |                   |
+|        | coaching see measurable   |  "Psychological   |
+|        | returns. "Psychological   |  safety was the   |
+|        | safety was the strongest  |  strongest..."    |
+|        | predictor of team per-    |  -- Workshop Notes|
+|        | formance, with 67% of    |  [Inserted] [Del] |
+|        | teams reporting meas-     |                   |
+|        | urable improvement." [1]  |                   |
+|        |                           |                   |
+|        | ---                       |                   |
+|        | [1] Workshop Notes March  |                   |
+|        |     2024                  |                   |
++--------+---------------------------+-------------------+
+```
+
+**Error states:**
+- **No cursor position in editor:** If the editor does not have focus or a cursor position, the insert action focuses the editor and appends the text at the end of the current chapter content. Toast: "Inserted at end of chapter."
+- **Editor is read-only or loading:** The Insert button is disabled (grayed) with a tooltip: "Editor is loading..."
+- **Footnote extension not loaded:** If the Tiptap footnote extension fails to load, the text is still inserted but without a footnote. Toast: "Inserted without footnote -- footnotes are not available." This is a graceful degradation.
+- **Chapter not selected:** Insert button disabled. Tooltip: "Select a chapter to insert into."
+
+**iPad-specific considerations:**
+- Inserting text requires the editor to regain focus. On iPad, focusing a contenteditable element may trigger the software keyboard. The insert action should store the cursor position before the Research Panel received focus, and restore it during insertion.
+- The cursor position is tracked by the editor (Tiptap's selection state) and persisted even when the user interacts with the Research Panel. This requires `editor.commands.focus()` before `editor.commands.insertContent()`.
+- The inserted text is wrapped in a blockquote node (styled distinctly) with the footnote reference as a superscript link. The footnote content appears at the bottom of the chapter in a dedicated footnotes section.
+- External keyboard: Cmd+Shift+V could be bound to "insert last saved clip" for power users (Phase C enhancement, not initial scope).
+
+---
+
+### Flow 7: Remove a Source
+
+**Precondition:** Research Panel is open with Sources tab active. At least one source exists.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Swipe left on a source card to reveal actions (or tap the overflow menu "..." on the card) | Sources tab | 1 |
+| 2 | Tap "Remove" action (red text) | Source card action area | 1 |
+| 3 | Confirmation dialog appears: "Remove [Source Title]? This removes the source from your project. The original file in Google Drive is not affected." with "Cancel" and "Remove" buttons. | Center dialog | 0 |
+| 4 | Tap "Remove" in the confirmation dialog | Center dialog | 1 |
+| 5 | Source is removed from the list with a fade-out animation. Any clips referencing this source retain their text but the source reference shows "[Source removed]". | Sources tab | 0 |
+
+**Total: 3 taps (including confirmation).**
+
+**Key moments:**
+
+```
+STEP 1: Swipe-left on source card
++-----------------------------------+
+|  Interview-Smith.doc              |
+|    1,240w  |  Cached 2h ago       |
+|            +-------+------+------+|
+|            | View  |Import|Remove||
+|            +-------+------+------+|
+
+STEP 3: Confirmation dialog
++-----------------------------------+
+|                                   |
+|  +-------------------------------+|
+|  |  Remove "Interview-Smith.doc"?||
+|  |                               ||
+|  |  This removes the source from ||
+|  |  your project. The original   ||
+|  |  file in Google Drive is not  ||
+|  |  affected.                    ||
+|  |                               ||
+|  |  Related clips will keep      ||
+|  |  their text but lose the      ||
+|  |  source link.                 ||
+|  |                               ||
+|  |      [Cancel]    [Remove]     ||
+|  +-------------------------------+|
+|                                   |
++-----------------------------------+
+```
+
+**Error states:**
+- **Remove API fails:** Dialog closes. Toast: "Could not remove source. Please try again." Source remains in the list.
+- **Source has clips:** Confirmation dialog includes the additional note: "N clips reference this source. They will keep their text but lose the source link." Removal proceeds if confirmed.
+
+**iPad-specific considerations:**
+- Swipe-left to reveal actions follows the standard iOS pattern (UITableView swipe actions). This is implemented with touch event handlers that track horizontal delta.
+- Alternative access: a visible "..." overflow button on each source card (44x44pt tap area) that reveals the same actions in a dropdown. This ensures the actions are discoverable without requiring knowledge of swipe gestures.
+- The confirmation dialog is a centered modal with a dimmed backdrop. Dialog buttons are minimum 44pt height with 16pt horizontal spacing. The "Remove" button is red; "Cancel" is default gray.
+- The dialog respects `prefers-reduced-motion` by omitting the fade/scale entrance animation.
+
+---
+
+### Flow 8: Browse Collected Snippets on Research Board
+
+**Precondition:** Research Panel is open. User has saved at least one clip.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Clips" tab. Badge shows count. | Research Panel tab bar | 1 |
+| 2 | Clips tab displays all saved clips, ordered by most recently saved. Each card shows the snippet text, source title, and action buttons. | Clips tab | 0 |
+| 3 | User scrolls through clips to review. | Clips tab | 0 (scroll) |
+| 4 | (Optional) User taps the source title link on a clip to view the full source | Clip card source link | 1 |
+| 5 | Sources tab opens with the Source Detail View for that source, scrolled to the approximate location of the clip | Source Detail View | 0 (transition) |
+
+**Total: 1 tap to view clips. 2 taps to navigate to a clip's source.**
+
+**Key moments:**
+
+```
+STEP 2: Clips tab with saved snippets
++-----------------------------------+
+|  RESEARCH                         |
+|  Sources  Ask  [Clips (5)]  [x]  |
+|  ================================ |
+|  [Search clips...]               |
+|                                   |
+|  +-------------------------------+|
+|  | "Psychological safety was the ||
+|  | strongest predictor of team   ||
+|  | performance, with 67% of     ||
+|  | teams reporting measurable    ||
+|  | improvement."                 ||
+|  |                               ||
+|  | Workshop Notes March 2024     ||
+|  | Saved 2h ago                  ||
+|  | [Insert]           [Delete]   ||
+|  +-------------------------------+|
+|                                   |
+|  +-------------------------------+|
+|  | "Q4 results showed a 23%     ||
+|  | increase in leadership        ||
+|  | effectiveness scores across   ||
+|  | all measured dimensions."     ||
+|  |                               ||
+|  | Q4-Report.doc                 ||
+|  | Saved 1d ago                  ||
+|  | [Insert]           [Delete]   ||
+|  +-------------------------------+|
+|                                   |
+|  +-------------------------------+|
+|  | "The framework suggests three ||
+|  | phases: awareness, practice,  ||
+|  | and integration."             ||
+|  |                               ||
+|  | Client-Notes.doc              ||
+|  | Saved 3d ago                  ||
+|  | [Insert]           [Delete]   ||
+|  +-------------------------------+|
+|                                   |
+|  5 clips saved                    |
++-----------------------------------+
+```
+
+**Error states:**
+- **No clips saved:** Empty state: "No clips yet. Save passages from AI results or select text in source documents to build your research board." with an illustrative icon.
+- **Source was removed:** Clip card shows source as "[Source removed]" in gray. The clip text remains. The source link is not tappable.
+- **Clip content very long:** Clip text is truncated at 300 characters with "..." and a "Show more" toggle that expands the card inline.
+
+**iPad-specific considerations:**
+- Clip cards have generous padding (16pt) for comfortable reading and tapping.
+- The search field at the top of the Clips tab searches clip text and source titles. It filters the list in real-time.
+- Delete action on clips shows a brief confirmation (swipe-to-delete with "Delete" button, same pattern as Flow 7's swipe). No modal confirmation for clip deletion -- clips are lightweight and recoverable by re-saving from the Ask tab.
+- Insert and Delete buttons are minimum 44pt height.
+- Clip cards do not use drag-and-drop for insertion (drag-and-drop is unreliable on iPad Safari). The Insert button is the sole insertion mechanism. Drag-and-drop is reserved as a Phase C+ enhancement when iPad support improves.
+
+---
+
+## 3. Panel Layout Specifications
+
+### Landscape iPad (1024pt+ wide)
+
+```
++--------+------------------------------------------+------------------+
+| Sidebar| Editor                                   | Research Panel   |
+| 260pt  | flex (min 400pt)                         | 340pt            |
++--------+------------------------------------------+------------------+
+```
+
+| Element | Width | Constraints |
+|---------|-------|-------------|
+| Chapter Sidebar | 260pt fixed | Collapsible to 0pt via toggle. When collapsed, editor expands. |
+| Editor | Flex (remaining space) | **Minimum 400pt.** If Research Panel would push editor below 400pt, the panel cannot open as side-by-side -- it opens as overlay instead. |
+| Research Panel | 340pt fixed | Opens from right. Pushes editor left (does not overlay). |
+
+**Panel open/close behavior:**
+- Opening: Research Panel slides in from the right edge over 200ms (`ease-out`). The editor width shrinks by 340pt. The editor content reflows (Tiptap re-wraps text).
+- Closing: Research Panel slides out to the right over 150ms (`ease-in`). Editor expands back to full width.
+- `prefers-reduced-motion`: Panel appears/disappears instantly (no slide animation). Width change is still animated at 0ms (effectively instant).
+
+**Width calculation for common devices:**
+
+| Device | Orientation | Viewport | Sidebar | Editor | Research | Viable? |
+|--------|-------------|----------|---------|--------|----------|---------|
+| iPad Air 11" | Landscape | 1180pt | 260pt | 580pt | 340pt | Yes (580 > 400) |
+| iPad Air 11" | Portrait | 820pt | 260pt | 220pt | 340pt | **No** -- overlay mode |
+| iPad Pro 13" | Landscape | 1366pt | 260pt | 766pt | 340pt | Yes |
+| iPad Pro 13" | Portrait | 1024pt | 260pt | 424pt | 340pt | Yes (424 > 400) |
+| iPad Mini 6 | Landscape | 1133pt | 260pt | 533pt | 340pt | Yes |
+| iPad Mini 6 | Portrait | 744pt | 260pt | 144pt | 340pt | **No** -- overlay mode |
+
+**Sidebar collapse interaction:**
+When the Research Panel is open and the sidebar is also visible, if the editor width falls below 400pt, the sidebar auto-collapses. When the Research Panel closes, the sidebar returns to its previous state.
+
+### Portrait iPad (768pt-1023pt wide)
+
+```
++--------+------------------------------------------+
+| Sidebar| Editor                                   |
+| 260pt  | flex                                     |
++--------+----------+-----------+-------------------+
+                     |           |
+                     | Research  |  <- Overlay panel
+                     | Panel     |     from right
+                     | 85% width |
+                     |           |
+                     +-----------+
+```
+
+| Element | Width | Behavior |
+|---------|-------|----------|
+| Research Panel | 85% of viewport | Slides in from right as an overlay. Editor is dimmed behind but remains in DOM (no unmount). |
+| Backdrop | 15% visible on left | Tapping the backdrop strip closes the panel. Provides a visual "peek" at the editor. |
+
+**Panel open/close behavior:**
+- Opening: Panel slides in from right edge over 200ms. A semi-transparent backdrop (`bg-black/30`) fades in over the editor/sidebar.
+- Closing: Panel slides out, backdrop fades out.
+- Swipe-right on the panel: Dismisses the panel (tracks horizontal touch delta > 60pt). This mimics the iOS sheet dismissal gesture.
+- `prefers-reduced-motion`: Instant appear/disappear, no slide.
+
+**Portrait mode does NOT support side-by-side viewing.** The Research Panel is explicitly an overlay. This is a deliberate constraint to maintain readable editor width (< 400pt side-by-side on most portrait iPads).
+
+### Desktop (1200pt+ wide)
+
+```
++--------+--------------------------------------------------+------------------+
+| Sidebar| Editor                                            | Research Panel   |
+| 260pt  | flex (typically 600-900pt)                        | 340pt            |
++--------+--------------------------------------------------+------------------+
+```
+
+Identical behavior to landscape iPad, but with more editor space. No additional desktop-specific patterns.
+
+| Element | Width | Constraints |
+|---------|-------|-------------|
+| Chapter Sidebar | 260pt fixed | Same as iPad |
+| Editor | Flex | Minimum 400pt, typically 600-900pt on desktop |
+| Research Panel | 340pt fixed | Same as iPad |
+
+**Resizable panel (desktop only, future enhancement):** On desktop with pointer devices, a drag handle on the left edge of the Research Panel allows resizing between 300pt (min) and 480pt (max). This is a Phase C+ enhancement and is NOT part of the initial implementation. The handle is hidden on touch devices.
+
+### Safe Area Handling
+
+All panel positioning uses `env(safe-area-inset-*)`:
+
+```css
+.research-panel {
+  padding-right: env(safe-area-inset-right, 0);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+.research-panel-overlay {
+  /* Full height minus safe areas */
+  height: 100dvh;
+  padding-top: env(safe-area-inset-top, 0);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+```
+
+The panel uses `100dvh` (dynamic viewport height), NOT `100vh`, to account for Safari's collapsible address bar.
+
+---
+
+## 4. Component Inventory
+
+### ResearchPanel
+
+- **Name:** `ResearchPanel`
+- **Type:** New
+- **Location:** `web/src/components/research/research-panel.tsx`
+- **Purpose:** Top-level container for the Research Panel. Manages tab navigation and panel open/close.
+
+```typescript
+interface ResearchPanelProps {
+  projectId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  /** Callback when a clip is inserted -- editor integration */
+  onInsertSnippet: (text: string, sourceTitle: string, sourceId: string | null) => void;
+  /** Whether the editor has focus/cursor for insertion */
+  canInsert: boolean;
+}
+```
+
+**States:**
+- Closed (not rendered / hidden)
+- Open with Sources tab active
+- Open with Ask tab active
+- Open with Clips tab active
+
+**Accessibility:**
+- `role="complementary"` with `aria-label="Research panel"`
+- Tab bar uses `role="tablist"` with `role="tab"` on each tab and `aria-selected`
+- Tab panels use `role="tabpanel"` with `aria-labelledby` pointing to the tab
+- Escape key closes the panel
+- Focus trap when in overlay mode (portrait)
+
+---
+
+### SourcesTab
+
+- **Name:** `SourcesTab`
+- **Type:** New
+- **Location:** `web/src/components/research/sources-tab.tsx`
+- **Purpose:** Source list with search, filter, and inline drill-down to detail/add views.
+
+```typescript
+interface SourcesTabProps {
+  projectId: string;
+  /** Navigate to source detail view */
+  onViewSource: (sourceId: string) => void;
+}
+```
+
+**States:**
+- List view (default): Shows all sources with search field
+- Detail view: Shows full content of a single source (inline replacement)
+- Add view: Shows Drive browser / upload options (inline replacement)
+- Loading: Initial source list loading
+- Empty: No sources added yet
+- Error: Failed to load sources
+
+**Accessibility:**
+- Source list uses `role="list"` with `role="listitem"` on each card
+- Search field has `aria-label="Search sources"` and announces result count changes via `aria-live="polite"`
+- In-list search filters update immediately (no submit required)
+
+---
+
+### AskTab
+
+- **Name:** `AskTab`
+- **Type:** New
+- **Location:** `web/src/components/research/ask-tab.tsx`
+- **Purpose:** AI natural-language query interface with streaming results.
+
+```typescript
+interface AskTabProps {
+  projectId: string;
+  onSaveClip: (clip: { content: string; sourceId: string | null; sourceTitle: string; sourceLocation: string | null }) => Promise<void>;
+  onInsertSnippet: (text: string, sourceTitle: string, sourceId: string | null) => void;
+  canInsert: boolean;
+}
+```
+
+**States:**
+- Empty (first visit): Shows suggested queries
+- Input focused: Keyboard open, ready to type
+- Loading: Query submitted, waiting for AI response (streaming)
+- Results: AI response with result cards
+- Conversation: Multiple query/response pairs (scrollable history)
+- Error: Query failed
+- No sources: Sources required but none exist
+
+**Accessibility:**
+- Query input has `aria-label="Ask about your sources"`
+- Submit button has `aria-label="Submit query"`
+- AI responses are announced via `aria-live="polite"` region
+- Result cards are focusable with action buttons reachable via Tab key
+- Loading state has `aria-busy="true"` on the results container
+
+---
+
+### ClipsTab
+
+- **Name:** `ClipsTab`
+- **Type:** New
+- **Location:** `web/src/components/research/clips-tab.tsx`
+- **Purpose:** Saved snippet board with search, insert, and delete actions.
+
+```typescript
+interface ClipsTabProps {
+  projectId: string;
+  onInsertSnippet: (text: string, sourceTitle: string, sourceId: string | null) => void;
+  canInsert: boolean;
+}
+```
+
+**States:**
+- Empty: No clips saved
+- List: Clips displayed, most recent first
+- Searching: Filter active on clip text or source title
+
+**Accessibility:**
+- Clips list uses `role="list"` with `role="listitem"` on each card
+- Search field has `aria-label="Search clips"`
+- Delete action requires confirmation (swipe or button, announced to screen readers)
+- Insert button has `aria-label="Insert into chapter with footnote"`
+
+---
+
+### SourceCard
+
+- **Name:** `SourceCard`
+- **Type:** New (replaces `SourceRow` in current `sources-panel.tsx`)
+- **Location:** `web/src/components/research/source-card.tsx`
+- **Purpose:** Individual source row in the source list.
+
+```typescript
+interface SourceCardProps {
+  source: SourceMaterial;
+  onTap: () => void;
+  onRemove: () => void;
+  onImportAsChapter: () => void;
+}
+```
+
+**States:**
+- Normal: Title, word count, cached time
+- Processing: Source added but text extraction in progress
+- Error: Text extraction failed
+- Archived: Drive account disconnected
+
+**Accessibility:**
+- Card is a `button` element (entire card is tappable to open detail)
+- Overflow menu (swipe actions or "..." button) uses `aria-haspopup="menu"`
+- Status (processing, error, archived) announced via `aria-describedby`
+- Minimum height 56pt; minimum tap target 44pt
+
+---
+
+### SourceAddFlow
+
+- **Name:** `SourceAddFlow`
+- **Type:** New (replaces `AddSourceSheet` + `DriveBrowserSheet`)
+- **Location:** `web/src/components/research/source-add-flow.tsx`
+- **Purpose:** Inline flow for adding sources from Drive or local device. Replaces the source list within the Sources tab.
+
+```typescript
+interface SourceAddFlowProps {
+  projectId: string;
+  driveAccounts: DriveAccount[];
+  onSourcesAdded: () => void;
+  onBack: () => void;
+  onConnectAccount: () => void;
+}
+```
+
+**States:**
+- Account selection: Choose Drive account or upload
+- Drive browsing: Navigate Drive folders, select files
+- Uploading: Local file upload in progress
+- Adding: Selected Drive files being added
+
+**Accessibility:**
+- Back button has `aria-label="Back to sources"`
+- Drive file checkboxes have `aria-label` including the file name
+- "Add N Selected" button announces selection count
+- Folder navigation announces the current path
+
+---
+
+### SourceDetailView
+
+- **Name:** `SourceDetailView`
+- **Type:** New (replaces `SourceViewerSheet`)
+- **Location:** `web/src/components/research/source-detail-view.tsx`
+- **Purpose:** Full source content viewer displayed inline within the Sources tab.
+
+```typescript
+interface SourceDetailViewProps {
+  sourceId: string;
+  title: string;
+  onBack: () => void;
+  onImportAsChapter: (sourceId: string) => void;
+  onSaveClip: (clip: { content: string; sourceId: string; sourceTitle: string; sourceLocation: string | null }) => Promise<void>;
+}
+```
+
+**States:**
+- Loading: Content being fetched
+- Loaded: Content displayed, scrollable
+- Error: Content fetch failed
+- Search active: In-document search field visible (for long documents)
+
+**Accessibility:**
+- Back button has `aria-label="Back to source list"`
+- Content area has `role="document"` with `aria-label="Source content: [title]"`
+- Text selection and "Save to Clips" action is keyboard-accessible (Cmd+Shift+S)
+- In-document search has `aria-label="Search within document"`
+
+---
+
+### QueryInput
+
+- **Name:** `QueryInput`
+- **Type:** New
+- **Location:** `web/src/components/research/query-input.tsx`
+- **Purpose:** Text input field for AI queries and source search.
+
+```typescript
+interface QueryInputProps {
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  isLoading: boolean;
+  disabled?: boolean;
+}
+```
+
+**States:**
+- Empty: Placeholder visible
+- Focused: Cursor active, keyboard open on iPad
+- Has value: Submit button enabled
+- Loading: Input disabled, spinner on submit button
+- Disabled: Input grayed out (no sources, etc.)
+
+**Accessibility:**
+- Input has `aria-label` matching the `placeholder` text
+- Submit button has `aria-label="Submit"` when not loading, `aria-label="Searching..."` when loading
+- Input is `type="text"` with `enterkeyhint="send"` for mobile keyboards
+- Minimum height 48pt for the input container
+- Minimum 16px font size (prevents iOS zoom on focus)
+
+---
+
+### ResultCard
+
+- **Name:** `ResultCard`
+- **Type:** New
+- **Location:** `web/src/components/research/result-card.tsx`
+- **Purpose:** Displays a single AI search result with source citation and actions.
+
+```typescript
+interface ResultCardProps {
+  content: string;
+  sourceTitle: string;
+  sourceId: string | null;
+  sourceLocation: string | null;
+  onSaveToClips: () => void;
+  onInsert: () => void;
+  isSaved: boolean;
+  canInsert: boolean;
+}
+```
+
+**States:**
+- Default: Content visible with Save and Insert actions
+- Saved: "Save to Clips" becomes "Saved" checkmark
+- Insert disabled: Editor not ready
+
+**Accessibility:**
+- Card has `role="article"` with `aria-label="Search result from [sourceTitle]"`
+- Action buttons have descriptive `aria-label` values
+- Source title link has `aria-label="View source: [sourceTitle]"`
+- Content text is selectable
+
+---
+
+### ClipCard
+
+- **Name:** `ClipCard`
+- **Type:** New
+- **Location:** `web/src/components/research/clip-card.tsx`
+- **Purpose:** Displays a saved snippet with source reference and actions.
+
+```typescript
+interface ClipCardProps {
+  clip: ResearchClip;
+  onInsert: () => void;
+  onDelete: () => void;
+  onViewSource: () => void;
+  canInsert: boolean;
+}
+```
+
+**States:**
+- Default: Snippet text, source reference, Insert/Delete actions
+- Expanded: Full text visible (for truncated clips)
+- Inserted: Visual indicator that this clip has been inserted into a chapter
+- Source removed: Source reference shows "[Source removed]"
+
+**Accessibility:**
+- Card has `role="article"` with `aria-label` including truncated clip text
+- Delete requires confirmation (swipe or button tap)
+- Insert button has `aria-label="Insert into chapter with footnote"`
+- Source link has `aria-label="View source: [sourceTitle]"` or is `aria-disabled` if removed
+
+---
+
+### SnippetInsertButton
+
+- **Name:** `SnippetInsertButton`
+- **Type:** New
+- **Location:** `web/src/components/research/snippet-insert-button.tsx`
+- **Purpose:** Reusable button component for inserting text into the editor with auto-footnote.
+
+```typescript
+interface SnippetInsertButtonProps {
+  text: string;
+  sourceTitle: string;
+  sourceId: string | null;
+  onInsert: (text: string, sourceTitle: string, sourceId: string | null) => void;
+  disabled?: boolean;
+  variant?: "default" | "compact";
+}
+```
+
+**States:**
+- Default: "Insert" label
+- Disabled: Grayed out (no cursor, editor loading)
+- Success: Brief "Inserted" feedback (1.5s, then reverts)
+
+**Accessibility:**
+- `aria-label="Insert quote into chapter with footnote"`
+- `aria-disabled` when disabled (not `disabled` attribute, to allow tooltip)
+- Minimum 44pt tap target
+
+---
+
+### ResearchPanelProvider
+
+- **Name:** `ResearchPanelProvider`
+- **Type:** New
+- **Location:** `web/src/components/research/research-panel-provider.tsx`
+- **Purpose:** React context provider that encapsulates all Research Panel state, eliminating prop threading through EditorDialogs.
+
+```typescript
+interface ResearchPanelContextValue {
+  // Panel state
+  isOpen: boolean;
+  activeTab: "sources" | "ask" | "clips";
+  openPanel: (tab?: "sources" | "ask" | "clips") => void;
+  closePanel: () => void;
+  setActiveTab: (tab: "sources" | "ask" | "clips") => void;
+
+  // Sources
+  sources: SourceMaterial[];
+  isSourcesLoading: boolean;
+  sourcesError: string | null;
+  fetchSources: () => Promise<void>;
+  removeSource: (sourceId: string) => Promise<void>;
+
+  // Source detail
+  sourcesView: "list" | "detail" | "add";
+  activeSourceId: string | null;
+  viewSource: (sourceId: string) => void;
+  backToSourceList: () => void;
+  startAddFlow: () => void;
+
+  // Clips
+  clips: ResearchClip[];
+  isClipsLoading: boolean;
+  saveClip: (clip: Omit<ResearchClip, "id" | "createdAt">) => Promise<void>;
+  deleteClip: (clipId: string) => Promise<void>;
+  clipCount: number;
+}
+```
+
+---
+
+## 5. State Model Changes
+
+### Hooks to Modify or Replace
+
+**`use-source-actions.ts` -- Replaced by `useResearchPanel`**
+
+The current `useSourceActions` hook manages 6+ boolean state variables and returns 30+ values. It is replaced by `useResearchPanel`, which uses a state machine pattern.
+
+Current hook is archived (not deleted) for reference. The new hook:
+
+```typescript
+// web/src/hooks/use-research-panel.ts
+
+type SourcesView = "list" | "detail" | "add";
+type ResearchTab = "sources" | "ask" | "clips";
+
+interface ResearchPanelState {
+  /** Whether the panel is open */
+  isOpen: boolean;
+  /** Currently active tab */
+  activeTab: ResearchTab;
+  /** Sources tab sub-view */
+  sourcesView: SourcesView;
+  /** Active source ID (for detail view) */
+  activeSourceId: string | null;
+  /** Drive connection ID (for add flow) */
+  driveConnectionId: string | null;
+}
+
+type ResearchPanelAction =
+  | { type: "OPEN_PANEL"; tab?: ResearchTab }
+  | { type: "CLOSE_PANEL" }
+  | { type: "SET_TAB"; tab: ResearchTab }
+  | { type: "VIEW_SOURCE"; sourceId: string }
+  | { type: "BACK_TO_LIST" }
+  | { type: "START_ADD_FLOW" }
+  | { type: "SET_DRIVE_CONNECTION"; connectionId: string }
+  | { type: "FINISH_ADD" };
+```
+
+The reducer enforces valid state transitions:
+
+```typescript
+function researchPanelReducer(
+  state: ResearchPanelState,
+  action: ResearchPanelAction
+): ResearchPanelState {
+  switch (action.type) {
+    case "OPEN_PANEL":
+      return {
+        ...state,
+        isOpen: true,
+        activeTab: action.tab ?? state.activeTab,
+        // Reset sources sub-view when opening
+        sourcesView: action.tab === "sources" ? "list" : state.sourcesView,
+      };
+    case "CLOSE_PANEL":
+      return {
+        ...state,
+        isOpen: false,
+        // Reset all sub-views on close
+        sourcesView: "list",
+        activeSourceId: null,
+        driveConnectionId: null,
+      };
+    case "SET_TAB":
+      return {
+        ...state,
+        activeTab: action.tab,
+        // Reset sources sub-view when switching away
+        sourcesView: action.tab === "sources" ? state.sourcesView : "list",
+      };
+    case "VIEW_SOURCE":
+      return {
+        ...state,
+        sourcesView: "detail",
+        activeSourceId: action.sourceId,
+      };
+    case "BACK_TO_LIST":
+      return {
+        ...state,
+        sourcesView: "list",
+        activeSourceId: null,
+        driveConnectionId: null,
+      };
+    case "START_ADD_FLOW":
+      return {
+        ...state,
+        sourcesView: "add",
+      };
+    case "SET_DRIVE_CONNECTION":
+      return {
+        ...state,
+        driveConnectionId: action.connectionId,
+      };
+    case "FINISH_ADD":
+      return {
+        ...state,
+        sourcesView: "list",
+        driveConnectionId: null,
+      };
+    default:
+      return state;
+  }
+}
+```
+
+**Valid state space (6 states vs current 64 theoretical combinations):**
+
+| State | isOpen | activeTab | sourcesView | activeSourceId |
+|-------|--------|-----------|-------------|----------------|
+| Closed | false | (any) | list | null |
+| Sources List | true | sources | list | null |
+| Source Detail | true | sources | detail | non-null |
+| Source Add | true | sources | add | null |
+| Ask | true | ask | (irrelevant) | null |
+| Clips | true | clips | (irrelevant) | null |
+
+**`use-chapter-sources.ts` -- Removed**
+
+This hook is deleted entirely. The `chapter_sources` table is deprecated. No chapter-level source linking exists in the new design.
+
+All references to `useChapterSources` in the editor page are removed. The `linkedSources`, `onLinkSource`, and `onUnlinkSource` props are removed from `EditorDialogs`.
+
+**New hooks:**
+
+```typescript
+// web/src/hooks/use-research-clips.ts
+export function useResearchClips(projectId: string) {
+  // Returns: clips, isLoading, error, saveClip, deleteClip, fetchClips
+}
+
+// web/src/hooks/use-ai-research.ts
+export function useAIResearch(projectId: string) {
+  // Returns: query, setQuery, submitQuery, isQuerying, results,
+  //          conversation, error, clearConversation
+}
+```
+
+### State Shape
+
+```typescript
+/** Full state model for the Research Panel system */
+interface ResearchPanelFullState {
+  // Panel UI state (managed by useReducer)
+  panel: ResearchPanelState;
+
+  // Sources data (managed by useSources -- existing hook, unchanged)
+  sources: SourceMaterial[];
+  isSourcesLoading: boolean;
+  sourcesError: string | null;
+
+  // Source content (managed by useSourceContent -- existing hook, unchanged)
+  viewerContent: string;
+  viewerWordCount: number;
+  isContentLoading: boolean;
+  contentError: string | null;
+
+  // AI research (managed by useAIResearch -- new hook)
+  conversation: ConversationEntry[];
+  isQuerying: boolean;
+  queryError: string | null;
+
+  // Clips (managed by useResearchClips -- new hook)
+  clips: ResearchClip[];
+  isClipsLoading: boolean;
+  clipsError: string | null;
+}
+
+interface ConversationEntry {
+  id: string;
+  type: "query" | "response";
+  content: string;
+  /** For responses: structured results with citations */
+  results?: AISearchResult[];
+  timestamp: string;
+}
+
+interface AISearchResult {
+  content: string;
+  sourceId: string | null;
+  sourceTitle: string;
+  sourceLocation: string | null;
+  /** Whether this result has been saved as a clip */
+  isSaved: boolean;
+}
+
+interface ResearchClip {
+  id: string;
+  projectId: string;
+  sourceId: string | null;
+  sourceTitle: string;
+  content: string;
+  sourceLocation: string | null;
+  createdAt: string;
+}
+```
+
+---
+
+## 6. API Changes
+
+### Existing Endpoints -- Disposition
+
+| Endpoint | Disposition | Notes |
+|----------|-------------|-------|
+| `POST /projects/:projectId/sources` | **Keep** | Add Drive sources. No changes needed. |
+| `POST /projects/:projectId/sources/upload` | **Modify** | Expand accepted types to include `.docx` and `.pdf` (requires #124 text extraction). |
+| `GET /projects/:projectId/sources` | **Keep** | List project sources. No changes needed. |
+| `GET /sources/:sourceId/content` | **Keep** | Get cached content. No changes needed. |
+| `DELETE /sources/:sourceId` | **Modify** | Add: when deleting a source, set `source_id = NULL` on any `research_clips` that reference it (cascade behavior). |
+| `POST /sources/:sourceId/import-as-chapter` | **Keep** | Import source as chapter. No changes needed. |
+| `GET /chapters/:chapterId/sources` | **Remove** | Chapter-source linking eliminated. |
+| `POST /chapters/:chapterId/sources/:sourceId/link` | **Remove** | Chapter-source linking eliminated. |
+| `DELETE /chapters/:chapterId/sources/:sourceId/link` | **Remove** | Chapter-source linking eliminated. |
+
+### New Endpoints
+
+#### POST /projects/:projectId/research/query
+
+Natural-language query against project sources. Returns structured results with source citations.
+
+```typescript
+// Request
+interface ResearchQueryRequest {
+  query: string;
+  /** Optional: limit search to specific source IDs */
+  sourceIds?: string[];
+}
+
+// Response (SSE stream)
+// Content-Type: text/event-stream
+//
+// event: result
+// data: {"content":"...","sourceId":"...","sourceTitle":"...","sourceLocation":"..."}
+//
+// event: result
+// data: {"content":"...","sourceId":"...","sourceTitle":"...","sourceLocation":"..."}
+//
+// event: done
+// data: {"resultCount":2}
+//
+// event: error
+// data: {"error":"..."}
+
+// Non-streaming fallback (Accept: application/json)
+interface ResearchQueryResponse {
+  results: Array<{
+    content: string;
+    sourceId: string;
+    sourceTitle: string;
+    sourceLocation: string | null;
+  }>;
+  /** Summary text generated by the AI */
+  summary: string;
+  /** Query processing time in ms */
+  processingTimeMs: number;
+}
+```
+
+**Implementation notes:**
+- Collects all source content for the project (from R2 cache).
+- Chunks content per the chunking strategy (see #126, #136).
+- Sends chunks + query to LLM (Workers AI or OpenAI depending on tier).
+- Parses structured response into individual results with citations.
+- Streams results as SSE events for responsive UI.
+- Rate limited: 20 queries per minute per user.
+
+#### GET /projects/:projectId/research/clips
+
+List saved clips for a project.
+
+```typescript
+// Response
+interface ClipsListResponse {
+  clips: Array<{
+    id: string;
+    projectId: string;
+    sourceId: string | null;
+    sourceTitle: string;
+    content: string;
+    sourceLocation: string | null;
+    createdAt: string;
+  }>;
+}
+```
+
+#### POST /projects/:projectId/research/clips
+
+Save a new clip.
+
+```typescript
+// Request
+interface SaveClipRequest {
+  content: string;
+  sourceId?: string;
+  sourceTitle: string;
+  sourceLocation?: string;
+}
+
+// Response (201)
+interface SaveClipResponse {
+  clip: {
+    id: string;
+    projectId: string;
+    sourceId: string | null;
+    sourceTitle: string;
+    content: string;
+    sourceLocation: string | null;
+    createdAt: string;
+  };
+}
+```
+
+**Deduplication:** If a clip with identical `content` + `sourceId` already exists for the project, return the existing clip with 200 (not 201). No duplicate created.
+
+#### DELETE /research/clips/:clipId
+
+Remove a saved clip.
+
+```typescript
+// Response (200)
+interface DeleteClipResponse {
+  success: boolean;
+}
+```
+
+**Authorization:** Clip ownership verified via project membership (clip's `projectId` matched against user's project access).
+
+#### GET /projects/:projectId/research/sources/search
+
+Full-text search across source content (for the Sources tab search field). Distinct from the AI query endpoint -- this is a simpler keyword search.
+
+```typescript
+// Query params: ?q=keyword
+// Response
+interface SourceSearchResponse {
+  results: Array<{
+    sourceId: string;
+    title: string;
+    /** Matching snippet from content */
+    snippet: string;
+    /** Approximate position in the source */
+    position: number;
+  }>;
+}
+```
+
+**Implementation:** Uses D1 FTS5 full-text search on source content stored in a new `source_content_fts` virtual table (see Data Model section). Falls back to LIKE search if FTS is not available.
+
+---
+
+## 7. Data Model Changes
+
+### New Tables
+
+#### research_clips
+
+Stores saved snippets from AI results or manual text selection.
+
+```sql
+-- Migration: 0014_create_research_clips.sql
+
+CREATE TABLE research_clips (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  source_id TEXT REFERENCES source_materials(id) ON DELETE SET NULL,
+  source_title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  source_location TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_research_clips_project ON research_clips(project_id);
+CREATE INDEX idx_research_clips_source ON research_clips(source_id);
+
+-- Dedup: same content + source within a project
+CREATE UNIQUE INDEX idx_research_clips_dedup
+  ON research_clips(project_id, source_id, content)
+  WHERE source_id IS NOT NULL;
+```
+
+**Key decisions:**
+- `source_id` uses `ON DELETE SET NULL` -- when a source is removed, the clip retains its text and `source_title` but loses the source link. This matches the user expectation from Flow 7.
+- `source_title` is stored redundantly (not just as a FK to `source_materials.title`) so that clips display the title even after source removal.
+- `content` is the full snippet text. Maximum size enforced at the API level (10KB per clip).
+- `source_location` stores a human-readable location reference (e.g., "Section 3" or "Near beginning") -- not a byte offset or page number, since source content is plain text extracted from various formats.
+
+#### research_queries (Phase B)
+
+Stores query history for conversation continuity and analytics.
+
+```sql
+-- Migration: 0015_create_research_queries.sql
+
+CREATE TABLE research_queries (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  query TEXT NOT NULL,
+  result_count INTEGER NOT NULL DEFAULT 0,
+  processing_time_ms INTEGER,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_research_queries_project ON research_queries(project_id);
+```
+
+**Key decisions:**
+- Query results are NOT stored in D1. They are ephemeral -- regenerated on each query. This avoids stale results as source content changes.
+- Only the query text and metadata are stored, for conversation history display and analytics.
+- No `response` column -- AI responses are streamed and not persisted. Users save specific results as clips.
+
+#### source_content_fts (Phase A)
+
+Full-text search index for source content.
+
+```sql
+-- Migration: 0016_create_source_content_fts.sql
+
+CREATE VIRTUAL TABLE source_content_fts USING fts5(
+  source_id,
+  title,
+  content,
+  tokenize='porter unicode61'
+);
+
+-- Populated by a trigger on source_materials content caching
+-- (or explicitly after text extraction completes)
+```
+
+**Key decisions:**
+- D1 supports FTS5 virtual tables. This enables fast keyword search in the Sources tab without requiring a vector database.
+- The FTS table is populated when source content is cached (after text extraction). It is rebuilt when content is refreshed.
+- This is NOT used for AI queries -- AI queries use the full source text sent to the LLM. FTS is for the simpler Sources tab search.
+
+### Modifications to Existing Tables
+
+#### source_materials
+
+No schema changes to `source_materials`. However, the text extraction service (issue #124) will populate `r2_key` and `cached_at` for `.docx` and `.pdf` files in addition to the existing Google Docs support.
+
+#### chapter_sources (deprecated)
+
+```sql
+-- Migration: 0017_deprecate_chapter_sources.sql
+
+-- No schema changes. Table is preserved for data integrity and potential rollback.
+-- Application code stops writing to this table.
+-- A future migration (after 90 days) can DROP the table.
+
+-- Add a comment column to mark deprecation
+-- (SQLite doesn't support table comments, so this is documentation only)
+```
+
+The `chapter_sources` table is **not dropped** in the initial migration. The table remains with its existing data. The three API endpoints that read/write it are removed. After 90 days with no issues, a follow-up migration drops the table.
+
+### R2 Storage Patterns
+
+| Data | Storage | Key Pattern | Notes |
+|------|---------|-------------|-------|
+| Source content (cached) | R2 (`dc-exports`) | `sources/{sourceId}/content.html` | Existing pattern, unchanged |
+| Source content (plain text for AI) | R2 (`dc-exports`) | `sources/{sourceId}/content.txt` | New: plain text version for AI queries and FTS |
+| Uploaded local files (original) | R2 (`dc-exports`) | `sources/{sourceId}/original.{ext}` | Existing for .txt/.md, extended for .docx/.pdf |
+
+**Key decisions:**
+- Source content is stored in R2 in two formats: HTML (for display in the viewer) and plain text (for AI queries and FTS indexing). The plain text version is generated during text extraction.
+- Clips are stored in D1 only (text content). They do not use R2 since they are short text excerpts (< 10KB).
+- AI query results are not stored in R2. They are ephemeral.
+
+---
+
+## 8. Backlog Issue Mapping
+
+### Issue #121: Authorize Google Drive access for source file reading
+
+- **Disposition:** Keep
+- **Phase:** Phase A (Foundation)
+- **Notes:** Existing Drive OAuth flow is unchanged. The Research Panel's Sources tab uses the same `useDriveAccounts` hook. No modifications needed to this issue.
+
+### Issue #122: Select specific Google Drive folders/files for AI search scope
+
+- **Disposition:** Rewrite
+- **Phase:** Phase A (Foundation)
+- **New title:** "Select Google Drive files as project sources via inline Drive browser"
+- **New description:** As a user, I want to browse my Google Drive within the Research Panel's Sources tab and select files to add as project sources. The Drive browser appears inline within the Sources tab (not as a separate sheet), replacing the source list while browsing. I can navigate folders, select multiple files via checkboxes, and add them in a single action.
+- **New ACs:**
+  - [ ] "Add" button in Sources tab header opens inline add flow
+  - [ ] Add flow shows connected Drive accounts and "Upload from device" option
+  - [ ] Selecting a Drive account opens an inline folder browser
+  - [ ] Folder browser shows folders (navigable) and Google Docs (selectable via checkbox)
+  - [ ] "Add N Selected" button adds all checked files as project sources
+  - [ ] After adding, view returns to source list showing new sources
+  - [ ] Files already in the project show a "Already added" indicator and disabled checkbox
+  - [ ] All touch targets minimum 44pt
+  - [ ] Back navigation at every level (no dead ends)
+- **Dependencies:** #121 (Drive auth)
+
+### Issue #123: Upload local files for AI search scope
+
+- **Disposition:** Rewrite
+- **Phase:** Phase A (Foundation)
+- **New title:** "Upload local files (.txt, .md, .docx, .pdf) as project sources"
+- **New description:** As a user, I want to upload files from my device as project sources via the Research Panel's Sources tab add flow. The upload option appears alongside Drive accounts in the add flow. Selecting it opens the system file picker. Uploaded files are processed and appear in the source list.
+- **New ACs:**
+  - [ ] "Upload from device" option in the Source Add Flow
+  - [ ] System file picker accepts `.txt`, `.md`, `.docx`, `.pdf`
+  - [ ] Uploaded file appears in source list with "Processing..." status
+  - [ ] After text extraction completes, source shows word count and "Cached" status
+  - [ ] File size limit: 5MB (error message for larger files)
+  - [ ] Unsupported file types show clear error message
+- **Dependencies:** #124 (text extraction for .docx/.pdf)
+
+### Issue #124: Backend text extraction service for .docx, .pdf, .txt
+
+- **Disposition:** Keep
+- **Phase:** Phase A (Foundation)
+- **Notes:** Unchanged. This is backend infrastructure required for local file upload (.docx, .pdf) and for generating plain-text versions of all sources for AI queries. Add requirement: extracted text must also be stored in R2 as `.txt` alongside the HTML version, and indexed in `source_content_fts`.
+- **New dependency note:** FTS indexing is part of this issue (populate `source_content_fts` after extraction).
+
+### Issue #125: API endpoint for natural language queries against source documents
+
+- **Disposition:** Rewrite
+- **Phase:** Phase B (AI Integration)
+- **New title:** "POST /projects/:projectId/research/query -- AI natural language query endpoint"
+- **New description:** As the Ask tab frontend, I need a secure API endpoint that accepts a user's natural language query and returns structured results with source citations, streamed as SSE events. The endpoint collects all project source content, chunks it, sends it with the query to the LLM, and parses the response into individual cited results.
+- **New ACs:**
+  - [ ] Endpoint accepts `{ query: string, sourceIds?: string[] }`
+  - [ ] Collects source content from R2 (plain text versions)
+  - [ ] Applies chunking strategy per #126
+  - [ ] Sends to LLM (Workers AI or OpenAI per project tier setting)
+  - [ ] Streams results as SSE events (`event: result`, `event: done`, `event: error`)
+  - [ ] Each result includes `content`, `sourceId`, `sourceTitle`, `sourceLocation`
+  - [ ] Rate limited: 20 queries/minute/user
+  - [ ] Saves query metadata to `research_queries` table
+  - [ ] Returns 400 if project has no sources with cached content
+  - [ ] Non-streaming fallback for `Accept: application/json`
+- **Dependencies:** #124 (text extraction), #126 (chunking), #134 (prompt engineering spike)
+
+### Issue #126: Chunk source text and build effective LLM prompts
+
+- **Disposition:** Keep
+- **Phase:** Phase B (AI Integration)
+- **Notes:** Unchanged. The chunking strategy feeds directly into the research query endpoint (#125). Output of spike #136 informs the approach.
+- **Dependencies:** #136 (chunking strategy spike)
+
+### Issue #127: Parse LLM responses into structured snippet list with source references
+
+- **Disposition:** Keep
+- **Phase:** Phase B (AI Integration)
+- **Notes:** Unchanged. The structured parsing is used by the research query endpoint to produce `ResultCard`-ready data. Output of spike #134 informs the prompt/response format.
+- **Dependencies:** #134 (prompt engineering spike)
+
+### Issue #128: Research Assistant side panel with toolbar toggle
+
+- **Disposition:** Rewrite
+- **Phase:** Phase A (Foundation) -- panel infrastructure ships first; Ask tab content ships in Phase B
+- **New title:** "Research Panel with tab navigation and toolbar toggle"
+- **New description:** As a user, I want a Research icon in the editor toolbar that toggles a right-hand panel containing three tabs: Sources, Ask, and Clips. In landscape orientation (1024pt+), the panel opens as a side-by-side view alongside the editor (340pt wide). In portrait orientation, it opens as an 85% overlay from the right. The panel replaces the current SourcesPanel, AddSourceSheet, DriveBrowserSheet, and SourceViewerSheet.
+- **New ACs:**
+  - [ ] Research icon in editor toolbar toggles panel open/close
+  - [ ] Panel has three tabs: Sources, Ask, Clips
+  - [ ] Keyboard shortcut: Cmd+Shift+R toggles panel
+  - [ ] Escape closes panel
+  - [ ] Landscape: panel is 340pt, pushes editor (editor min 400pt)
+  - [ ] Portrait: panel is 85% overlay with backdrop
+  - [ ] Panel uses `100dvh` and `env(safe-area-inset-*)`
+  - [ ] Tab state persists while panel is open (switching tabs doesn't reset)
+  - [ ] `prefers-reduced-motion` disables slide animations
+  - [ ] Panel does not break editor auto-save
+  - [ ] All text minimum 16px
+  - [ ] `ResearchPanelProvider` context encapsulates all panel state
+  - [ ] EditorDialogsProps reduced by ~50 source-related props
+- **Dependencies:** None (pure frontend infrastructure)
+
+### Issue #129: Research query input with loading state and result cards
+
+- **Disposition:** Rewrite
+- **Phase:** Phase B (AI Integration)
+- **New title:** "Ask tab with query input, streaming results, and result cards"
+- **New description:** As a user, I want a text input in the Ask tab where I can type natural-language questions about my source documents. After submitting, I see a loading state followed by streaming result cards with cited passages. Each result card has "Save to Clips" and "Insert" actions.
+- **New ACs:**
+  - [ ] Query input at bottom of Ask tab (chat-pattern layout)
+  - [ ] Send button (44pt minimum) and Cmd+Return keyboard shortcut
+  - [ ] Empty state shows suggested queries (tappable)
+  - [ ] Loading state: skeleton loader with "Searching across N sources..."
+  - [ ] Results stream in as SSE events
+  - [ ] Each ResultCard shows: passage text, source title (tappable), source location
+  - [ ] "Save to Clips" action on each card (updates to "Saved" checkmark)
+  - [ ] "Insert" action on each card (inserts at editor cursor with footnote)
+  - [ ] Error state: "Something went wrong" with Retry button
+  - [ ] No-results state: helpful message with suggestions
+  - [ ] Conversation history persists within session (multiple Q&A pairs)
+  - [ ] Input minimum 16px font size (prevents iOS zoom)
+- **Dependencies:** #125 (query endpoint), #128 (panel infrastructure)
+
+### Issue #130: Click source filename to preview original document at snippet location
+
+- **Disposition:** Rewrite
+- **Phase:** Phase B (AI Integration)
+- **New title:** "Tappable source citations in AI results and clips that navigate to source detail"
+- **New description:** As a user, when I see a source title in an AI result card or a clip card, I want to tap it and be taken to the full source document in the Sources tab, ideally scrolled near the cited passage.
+- **New ACs:**
+  - [ ] Source title in ResultCard and ClipCard is a tappable link
+  - [ ] Tapping navigates to Sources tab > Source Detail View for that source
+  - [ ] If `sourceLocation` is available, the detail view scrolls to the approximate position
+  - [ ] If `sourceLocation` is null, the detail view opens at the top
+  - [ ] Back navigation returns to the previous tab (Ask or Clips)
+  - [ ] Minimum 44pt tap target on source title link
+- **Dependencies:** #128 (panel infrastructure), #137 (preview component)
+
+### Issue #131: Add selected snippets to Research Board
+
+- **Disposition:** Rewrite
+- **Phase:** Phase C (Board + Editor)
+- **New title:** "Save snippets to Clips from AI results and source text selection"
+- **New description:** As a user, I want to save useful passages to my Clips collection from two paths: (1) tapping "Save to Clips" on an AI result card, and (2) selecting text in the Source Detail View and choosing "Save to Clips" from a floating toolbar.
+- **New ACs:**
+  - [ ] "Save to Clips" button on each AI ResultCard
+  - [ ] Button changes to "Saved" checkmark after saving
+  - [ ] Duplicate detection: same content + source does not create a second clip
+  - [ ] Long-press text selection in Source Detail View shows "Save to Clips" floating action
+  - [ ] Saved clip includes: content, sourceId, sourceTitle, sourceLocation
+  - [ ] Clips tab badge updates to show new count
+  - [ ] Toast notification on successful save
+  - [ ] API: POST /projects/:projectId/research/clips
+- **Dependencies:** #128 (panel infrastructure), #125 (for AI result saving path)
+
+### Issue #132: View and manage collected snippets on Research Board
+
+- **Disposition:** Rewrite
+- **Phase:** Phase C (Board + Editor)
+- **New title:** "Clips tab for viewing, searching, and managing saved snippets"
+- **New description:** As a user, I want to view all my saved clips in the Clips tab, search across them, and delete clips I no longer need. Clips are displayed as cards with their text, source reference, and action buttons.
+- **New ACs:**
+  - [ ] Clips tab shows all saved clips, most recent first
+  - [ ] Each ClipCard shows: snippet text (truncated at 300 chars with "Show more"), source title (tappable), save date
+  - [ ] Search field filters clips by text content and source title
+  - [ ] Delete action with swipe-left or overflow menu (no modal confirmation for clips)
+  - [ ] Empty state: "No clips yet" with guidance text
+  - [ ] Source title tappable -- navigates to Sources tab > detail view
+  - [ ] Clips with removed sources show "[Source removed]" in gray
+  - [ ] API: GET /projects/:projectId/research/clips, DELETE /research/clips/:clipId
+- **Dependencies:** #131 (save clips)
+
+### Issue #133: Drag-and-drop snippets from Research Board into editor with auto-footnotes
+
+- **Disposition:** Rewrite
+- **Phase:** Phase C (Board + Editor)
+- **New title:** "Insert clips into editor with automatic footnote creation"
+- **New description:** As a user, I want to insert a saved clip into my chapter at the current cursor position. The inserted text is wrapped in a blockquote, and a footnote is automatically created referencing the source document. Insertion is via an "Insert" button on the clip card (not drag-and-drop, which is unreliable on iPad Safari).
+- **New ACs:**
+  - [ ] "Insert" button on each ClipCard and ResultCard
+  - [ ] Tapping Insert: focuses editor, inserts blockquote at cursor position
+  - [ ] Footnote auto-created with source title as reference text
+  - [ ] If no cursor position, text appended to end of chapter
+  - [ ] Success toast: "Inserted with footnote"
+  - [ ] Insert button disabled when no chapter selected or editor loading
+  - [ ] Tiptap footnote extension created (new Tiptap node type)
+  - [ ] Footnotes rendered at bottom of chapter content
+  - [ ] Undo (Cmd+Z) removes the inserted blockquote and footnote together
+  - [ ] Inserted text participates in Drive write-through (auto-saves normally)
+  - [ ] **NOT** drag-and-drop (iPad Safari limitation). Button-only insertion.
+- **Dependencies:** #131, #132, Tiptap footnote extension (new sub-task)
+
+### Issue #134: SPIKE: LLM prompt engineering for structured snippet output
+
+- **Disposition:** Keep
+- **Phase:** Pre-Phase B (spike)
+- **Notes:** Unchanged. Output directly informs #125 and #127.
+- **Dependencies:** None
+
+### Issue #135: SPIKE: Document parsing library evaluation for .pdf and .docx
+
+- **Disposition:** Keep
+- **Phase:** Pre-Phase A (spike)
+- **Notes:** Unchanged. Output directly informs #124.
+- **Dependencies:** None
+
+### Issue #136: SPIKE: Content chunking strategy and context window management
+
+- **Disposition:** Keep
+- **Phase:** Pre-Phase B (spike)
+- **Notes:** Unchanged. Output directly informs #126.
+- **Dependencies:** None
+
+### Issue #137: SPIKE: File preview UI component with scroll-to-position
+
+- **Disposition:** Rewrite
+- **Phase:** Phase A (Foundation)
+- **New title:** "SPIKE: Source content renderer with scroll-to-position for Research Panel"
+- **New description:** Build a proof-of-concept for the Source Detail View component that renders source content (extracted text/HTML) within the Research Panel's 340pt width, supports text selection, and can scroll to an approximate text position. Test with real source content of varying lengths (500 - 10,000+ words). Evaluate performance on iPad Safari.
+- **New ACs:**
+  - [ ] Renders HTML content in a scrollable container
+  - [ ] Supports programmatic scroll to a text position (for #130 citation links)
+  - [ ] Text selection works on iPad (long-press)
+  - [ ] Performance acceptable for 10,000+ word documents on iPad Safari
+  - [ ] In-document search field (Cmd+F equivalent) for long documents
+  - [ ] Minimum 16px text size
+- **Dependencies:** None
+
+### Phase Assignment Summary
+
+| Issue | Phase | Disposition |
+|-------|-------|-------------|
+| #121 | A | Keep |
+| #122 | A | Rewrite |
+| #123 | A | Rewrite |
+| #124 | A | Keep (extend) |
+| #125 | B | Rewrite |
+| #126 | B | Keep |
+| #127 | B | Keep |
+| #128 | A | Rewrite |
+| #129 | B | Rewrite |
+| #130 | B | Rewrite |
+| #131 | C | Rewrite |
+| #132 | C | Rewrite |
+| #133 | C | Rewrite |
+| #134 | Pre-B | Keep |
+| #135 | Pre-A | Keep |
+| #136 | Pre-B | Keep |
+| #137 | A | Rewrite |
+
+---
+
+## 9. Implementation Phases
+
+### Phase A: Foundation (Sources Tab + Panel Infrastructure)
+
+**What ships:**
+The Research Panel with full Sources tab functionality. The panel replaces all existing source management UI. The Ask tab and Clips tab exist as tabs but show "Coming soon" placeholder content. This phase delivers immediate value by fixing the sheet-stacking UX, eliminating chapter-source linking confusion, and providing the panel infrastructure for Phases B and C.
+
+**Components:**
+- `ResearchPanel` (container + tab navigation)
+- `ResearchPanelProvider` (context)
+- `SourcesTab` (source list + search)
+- `SourceCard` (source row)
+- `SourceAddFlow` (inline Drive browser + upload)
+- `SourceDetailView` (inline content viewer)
+- `QueryInput` (reusable -- used for source search in Phase A, AI query in Phase B)
+- Ask tab placeholder ("Coming soon" with description of what it will do)
+- Clips tab placeholder ("Coming soon" with description of what it will do)
+
+**API changes:**
+- Remove 3 chapter-source endpoints
+- Add `GET /projects/:projectId/research/sources/search` (source text search)
+- Modify `POST /projects/:projectId/sources/upload` to accept `.docx` and `.pdf` (depends on #124)
+- Modify `DELETE /sources/:sourceId` to handle future clip references (add `ON DELETE SET NULL` readiness)
+
+**Database changes:**
+- Migration 0014: `research_clips` table (created early, used in Phase C)
+- Migration 0016: `source_content_fts` virtual table
+- Migration 0017: `chapter_sources` deprecation note
+
+**What the user sees:**
+- A "Research" button in the toolbar replaces the current "Sources" action
+- Tapping it opens a right-hand panel with three tabs
+- Sources tab: same source list as before, but with search, inline Drive browser, and inline content viewer -- no more sheet stacking
+- Ask and Clips tabs: placeholder content explaining what's coming
+- All chapter-source link/unlink UI is gone
+- Source viewing works side-by-side with the editor in landscape
+
+**Estimated scope:** 2-3 weeks for one developer
+- Week 1: ResearchPanel, ResearchPanelProvider, SourcesTab (list + search), SourceCard. Remove old components. Remove chapter-source endpoints. Migrate EditorDialogs.
+- Week 2: SourceAddFlow (inline Drive browser), SourceDetailView (inline viewer). Source content FTS. Panel layout (landscape side-by-side, portrait overlay).
+- Week 3: Polish, iPad testing, accessibility audit, edge cases.
+
+**Risks:**
+- The SourceAddFlow (inline Drive browser) reuses the existing `useDriveBrowser` hook but renders inline instead of as a sheet. The hook may need minor adjustments for the inline context.
+- Removing chapter-source linking is a breaking change for any users who have linked sources. Since this is Phase 0 with very few users, the risk is acceptable. A migration note should be displayed to affected users.
+
+---
+
+### Phase B: AI Integration (Ask Tab)
+
+**What ships:**
+The Ask tab becomes functional with AI-powered natural-language queries across project sources. Users can ask questions and receive structured results with source citations. "Save to Clips" is available on result cards (creates the clip but the Clips tab gets full functionality in Phase C). Source citation links navigate to the Source Detail View.
+
+**Components:**
+- `AskTab` (full implementation)
+- `ResultCard` (AI search result display)
+- `SnippetInsertButton` (reusable insert action)
+
+**API changes:**
+- Add `POST /projects/:projectId/research/query` (AI query with SSE streaming)
+- Add `POST /projects/:projectId/research/clips` (save clip -- simple version)
+- Add `GET /projects/:projectId/research/clips` (list clips -- for Clips tab badge count)
+- Migration 0015: `research_queries` table
+
+**Database changes:**
+- Migration 0015: `research_queries` table
+
+**Dependencies on spikes:**
+- #134 (prompt engineering) must be completed. The prompt format and expected response structure inform the query endpoint implementation.
+- #135 (document parsing) must be completed. AI queries require plain-text source content.
+- #136 (chunking strategy) must be completed. The chunking approach determines how source content is prepared for the LLM context window.
+
+**What the user sees:**
+- Ask tab is now functional (replaces "Coming soon" placeholder)
+- User types a question, sees a loading state, then receives results with source citations
+- Each result shows the relevant passage and which source document it came from
+- "Save to Clips" button on each result
+- Source titles are tappable and navigate to the full source document
+- Conversation history within the session (multiple queries)
+- Clips tab badge shows count of saved clips (full Clips tab UI ships in Phase C)
+
+**Estimated scope:** 3-4 weeks for one developer
+- Week 1: Research query endpoint (chunking + LLM integration + response parsing). SSE streaming.
+- Week 2: AskTab UI (QueryInput, ResultCard, conversation view). Empty states, error states, loading states.
+- Week 3: Save-to-clips API + frontend integration. Source citation navigation (link from ResultCard to SourceDetailView).
+- Week 4: Polish, performance testing (query latency), iPad testing, edge cases (large source libraries, long responses).
+
+**Risks:**
+- AI query quality is the existential risk. Both personas identified this as the deal-breaker. If results are inaccurate, incorrectly cited, or hallucinated, users will abandon the feature. The spike outputs (#134, #136) must produce reliable approaches before Phase B begins.
+- SSE streaming on Cloudflare Workers has specific constraints (no long-lived connections). The endpoint must stream and close within Workers' execution time limits.
+- Performance with large source libraries (Marcus's 100+ docs) requires testing. The chunking strategy must handle this scale within LLM context window limits.
+
+---
+
+### Phase C: Board + Editor Integration (Clips Tab)
+
+**What ships:**
+The Clips tab becomes fully functional. Users can view, search, and manage their saved clips. The "Insert" action on clips and AI results inserts text into the editor with automatic footnote creation. The Tiptap footnote extension is built.
+
+**Components:**
+- `ClipsTab` (full implementation)
+- `ClipCard` (saved snippet display)
+- `SnippetInsertButton` (full implementation with editor integration)
+- Tiptap footnote extension (new Tiptap node type for footnotes)
+- Footnote rendering in chapter content
+
+**API changes:**
+- Add `DELETE /research/clips/:clipId` (delete clip)
+- The save and list endpoints were added in Phase B
+
+**Database changes:**
+- None (all tables created in earlier phases)
+
+**What the user sees:**
+- Clips tab is now functional (replaces placeholder)
+- All saved clips displayed as cards with text, source reference, and timestamp
+- Search field filters clips
+- Delete action removes clips
+- "Insert" button inserts clip text as a blockquote with an automatic footnote
+- Footnotes appear at the bottom of the chapter
+- Undo removes the inserted content and footnote together
+- Insert works from both Clips tab and Ask tab result cards
+
+**Estimated scope:** 2-3 weeks for one developer
+- Week 1: ClipsTab UI (ClipCard, search, delete). Tiptap footnote extension (new node type).
+- Week 2: Insert action (editor focus, cursor position, blockquote + footnote insertion). Undo integration. Drive write-through compatibility.
+- Week 3: Polish, iPad testing (especially text selection and insertion flow), accessibility audit, edge cases.
+
+**Risks:**
+- The Tiptap footnote extension is non-trivial. Footnotes must be rendered in the editor, survive serialization to HTML (for Drive write-through), and participate in undo/redo. This may require 1-2 additional days of investigation.
+- Cursor position management between the editor and the Research Panel is tricky on iPad. The editor must track its last cursor position even when focus moves to the Research Panel. Tiptap's `editor.state.selection` provides this, but it must be tested thoroughly on iPad Safari.
+- Insert action must not break the three-tier save architecture (local, R2, Drive). The inserted content is just Tiptap content and flows through the existing save pipeline, but the footnote node type must be handled in the HTML serializer.
+
+---
+
+## Appendix: Design Constraints Checklist
+
+| Constraint | How Addressed |
+|------------|---------------|
+| iPad Safari is primary test target | All layouts tested at iPad Air, Pro, and Mini dimensions. Portrait/landscape both specified. |
+| 44pt minimum touch targets | All buttons, checkboxes, tap areas specified at minimum 44pt. Source cards 56pt height. |
+| No hover-dependent interactions | All actions use tap/press. Swipe-to-reveal has button fallback. No tooltips as sole discovery mechanism. |
+| `100dvh` not `100vh` | Panel and overlay use `100dvh` for Safari address bar compatibility. |
+| `env(safe-area-inset-*)` | Panel positioning uses safe area insets. Specified in CSS section. |
+| Editor content area >= 400pt | Enforced in layout spec. If panel would violate, portrait overlay mode is used instead of side-by-side. |
+| Portrait mode: overlay, not side-by-side | Explicitly specified. Portrait < 1024pt triggers overlay mode. |
+| External keyboard shortcuts | Cmd+Shift+R (panel toggle), Escape (close), Cmd+Return (submit query). Specified per flow. |
+| All text >= 16px | Input fields, card content, source content all minimum 16px. Prevents iOS auto-zoom. |
+| `prefers-reduced-motion` | All slide/fade animations disabled. Instant transitions. Specified per component. |
+| Three-tier save architecture | Insert action produces standard Tiptap content. Footnotes serialize to HTML. No new save paths needed. |

--- a/docs/design/source-review/03b-stress-test.md
+++ b/docs/design/source-review/03b-stress-test.md
@@ -1,0 +1,720 @@
+# Phase 3b: User Stress Test
+
+> DraftCrane Source/Research UX Redesign
+> Persona-based stress test of the Detailed Interaction Design (Option B: "Research Companion")
+> Date: 2026-02-19
+
+---
+
+## Part 1: Flow-by-Flow Walkthrough
+
+*All walkthroughs written in first person as Diane Mercer unless otherwise noted.*
+
+---
+
+### Flow 1: Add Source from Google Drive
+
+**Precondition check:** The flow says "Research Panel is open with Sources tab active." Okay, but how did I get here? I'm looking at the editor for the first time. I see a "Research" button in the toolbar. I tap it. A panel slides in from the right. It has three tabs at the top: Sources, Ask, Clips. Sources is selected by default. I see an empty list and a [+ Add] button. So far, so good -- the button is the obvious next thing to tap.
+
+**Step 1: Tap [+ Add].**
+I see it in the Sources tab header. It's right there next to the search field. I tap it. Clear.
+
+**Step 2: Source Add Flow replaces the source list.**
+The list smoothly transitions to show my connected Google accounts. I see "scott@email.com -- Browse Google Drive" and below it "Upload from device." This is clear. I know my stuff is in Google Drive. I also notice it says "FROM GOOGLE DRIVE" as a section header. That's helpful -- it tells me what I'm looking at.
+
+**Step 3: Tap my Google account.**
+I have one account. I tap it. No confusion here.
+
+**Step 4: Drive browser appears inline.**
+Now I see my folders. Research/, Interviews/, External Data/. Below the folders, I see loose files. This looks like my Drive -- same folder names, same files. There are checkboxes next to the files.
+
+**Hesitation point:** I see a [Search files...] field at the top. That's good -- if I had a lot of files I'd want that. But right now I'm just browsing. I navigate into "Interviews/" (one tap), I see my files. I check two of them.
+
+**Step 5-6: Select files.**
+The checkboxes are clear. I tap "Interview-Smith.doc" and "Client-Notes.doc." Each gets a checkmark. I see files I already added are grayed out with "Already added" -- nice, I won't accidentally add duplicates.
+
+**Step 7: Tap "Add 2 Selected."**
+A big button at the bottom. Full width. Hard to miss. I tap it.
+
+**Step 8: Back to source list.**
+The view transitions back to my source list. I see the two new sources with "Processing..." spinners. After a few seconds, they show word counts and "Cached" status.
+
+**The back navigation:** One thing I want to call out -- the [< Sources] back button at the top left is how I get back to my source list from the add flow. I notice it says "< Sources" -- I assume that means "back to the Sources list." That tracks.
+
+**Where I did NOT get confused:** I never left the Sources tab. I never had a sheet open on top of another sheet. I never lost track of where I was. The flow stayed in one panel the whole time.
+
+**Rating: GREEN**
+
+This felt natural. The [+ Add] button was obvious. The Drive browser looked like my Drive. The checkboxes were clear. The "Add Selected" button was prominent. I never felt lost. The inline replacement pattern -- where the source list becomes the add flow and then becomes the source list again -- is intuitive. It feels like navigating *within* a panel, not opening new windows on top of each other.
+
+The one minor concern: if I had *no* Google accounts connected, would I know to connect one? The design says it shows a "Connect Google Account" button in that case. Fine. But I'd need to have connected my account during initial setup before any of this makes sense. That's a separate flow I'm trusting works.
+
+---
+
+### Flow 2: Add Source from Local Device
+
+**Step 1: Tap [+ Add] in Sources tab.**
+Same as before. Clear.
+
+**Step 2-3: Source Add Flow, tap "Upload file."**
+I see "FROM DEVICE" with an "Upload file" option that shows accepted types: ".txt .md .docx .pdf." I tap it.
+
+**Hesitation point:** I know what .pdf is. I know what .docx is (that's Word, right?). I don't know what .txt or .md are. Not a problem -- I wouldn't have those files anyway. I just need to know that my Word documents and PDFs are accepted. The fact that the accepted types are listed is actually reassuring. I know what I can bring in.
+
+**Step 4-5: System file picker.**
+iPadOS's file picker opens. This I know. This is Apple's own interface. I navigate to the file, tap it.
+
+**Step 6: Back to source list.**
+The picker closes. I see my new source with "Processing..." spinner. Done.
+
+**Rating: GREEN**
+
+Even simpler than Drive because the system file picker is something I already use. The only thing I'd note: will most of my files be in Google Drive, not on my device? Probably. So this is a backup path. But it's clean and works.
+
+One wish: I wish I could add a Google Doc by pasting a link. Like, if I'm looking at a Google Doc in Safari and I want to add it to DraftCrane, I'd love to just copy the URL and paste it somewhere. The current design requires me to browse through Drive's folder structure to find the file. That's fine for most cases but sometimes I already have the doc open.
+
+---
+
+### Flow 3: View a Source While Writing
+
+**Step 1: Tap a source card.**
+I'm in the Sources tab. I see my list of sources. I tap "Interview-Smith.doc."
+
+**Step 2: Source Detail View appears.**
+The source list slides away and I see the full content of the document. At the top: "< Sources" back button, the filename, word count, and when it was cached. Below: the actual text of my interview notes.
+
+**This is the critical moment:** In landscape mode on my iPad Pro, I can see the editor AND the source content side by side. Left side: my chapter. Right side: my source document. I'm reading my interview notes while my chapter sits right there. I can glance back and forth.
+
+This is what I've been wanting. This is the upgrade from having two Safari tabs. The source content is right beside my writing. I don't have to switch anything. I don't have to remember what I was writing.
+
+**Step 3: Reading the source.**
+I scroll through the source content. It's a long document. I'm scanning for a specific stat. The design says that for documents over 10,000 words, a "Search within document" field appears. Mine is 1,240 words so no search field. I scroll and find what I'm looking for.
+
+**Concern:** For my longer documents -- I have a few that are 5,000+ words -- I might want that search field even at 5,000 words. Scrolling through 5,000 words looking for one sentence is tedious. The 10,000-word threshold feels high. I'd lower it to maybe 2,000 words, or just always show it.
+
+**Step 4: Tap "< Sources" to go back.**
+I'm done reading. I tap the back button. The source list reappears. My place in my chapter hasn't changed.
+
+**Portrait mode concern:** The design says in portrait mode, the Research Panel is an overlay covering 85% of the screen. So I can't see my editor while viewing a source. I'd be reading the source, then closing the panel, then writing, then opening the panel again. That back-and-forth is the same problem I have with two Safari tabs. In portrait mode, this flow is significantly less useful.
+
+But -- I use my iPad Pro 12.9" in landscape most of the time with my Smart Keyboard. So for me, landscape is the default. In landscape, this is great.
+
+**Rating: GREEN**
+
+In landscape mode, this is a genuine improvement over my current workflow. Side-by-side viewing with one tap to open a source. The inline replacement (list becomes detail, then back to list) keeps me oriented. I always know where I am.
+
+The portrait mode limitation is real but I'm rating this for my primary usage, which is landscape. I'd give portrait mode alone a YELLOW.
+
+---
+
+### Flow 4: Search Sources with Natural Language Query
+
+**Step 1: Tap the "Ask" tab.**
+I see three tabs at the top: Sources, Ask, Clips. I tap "Ask."
+
+**First impression:** The tab opens and I see... space. A lot of empty space. Then at the very bottom, a text field: "Ask about your sources..." And above the empty space, some suggested queries:
+
+- "What data do I have on..."
+- "Summarize my notes about..."
+- "Find quotes about..."
+
+**Emotional reaction:** This is the moment. Right here. I read "Ask about your sources" and I think -- can I really just ask it a question? About MY documents? The ones I just added? I feel a flutter of something between excitement and skepticism. I've used ChatGPT enough to know that AI can be impressive and also confidently wrong. Let me try.
+
+**Step 2-3: Tap the input, type a question.**
+I tap the text field. My keyboard comes up. I type: "What did my workshop notes say about psychological safety?"
+
+**iPad keyboard consideration:** When the keyboard appears, the design says the conversation area scrolls up and the input stays above the keyboard. This follows the iMessage pattern. Good -- I know this pattern. The input doesn't get hidden behind the keyboard. I can see what I'm typing.
+
+**Step 4: Tap Send.**
+I tap the arrow button next to the input field. A loading indicator appears. "Searching across 6 sources..."
+
+**Step 5: Results appear.**
+The AI responds with two result cards. The first one says:
+
+> "Psychological safety was the strongest predictor of team performance, with 67% of teams reporting measurable improvement."
+>
+> -- Workshop Notes March 2024
+
+I stare at this. It found the exact quote. From the right document. It's telling me which document it came from. Below the quote, there are two buttons: "Save to Clips" and "Insert."
+
+**Emotional reaction:** I feel a rush. This is what I've been wanting. I have 30+ Google Docs and I've been searching through them manually for three years. This just found the exact passage I needed in seconds. If this works consistently, this tool is worth whatever it costs.
+
+**The second result** is from a different document -- Q4-Report.doc. It found a related passage about psychological safety from a completely different source. I didn't even remember that document had this information. That's... genuinely useful. Cross-document discovery.
+
+**Skepticism check:** But is the quote accurate? Did it actually say "67%" or did the AI make that up? I'd want to verify. I see the source title "Workshop Notes March 2024" -- can I tap it? The design for Flow 4 doesn't explicitly say the source title is tappable in the result cards, but Flow 5 and the ResultCard component spec say source titles are tappable links. So yes, I could tap it and go verify. That's important.
+
+**Follow-up query:** The input field now says "Ask a follow-up..." I can ask another question. The conversation stays on screen -- my first question and its results are scrolled up above, and I can ask more. This is familiar from ChatGPT.
+
+**Rating: GREEN**
+
+This is the feature that makes DraftCrane worthwhile. The suggested queries give me a starting point. The results are structured with source citations. I can verify. I can save. I can ask follow-ups. The keyboard handling follows a familiar pattern. The loading state tells me what's happening.
+
+The one risk -- and this is a BIG one -- is if the AI gives bad answers in practice. My rating is GREEN for the *interaction design*. The interaction is intuitive and clear. Whether the AI behind it actually works is a quality question, not a design question. If the AI hallucinates, no amount of good design will save it. But the design itself is right.
+
+---
+
+### Flow 5: Save a Snippet from Search Results
+
+**Path A: Save from AI result (1 tap)**
+
+**Step 1: Tap "Save to Clips."**
+I'm looking at the AI result card from my previous search. I see the "Save to Clips" button. I tap it.
+
+**Step 2: Feedback.**
+The button changes to a checkmark with "Saved." The Clips tab up top now shows "(1)" next to it. Something was saved somewhere.
+
+**Hesitation point:** "Clips." What are clips? This is the first time I'm really thinking about it. I saved something "to Clips." Is that like a clipboard? Like a scrapbook? I think... it's a collection of things I've saved? The word "clips" makes me think of video clips or newspaper clippings. Newspaper clippings -- that's actually the right metaphor. I'm clipping passages from my sources. Okay, I can work with that. It took me a beat, but I get it.
+
+**Path B: Save from Source Detail View (2-3 taps)**
+
+**Step 1: Long-press to select text.**
+I'm reading a source document in the Source Detail View. I find a passage I like. I long-press on it. The standard iOS text selection handles appear.
+
+**Step 2: Adjust selection.**
+I drag the handles to select the exact passage I want. This is standard iOS text selection. I know how to do this.
+
+**Step 3: Floating toolbar appears.**
+Above my selection, a toolbar pops up. It shows the standard "Copy" option AND a "Save to Clips" option. The DraftCrane option is right there next to the system option.
+
+**Step 4: Tap "Save to Clips."**
+I tap it. A toast pops up: "Saved to Clips." The Clips tab badge increments.
+
+**Hesitation point (Path B):** The long-press to select text is fine -- I do this all the time. But will I *discover* the "Save to Clips" option in the floating toolbar? The design says it appears alongside the system "Copy" action. If it's in the standard iOS cut/copy/paste toolbar, I'll see it because I look at that toolbar whenever I select text. If it's a separate custom toolbar, I might miss it.
+
+**Rating: GREEN (Path A) / YELLOW (Path B)**
+
+Path A is dead simple. One tap. Clear feedback. The Clips badge updating tells me something happened.
+
+Path B depends on whether the floating toolbar is discoverable. The text selection itself is natural -- it's a standard iOS gesture. But adding a custom action to the selection toolbar is something I've only seen in a few apps. Some apps do it well (Safari's "Share" option). Some apps do it poorly (random options I don't understand). If "Save to Clips" is clearly labeled and positioned, it'll work. But I'd give it YELLOW because discovery depends on UI details that could easily go wrong.
+
+Also: the toast notification "Saved to Clips" is important. Without it, I wouldn't be confident the save worked. The toast confirms it.
+
+---
+
+### Flow 6: Insert a Snippet into the Editor
+
+**Path A: Insert from Clips tab (2 taps)**
+
+**Step 1: Tap "Clips" tab.**
+I see it up top. It says "Clips (3)" -- I have three saved clips. I tap it.
+
+**Step 2: I see my clips.**
+Three cards, each with a quoted passage, the source document name, and when I saved it. Below each: "Insert" and "Delete" buttons.
+
+**Step 3: Tap "Insert" on a clip.**
+I tap "Insert" on the psychological safety quote. The design says: "Clip text is inserted at the current cursor position in the editor. A footnote is automatically created referencing the source document."
+
+**Wait.** My cursor position in the editor. Where was my cursor? I've been tapping around in the Research Panel. Did the editor lose my cursor position? The design says: "The cursor position is tracked by the editor (Tiptap's selection state) and persisted even when the user interacts with the Research Panel."
+
+I look at the editor (visible to my left in landscape mode). The cursor should be wherever I left it. Let's say it's at the end of a paragraph where I was writing about team performance. I tap "Insert."
+
+**The result:** The quote appears in my chapter, wrapped in a blockquote (visually distinct from my own text). Below the chapter text, a footnote appears: "[1] Workshop Notes March 2024." A toast says "Inserted with footnote."
+
+**Emotional reaction:** That's... really nice. The quote is clearly marked as a quote (blockquote styling). The footnote was created automatically -- I didn't have to figure out how to do footnotes. And it references my source document by name. This is the kind of thing that would have taken me 5 minutes of formatting. It just happened in one tap.
+
+**Concern:** What if I don't want a blockquote? What if I want to paraphrase and just keep the footnote? The current design always wraps the inserted text in a blockquote. That's fine for direct quotes, but sometimes I'd want to insert the text as regular paragraph text with just the citation. This is a minor concern -- I can always edit the text after insertion to remove the blockquote formatting.
+
+**Path B: Insert from AI result (1 tap)**
+
+Even simpler. I'm in the Ask tab looking at results. I tap "Insert" on a result card. Same behavior -- text inserted with footnote. I don't even need to save it to Clips first.
+
+**The cursor position problem (detailed):** Here's where I want to get specific about iPad behavior. When I tap into the Research Panel's Ask tab and type a query, the editor loses focus. My cursor is no longer blinking in the editor. When I tap "Insert," the design says the editor refocuses and inserts at the stored cursor position. On iPad, refocusing a contenteditable element can trigger the software keyboard. So after I tap "Insert," will my keyboard pop up unexpectedly? Will the viewport jump? These are real iPad Safari quirks that could make the insertion feel janky.
+
+If the insertion is smooth -- text appears at the right spot, footnote appears at the bottom, no viewport jumping -- this is beautiful. If there's viewport jumping or keyboard flickering, it'll feel broken.
+
+**Rating: YELLOW**
+
+The interaction design is excellent. One or two taps to insert a cited quote with automatic footnoting. But I'm giving this YELLOW rather than GREEN because of two concerns:
+
+1. **Cursor position reliability on iPad.** The design acknowledges this is tricky. If the cursor ends up in the wrong place or the viewport jumps, the experience breaks.
+2. **Blockquote-only insertion.** I sometimes want to insert text as regular text with just a citation. The blockquote is appropriate for direct quotes but not for paraphrased material. A future enhancement could offer "Insert as quote" (blockquote + footnote) vs. "Insert citation only" (just the footnote, no text).
+
+Marcus would rate this GREEN. He's used to precise cursor positioning and wouldn't worry about it. He'd appreciate the automatic footnoting as a time-saver.
+
+---
+
+### Flow 7: Remove a Source
+
+**Step 1: Swipe left on a source card.**
+I see my source in the list. I swipe left on it. Action buttons slide in from the right: "View," "Import," "Remove."
+
+**Alternative:** I could also tap the "..." overflow button on the card. Good -- because I don't always discover swipe gestures. The "..." button is always visible.
+
+**Step 2: Tap "Remove."**
+I tap the red "Remove" text.
+
+**Step 3: Confirmation dialog.**
+A dialog pops up in the center of the screen:
+
+> "Remove 'Interview-Smith.doc'?"
+> "This removes the source from your project. The original file in Google Drive is not affected."
+> "Related clips will keep their text but lose the source link."
+
+**Emotional reaction:** This is exactly the information I need. My first fear when I see "Remove" on anything connected to my Google Drive is: "Will it delete my Google Doc?" The dialog explicitly says "The original file in Google Drive is not affected." I exhale. My file is safe.
+
+The note about clips is also reassuring. If I saved some passages from this source and then remove it, my saved passages don't disappear. They just lose the connection back to the source. That's fair.
+
+**Step 4: Tap "Remove."**
+I tap the red "Remove" button in the dialog. The source fades out of the list. Done.
+
+**Rating: GREEN**
+
+This is exactly how destructive actions should work. Clear warning. Explicit reassurance about what happens to the original file. Information about side effects (clips). Two-tap confirmation so I can't accidentally delete things. The swipe-left pattern is familiar from iOS, and the "..." fallback ensures discoverability.
+
+The only thing that could improve it: an "Undo" toast after removal instead of (or in addition to) the confirmation dialog. "Source removed. [Undo]" appearing for 5 seconds would let me recover from mistakes without the friction of a dialog. But the dialog approach is perfectly fine -- it's the safer choice for a less technical user like me.
+
+---
+
+### Flow 8: Browse Collected Snippets on Research Board
+
+**Step 1: Tap "Clips" tab.**
+I see "Clips (5)" in the tab bar. I tap it.
+
+**Step 2: My clips appear.**
+Five cards, each with a quoted passage, the source it came from, and when I saved it. Newest first. Each card has "Insert" and "Delete" buttons.
+
+**First impression:** This feels like a collection of sticky notes. Each one has a quote I pulled from my research. I can read through them, remember why I saved them, and decide which ones to use in my chapter.
+
+**Step 3: Scroll and review.**
+I scroll through. The clips are in reverse chronological order (newest first). I read through them, re-familiarizing myself with what I've collected.
+
+**Concern:** With only 5 clips, this is manageable. But what about when I have 30 clips? 50? The design shows a "Search clips..." field at the top. Good -- I can search by text or source title. But I might also want to organize clips by chapter topic. "These three clips are for Chapter 4. These two are for Chapter 7." The current design doesn't support any grouping. It's a flat chronological list. For now, that's fine. But as the Clips tab grows, I can see myself wanting folders or tags.
+
+**Step 4 (optional): Tap source title.**
+I see "Workshop Notes March 2024" under one of my clips. I tap it. The design says this navigates me to the Sources tab with the Source Detail View for that document, scrolled near the passage. That's useful -- if I want to see the full context around a clip, I can jump right to it.
+
+**The back-navigation question:** After tapping the source title and viewing the source, how do I get back to Clips? The design says the Sources tab opens with the Source Detail View. So I'm now on the Sources tab. To get back to Clips, I'd tap the "Clips" tab. My clips list should still be there. The design says tab state persists. Good.
+
+But wait -- I was on the Clips tab, I tapped a source title, and now I'm on the Sources tab viewing a source. That's a cross-tab navigation. It works logically, but it might feel disorienting. I went from Clips to Sources without explicitly choosing to switch tabs. A breadcrumb trail or a "Back to Clips" button in the Source Detail View would help me get back to where I was.
+
+**Rating: YELLOW**
+
+The clips display is clean and readable. Searching works. Insert and Delete are clear. But I'm giving YELLOW for two reasons:
+
+1. **Cross-tab navigation confusion.** Tapping a source title in a clip takes me from the Clips tab to the Sources tab. That's logical but potentially disorienting. I'd want a clear way to get back to Clips.
+2. **Scaling concern.** A flat chronological list works for 5-10 clips. It won't work for 30+. Search helps but isn't a substitute for organization. This is a known limitation the design acknowledges, but it affects my confidence in the long-term usability.
+
+Marcus would also rate this YELLOW, but for different reasons. He'd be frustrated by the lack of chapter-based organization from day one. He'd want to tag clips by chapter as he saves them.
+
+---
+
+## Part 2: Experience Scenarios
+
+### Scenario A: First-Time Experience
+
+*"I just signed up for DraftCrane. I created my first project. I connected my Google Drive. Now I see the editor. I've been told there's a way to bring in my existing Google Docs as reference material. What do I do?"*
+
+**1. Do I see the Research panel? Is it open by default? How do I find it?**
+
+The design says the Research Panel is toggleable -- it's closed by default. So I see my editor taking up most of the screen, with my chapter sidebar on the left. I need to find the Research panel.
+
+I scan the toolbar above the editor. I see formatting buttons (bold, italic, etc.) and then -- there should be a "Research" button. The design specifies this as a toolbar button that toggles the panel. If it's a clearly labeled button with text ("Research") or an obvious icon (a magnifying glass? a book?), I'll find it. If it's an ambiguous icon buried among 10 other toolbar icons, I might not.
+
+**Assumption:** The button is reasonably prominent. I tap it. The panel slides in.
+
+**2. Do I understand what "Sources" means in this context?**
+
+The panel opens to the Sources tab. I see an empty state. What does the empty state say? The design for Flow 4 mentions an empty state for the Ask tab ("Add source documents first") but doesn't describe the Sources tab empty state explicitly. If the Sources tab empty state says something like:
+
+> "No sources yet. Add your Google Docs and other research files to reference them while you write."
+
+...then yes, I understand. "Sources" means "my reference files." The word "sources" is slightly academic, but in context -- next to "Add your Google Docs" -- it clicks.
+
+If the empty state is just a blank list with a [+ Add] button and no explanation, I'd be confused. "Add what? What goes here?"
+
+**3. Can I add my first source without help?**
+
+Assuming the [+ Add] button is visible in the empty state, yes. I tap it, see my Google account, browse my Drive, select files, tap "Add Selected." I just walked through this in Flow 1. It works.
+
+**4. After adding one source, do I understand what just happened and what I can do next?**
+
+I see my source in the list with "Processing..." and then a word count. I understand: DraftCrane read my Google Doc and now has it available. I can tap on it to read it.
+
+Do I understand what the Ask and Clips tabs are? Probably not yet. I might tap "Ask" out of curiosity and see the empty state with suggested queries. If I try one, I'd discover the AI search. If I don't, I'd move on and come back later.
+
+The progressive disclosure works here: I added a source, I can view it, and the other tabs are there when I'm ready for them.
+
+**5. Rating: YELLOW**
+
+I'm giving this YELLOW, not GREEN, for one specific reason: **the Research panel is hidden by default.** If someone told me "there's a way to bring in your Google Docs," I'd look for it. But if nobody told me -- if I just signed up and started writing -- I might not discover the Research button in the toolbar for days or weeks. There's no onboarding prompt, no tooltip, no "Hey, want to add your research materials?" nudge.
+
+The flows themselves are GREEN once I'm inside the panel. But *finding* the panel in the first place is the gap. A first-use prompt or a visible empty state in the sidebar ("Add research material") would close this gap.
+
+---
+
+### Scenario B: Mid-Writing Experience
+
+*"I'm deep in Chapter 6 -- 'Building Psychological Safety.' I just wrote a paragraph claiming that 'teams with high psychological safety are 40% more productive.' I need to verify that stat because I think it came from one of my workshop preparation docs."*
+
+**1. I'm in the editor. The Research panel may or may not be open. What's my first move?**
+
+If the panel is already open from earlier, I glance right. I see the Sources tab. But I don't want to browse -- I want to find a specific stat. I tap the "Ask" tab.
+
+If the panel is closed, I tap the Research button in the toolbar. The panel opens. I switch to the Ask tab.
+
+Either way, I'm 1-2 taps from the Ask tab.
+
+**2. Do I search? Browse sources? How do I find this specific stat?**
+
+I type in the Ask input: "What stat do I have about psychological safety and productivity?"
+
+The AI responds. It finds two passages:
+- One from Workshop Notes March 2024: "67% of teams reporting measurable improvement"
+- One from Q4-Report.doc: "2.3x faster decision-making"
+
+Wait. Neither of those says "40% more productive." Did I make up that number? Or did the AI miss it? This is a realistic scenario: I wrote a stat from memory and now I can't find it in my sources.
+
+**3. Once I find it (or don't), how do I verify the context?**
+
+I tap the source title "Workshop Notes March 2024" on the first result. The design says this takes me to the Sources tab with the Source Detail View. I can read the full document to see if there's a "40% more productive" stat anywhere in it.
+
+I scroll through. I find a passage that says "teams with high psychological safety are 40% more likely to take productive risks." Aha -- I misremembered. It's "40% more likely to take productive risks," not "40% more productive." I need to correct my chapter.
+
+**4. If I want to use a specific quote, how do I get it into my chapter?**
+
+I have two options:
+- I can long-press to select the corrected passage in the Source Detail View, tap "Save to Clips," then go to Clips and tap "Insert."
+- Or I can go back to the Ask tab, ask a more specific question to get the passage as a result card, and tap "Insert" directly.
+
+The faster path: I long-press, select "Psychological safety teams are 40% more likely to take productive risks (Google re:Work study, 2015)," tap "Save to Clips," switch to Clips tab, tap "Insert." That's about 5 taps after finding the passage.
+
+The simpler path: I just select the text, copy it (standard iOS copy), close the Research panel, and paste it into my chapter. Then manually fix the footnote. That's fewer taps but no auto-footnote.
+
+**5. How much time has this taken? Am I still in writing flow?**
+
+Total time estimate: 30-60 seconds for the Ask query + reading results + verifying in the source + correcting my chapter. That's fast. Without DraftCrane, this would have been: open Google Drive (30s), try to remember which document (30s), open the wrong one first (30s), open the right one (15s), search within the doc (30s), find the passage (30s), copy it (10s), switch back to my writing doc (15s), paste (5s), create footnote manually (60s). Total: 3-4 minutes minimum. More likely 5-10 minutes because I'd get distracted reading.
+
+DraftCrane compressed a 5-minute research interruption into about a minute. My writing flow is bruised but not broken.
+
+**6. Rating: GREEN**
+
+This is the scenario that sells DraftCrane. The Ask tab turns a multi-minute Google Drive scavenger hunt into a 30-second query. The ability to verify by tapping through to the source document addresses my trust concerns. The insertion path exists even if it's a few taps more than ideal.
+
+The only thing that could make this RED: if the AI misattributes the quote or can't find it at all. The design can't control AI quality, but it handles the "no results" case with a helpful message. The *design* is GREEN. The *experience* depends on the AI working correctly.
+
+---
+
+### Scenario C: Research Session Experience
+
+*"I'm not writing today. I'm organizing. I want to go through 5 of my Google Docs and pull out the best passages for my book. I'll use them later when I actually write."*
+
+**1. Can I do this in DraftCrane, or do I need to use Google Docs directly?**
+
+I can do this in DraftCrane. Here's the workflow:
+
+- Open the Research Panel
+- Go to the Sources tab
+- Tap on the first source to view it
+- Read through it, long-pressing to select good passages
+- "Save to Clips" on each passage
+- Tap "< Sources" to go back to the list
+- Open the next source
+- Repeat
+
+Alternatively, I can use the Ask tab to accelerate: "Find the most important quotes about leadership from my interview documents." The AI surfaces key passages across multiple sources. I save the good ones to Clips. Much faster than reading each document front to back.
+
+**2. Is there a workflow for "browse source, find passage, save for later"?**
+
+Yes. The Source Detail View + "Save to Clips" via text selection is exactly this workflow. I browse the source, find a good passage, long-press to select it, tap "Save to Clips." It's a 3-gesture workflow (tap source, select text, save). That's clean.
+
+The Ask tab offers a complementary workflow: instead of browsing, I ask questions and save the results. "What's the best quote about resilience in my Smith interview?" Save to Clips. "What data do I have about coaching ROI?" Save to Clips. This is a faster way to extract the highlights without reading every word.
+
+**3. Can I organize what I save? By chapter? By topic?**
+
+No. This is the gap. Clips are a flat chronological list. I can search them by text or source title, but I can't tag them "Chapter 4" or "Leadership" or "Stats." After a research session where I pull 15-20 passages, they'll all be in one list with no organization.
+
+My current workflow: I read Google Docs and copy-paste good passages into Apple Notes, organized by chapter or topic. Each Apple Note is "Ch4 - Safety Quotes" or "Stats for Conclusion." DraftCrane's Clips tab doesn't offer this level of organization.
+
+**4. How does this feel compared to my current workflow?**
+
+Better in some ways, worse in others.
+
+Better: I don't have to switch between apps. I don't have to copy-paste between Google Docs and Apple Notes. The source attribution is automatic (each clip knows where it came from). The Ask tab can surface passages I might miss by reading manually.
+
+Worse: I can't organize my clips. My Apple Notes folders gave me structure. DraftCrane's flat list doesn't. After a heavy research session, I'd have a pile of unsorted clips and no way to group them by chapter.
+
+About equal: The actual "select a passage" workflow is similar -- long-press and select text in DraftCrane vs. long-press and copy in Google Docs. The DraftCrane version has one fewer step (no paste into Apple Notes) but adds the constraint of working within the Research Panel's width.
+
+**5. Rating: YELLOW**
+
+The individual workflow steps are clean (GREEN-worthy), but the lack of clip organization makes a dedicated research session less productive than it could be. After pulling 20 passages from 5 documents, I'd have an unstructured pile. I'd miss my Apple Notes folders.
+
+This is a "good enough to try, not good enough to commit to" situation. I'd use it for a session or two. If the Clips tab stays flat, I'd eventually go back to Apple Notes for my research organization and use DraftCrane only for writing + quick fact-checking.
+
+To make this GREEN: add the ability to tag clips when saving them. Even a simple single-select "For which chapter?" dropdown on the save action would transform the Clips tab from a pile into a usable system.
+
+---
+
+## Part 3: Specific Concerns
+
+### Terminology
+
+**"Sources"**
+I know what "sources" means in the abstract -- it's where information comes from. But it has an academic connotation. "Bibliography sources." "Cite your sources." When I see "Sources" as a tab label, my first thought is academic citation management. My *second* thought is "oh, these are my reference files." The second thought is correct, but the first thought creates a moment of "is this for me?"
+
+Better alternatives: "My Docs" (too casual?), "Reference Docs" (clearer but longer), "Files" (generic but accurate). Honestly, "Sources" is fine. It's one of those things that feels slightly off on first encounter but becomes invisible after the first session. I wouldn't change it unless user testing shows real confusion. **Verdict: Acceptable.**
+
+**"Clips"**
+This one is harder. "Clips" makes me think of video clips first. Then newspaper clippings. The newspaper metaphor is actually right -- I'm "clipping" passages from my sources. But the word doesn't immediately convey "saved passages from your research."
+
+Better alternatives: "Saved" (boring but clear), "Snippets" (slightly technical), "Notes" (overloaded -- I might think these are my own notes), "Highlights" (implies visual highlighting, which isn't quite right), "Quotes" (too specific -- not everything I save is a quote).
+
+I'd actually suggest "Saved" or "Saved Quotes" but neither is perfect. "Clips" is fine as long as the first-use experience clearly explains what it is. The empty state message becomes critical: "No clips yet. Save passages from your sources to reference them later." **Verdict: Slightly confusing at first. Needs clear empty state.**
+
+**"Research"**
+This is good. I'm doing research for my book. The panel helps me do research. "Research" as the panel name works. **Verdict: Good.**
+
+**"Ask" tab**
+Yes, this implies I can ask questions. And I can. The label matches the action. The only concern: "Ask" is a verb, while "Sources" and "Clips" are nouns. The inconsistency is subtle but noticeable. "Sources | Ask | Clips" -- one of these is not like the others. Alternatives: "Search" (but the Sources tab also has search), "Q&A" (too jargony), "Assistant" (too vague).
+
+Actually, "Ask" is fine. It's the most direct label for "type a question here." **Verdict: Good.**
+
+**Other terms:**
+- "Processing..." on a new source: Clear. It's working on my file.
+- "Cached 2h ago": I don't know what "cached" means. "Updated 2h ago" would be clearer.
+- "Import as Chapter": This one still concerns me from the earlier analysis. Does "import" mean "copy"? Does "as chapter" mean it becomes a chapter? Yes, but the stakes are high -- I might accidentally turn a reference doc into a chapter. The confirmation dialog should be explicit about what happens.
+
+### iPad-Specific Issues
+
+**Three-panel layout (sidebar + editor + research): does the editor feel cramped?**
+
+On my iPad Pro 12.9" in landscape, the viewport is about 1366pt. Sidebar: 260pt. Research Panel: 340pt. That leaves 766pt for the editor. That's generous -- more than enough. I wouldn't feel cramped.
+
+On an iPad Air 11" in landscape, the viewport is 1180pt. After sidebar and Research Panel, the editor gets 580pt. That's still comfortable. I can write a paragraph and see 60+ characters per line. That's readable.
+
+The concern is the iPad Air in portrait (820pt viewport). The design correctly identifies this as an overlay scenario -- the Research Panel covers 85% of the screen. Good design decision. Don't try to fit three panels in 820pt.
+
+**Verdict: Not cramped on my device (iPad Pro landscape). Correctly handled for smaller devices.**
+
+**Portrait mode: is the overlay research panel intuitive?**
+
+The 85% overlay with a 15% visible strip of the editor behind it. I can swipe right to dismiss, or tap the visible strip. This pattern is familiar from apps like Apple Maps (the bottom sheet) and many iOS apps.
+
+My concern: the 15% strip of editor visible on the left. Is that useful, or just visual noise? I can't really read or write in 15% of the screen width. It's more of a "you're still in the editor, just viewing research on top" visual cue. That's fine as long as it doesn't feel like a tease. I'd rather have the panel take the full screen in portrait than see a useless sliver of my chapter.
+
+**Verdict: YELLOW. The 85% overlay pattern works, but the 15% editor strip might feel like wasted space rather than useful context. Consider making it full-screen in portrait with a clear "Back to editor" button at the top.**
+
+**Touch targets: any interactions that feel too small or fiddly?**
+
+The design specifies 44pt minimum for all interactive elements. Good. Specific areas I'd watch:
+
+- **Checkboxes in the Drive browser:** The design says "44x44pt tap area (visually 24x24px icon)." That's good -- the visual checkbox is small but the tap target is large. As long as the tap target is truly 44pt, I won't have trouble.
+- **Tab labels (Sources | Ask | Clips):** These need to be large enough to tap without accidentally hitting the adjacent tab. With three tabs in a 340pt panel, each tab gets about 100pt of width. That's plenty.
+- **"..." overflow menu on source cards:** 44x44pt is specified. Good.
+- **"Save to Clips" and "Insert" buttons on result cards:** These are small-text action links inside cards. If they're full-width buttons, fine. If they're small text links, they might be hard to tap. The design specifies "44pt minimum touch targets on all action buttons." As long as that's enforced in implementation, it's fine.
+
+**Verdict: GREEN, assuming the 44pt specifications are followed in implementation.**
+
+**Keyboard: when typing a query in the Ask tab, does the virtual keyboard cause problems?**
+
+The design says the query input is at the bottom of the Ask tab (chat pattern) and the conversation area scrolls up when the keyboard appears, using the `visualViewport` API.
+
+My concern: on iPad with the Smart Keyboard Folio attached, there IS no virtual keyboard. The physical keyboard is always there. So the layout should work identically whether or not a software keyboard is present. The design doesn't mention this scenario explicitly, but it shouldn't be a problem -- the input is at the bottom, the conversation scrolls, and the keyboard (physical or virtual) doesn't change the layout.
+
+However: if I detach my Smart Keyboard and use the on-screen keyboard, the Ask tab needs to handle the viewport resize gracefully. The virtual keyboard on a 12.9" iPad Pro covers roughly 40% of the screen height. The Ask tab's conversation area would be compressed to about 60% of its normal height. That should still show the latest query and response, but scrolling through conversation history would be cramped.
+
+**Verdict: GREEN for physical keyboard. YELLOW for virtual keyboard in portrait mode (cramped conversation area). Overall GREEN because I usually use my Smart Keyboard.**
+
+**Split View: what if I have DraftCrane + Safari in Split View?**
+
+This is how I work sometimes -- DraftCrane on the left, Safari or a Google Doc on the right, using iPadOS Split View. In Split View, each app gets roughly half the screen.
+
+On my iPad Pro 12.9" in landscape, that's about 683pt per app. DraftCrane with 683pt: sidebar (260pt) + editor (423pt). That's right at the minimum editor width (400pt). If I open the Research Panel in this configuration, the editor would be pushed below 400pt. The design says: "If Research Panel would push editor below 400pt, the panel cannot open as side-by-side -- it opens as overlay instead."
+
+So in Split View, the Research Panel would always be an overlay. That's acceptable -- I'm already in a constrained space. The overlay makes sense here.
+
+**Verdict: GREEN. The design handles this correctly with the 400pt minimum and automatic overlay fallback.**
+
+### Cognitive Load
+
+**How many concepts must I hold in my head to use this?**
+
+Let me count the concepts:
+
+1. **Research Panel** -- a side panel I can open and close
+2. **Sources** -- my reference documents connected to this project
+3. **Ask** -- I can ask questions about my sources
+4. **Clips** -- passages I've saved for later
+5. **Insert** -- I can put a clip into my chapter with a footnote
+
+That's five concepts. Compared to the current design (sources, linking, chapter-source associations, sheets stacking on sheets, viewers overlaying panels), this is dramatically simpler. Five concepts is manageable. Each one maps to something I already understand: a panel (like a drawer), files (like Drive), asking questions (like ChatGPT), saving things (like bookmarks), and inserting (like paste).
+
+**Verdict: Manageable. Five concepts, each with a real-world analogy.**
+
+**Is the tab model (Sources | Ask | Clips) intuitive or overwhelming?**
+
+Three tabs is the sweet spot. Two would be too few (you'd have to combine unrelated things). Four would start feeling heavy. Three is the standard for mobile tab bars -- every iPhone app I use has a bottom bar with 3-5 tabs.
+
+The tabs represent three distinct activities: browse, search, collect. Those activities don't overlap much, which makes the tab separation feel natural. I wouldn't go to the Ask tab to browse my files. I wouldn't go to the Sources tab to save a snippet.
+
+The only cognitive load is remembering which tab I'm on. If I drift between tabs frequently, I might lose context. But the design preserves tab state (switching tabs doesn't reset), so I won't lose my work.
+
+**Verdict: Intuitive. Three tabs is the right number.**
+
+**Does the progressive disclosure work?**
+
+Level 0: Panel closed. I'm just writing. Zero research UI visible.
+Level 1: Panel open, tab selected. I see my sources, or the Ask interface, or my clips.
+Level 2 (Sources tab only): Source detail view or add flow.
+
+This is a clean two-level disclosure model. I never go deeper than two levels. I never have a sheet on top of a sheet on top of a panel. The "back" navigation is always one tap to get back to Level 1.
+
+The transition from "I don't know this exists" (Level 0) to "I opened it and see tabs" (Level 1) is the only potentially confusing jump. Once I'm in Level 1, everything is flat tabs with at most one drill-down.
+
+**Verdict: Yes, the progressive disclosure works. The two-level maximum is exactly right.**
+
+**Is there a "wall" moment where complexity jumps suddenly?**
+
+The closest thing to a "wall" would be the first time I use the Ask tab and receive AI results. Suddenly I see result cards with citations, "Save to Clips" buttons, "Insert" buttons, source title links. That's a lot of new UI appearing at once.
+
+But it's not really a wall because I asked for it. I typed a question and submitted it. The results are in response to my action. Each result card is self-contained and the actions are labeled. I might not use "Save to Clips" or "Insert" the first time, but I'll understand what they do.
+
+The bigger "wall" risk is the first-time setup: connecting Google Drive, adding sources, understanding what the Research Panel is for. That's the Scenario A YELLOW I identified above.
+
+**Verdict: No wall. The complexity ramp is gradual.**
+
+### Trust
+
+**Does Diane trust that her Google Docs are safe?**
+
+My first and deepest concern with any tool that touches my Google Drive: *will it change my files?* Will it edit them? Will it share them? Will it delete them?
+
+The detailed design doesn't include explicit reassurance messaging during the add flow. When I browse my Drive and select files, there's no message saying "DraftCrane reads your files but never modifies them." The confirmation dialog for *removing* a source says "The original file in Google Drive is not affected" -- which is reassuring at removal time. But at *addition* time, when I'm first connecting my files, there's no equivalent reassurance.
+
+**What I'd want to see:** During the Source Add Flow, somewhere visible: "DraftCrane reads your files to help you search and reference them. Your original files are never modified." One sentence. Enormous trust impact.
+
+**Verdict: Trust is partially addressed (removal dialog is good) but not fully addressed (addition flow needs reassurance). YELLOW.**
+
+**Does she trust the AI search results?**
+
+Not initially. I'd trust the results *after* I verify them a few times. The design supports verification: I can tap the source title and see the original document. If the AI says "according to Workshop Notes March 2024" and I can open that document and see the quote in context, trust builds.
+
+The design does NOT show the AI ever making things up. It quotes passages from my actual documents. That's fundamentally different from ChatGPT, which might paraphrase or hallucinate. If the AI consistently shows me exact quotes from named sources, I'll trust it within a few sessions.
+
+**Verdict: Trust builds through verification. The design supports verification well. YELLOW initially, GREEN after a few uses.**
+
+**Does she understand what "adding a source" does to her original file?**
+
+Not clearly. "Adding a source" could mean:
+- DraftCrane bookmarks my file (correct -- it's more like bookmarking)
+- DraftCrane copies my file into its own storage (partially correct -- it caches the content)
+- DraftCrane modifies my file (incorrect, but plausible fear)
+
+The design should make clear that adding a source = "DraftCrane remembers this file and caches its text so you can search it." The cached/read-only nature should be explicit.
+
+**Verdict: YELLOW. Needs clearer messaging about what "adding" does.**
+
+**If she removes a source, does she worry about losing her Google Doc?**
+
+No -- the removal dialog explicitly says "The original file in Google Drive is not affected." That's the right message at the right time. This is well-handled.
+
+**Verdict: GREEN.**
+
+---
+
+## Part 4: The Verdict
+
+### Traffic Light Summary
+
+| # | Flow / Scenario | Rating | Key Factor |
+|---|----------------|--------|------------|
+| 1 | Add source from Google Drive | GREEN | Inline flow, no sheet stacking, clear back navigation |
+| 2 | Add source from local device | GREEN | System file picker is familiar, supported types listed clearly |
+| 3 | View source while writing | GREEN | Side-by-side in landscape is the core value proposition |
+| 4 | Search sources with natural language | GREEN | Intuitive query pattern, structured results with citations |
+| 5 | Save a snippet from search results | GREEN / YELLOW | Path A (from AI result) is trivial; Path B (text selection) depends on floating toolbar discoverability |
+| 6 | Insert a snippet into the editor | YELLOW | Design is excellent but iPad cursor position and viewport behavior are risky |
+| 7 | Remove a source | GREEN | Perfect destructive action pattern with reassurance |
+| 8 | Browse clips on Research Board | YELLOW | Clean display, but cross-tab navigation and lack of organization are concerns |
+| A | First-Time Experience | YELLOW | Panel discoverability and empty-state guidance need work |
+| B | Mid-Writing Experience | GREEN | The killer scenario. Ask tab compresses a 5-minute interruption to 30 seconds |
+| C | Research Session Experience | YELLOW | Good individual steps, but flat clip list doesn't support dedicated research sessions |
+
+**Summary: 6 GREEN, 5 YELLOW, 0 RED.**
+
+No reds. That's significant. Nothing in this design would make me give up or feel completely lost. The yellows are about polish and edge cases, not fundamental confusion.
+
+### Top 3 Changes I'd Make
+
+**1. Add a "trust line" during the Source Add Flow.**
+
+During Step 2 of Flow 1 (when the Source Add Flow first appears), add a single line of text above the account list:
+
+> "DraftCrane reads your files to help you search and reference them. Your originals are never changed."
+
+This costs nothing to implement. It addresses the deepest anxiety of anyone connecting their Google Drive to a new application. Every user will read this the first time. Most will only need to read it once. But that one reading prevents a trust barrier that could stop adoption before it starts.
+
+**Why:** Both Diane and Marcus have their professional work in Google Drive. The fear of a tool modifying or mishandling their files is real and justified. The removal dialog says "Drive is not affected" but by then it's too late -- the trust barrier is at the *connection* point, not the *removal* point.
+
+**2. Lower the in-document search threshold from 10,000 words to 2,000 words (or just always show it).**
+
+The Source Detail View shows a "Search within document" field only for documents exceeding 10,000 words. That's too high. My average Google Doc is 2,000-4,000 words. Finding a specific sentence in a 3,000-word document by scrolling is tedious.
+
+Always showing the search field in the Source Detail View -- or at minimum lowering the threshold to 2,000 words -- would dramatically improve the "verify a fact" workflow. When I tap through from an AI result to verify a citation, I want to find the passage quickly. Ctrl+F (or its equivalent) should always be available.
+
+**Why:** The Source Detail View is where verification happens. Verification is what builds trust in the AI results. Making verification faster makes trust-building faster. The search field is the tool that makes verification fast.
+
+**3. Add a first-use nudge for the Research Panel.**
+
+When a user first opens a project that has no sources, show a subtle prompt or visual indicator near the Research toolbar button:
+
+> "Have research files in Google Drive? Tap Research to bring them in."
+
+This can be a tooltip, a pulsing dot, or a one-time banner at the top of the editor. It should appear once and then never again. The goal is to close the discoverability gap I identified in Scenario A -- the Research Panel is hidden by default, and without guidance, a new user might not find it for days.
+
+**Why:** The entire Research Companion value proposition requires users to add sources. Users who don't discover the Research Panel never add sources. Users who never add sources never experience the Ask tab. Users who never experience the Ask tab never understand why DraftCrane is better than Google Docs. This is a funnel problem. The nudge ensures users enter the funnel.
+
+### Deal Breakers
+
+**Would anything in this design make Diane abandon DraftCrane entirely?**
+
+No. Nothing in the *design* is a deal breaker. The design is sound. The flows are intuitive. The complexity is managed.
+
+The deal breaker is **AI quality.** If the Ask tab returns wrong answers, misattributes quotes, or hallucinates information, I will never trust DraftCrane with my research. This is not a design flaw -- it's an implementation risk. But it's worth stating explicitly: the design is building a product whose central value proposition depends on AI reliability. The design handles the "AI fails" case gracefully (error messages, fallback to manual browsing), but graceful degradation doesn't prevent abandonment. If I ask five questions and three give wrong answers, I won't ask a sixth.
+
+**What must absolutely work:**
+
+1. **The Ask tab must give correct, verifiable answers with accurate source citations.** This is the product.
+2. **Side-by-side viewing in landscape must actually work on iPad Safari.** If the panel causes the editor to reflow, lag, or lose cursor position, the writing experience degrades.
+3. **Adding sources from Drive must be fast.** If I have to tap 8 times per file and I have 30 files, I'll quit after 5.
+
+### Moments of Delight
+
+Despite my skepticism, here's what excites me about this design:
+
+**1. The first successful Ask query.**
+The moment when I type a question about my own documents and the AI returns the exact passage from the right file -- with the document name and a citation I can verify -- that is genuinely thrilling. I've been searching through 30 Google Docs manually for three years. If this works, it's the most significant time-saver I've encountered in any writing tool.
+
+**2. Automatic footnotes on insertion.**
+I *hate* doing footnotes. I never know the right format. I forget to add them. I know my book needs them but I dread the work. The fact that tapping "Insert" on a clip or AI result creates a properly formatted footnote automatically -- that's the kind of invisible help that makes a tool feel magical. I'd tell my writing group about this specific feature.
+
+**3. Side-by-side source viewing in landscape.**
+After three years of toggling between Safari tabs, having my source document visible *beside* my chapter text feels like the upgrade I didn't know I was waiting for. It's such a simple thing -- split the screen -- but none of my current tools do it seamlessly. DraftCrane in landscape with the Research Panel open is how I imagined writing a book would feel when I first started.
+
+**4. Clips as a running collection.**
+The idea that I'm building a curated collection of useful passages as I research -- and that each passage remembers where it came from -- is powerful. It's better than my Apple Notes system because the attribution is automatic. I've lost track of where quotes came from more times than I can count. If every clip carries its source, that problem disappears.
+
+**What would make me tell a colleague about DraftCrane:**
+
+"It reads all your Google Docs and you can just ask it questions -- like 'what did I write about psychological safety?' -- and it finds the exact quote, tells you which document it's from, and lets you drop it into your chapter with a footnote. In one tap."
+
+That's the pitch. The Research Companion design makes that pitch possible. If the AI delivers, Diane becomes an evangelist.
+
+---
+
+## Marcus's Divergent Notes
+
+*Brief perspective from Marcus Chen (34, academic, organized, 100+ documents)*
+
+Marcus agrees with most of Diane's ratings but diverges on three points:
+
+**Flow 1 (Add Source from Google Drive): YELLOW for Marcus.**
+Marcus has 12 subfolders with 3-15 documents each. Adding 80+ documents one browse session at a time -- even with the improved inline Drive browser -- is a significant time investment. Marcus would want a "select entire folder" option or a "bulk add from folder" capability. The current design requires navigating into each folder, selecting files individually, adding them, going back, and navigating to the next folder. For 12 folders, that's 12 cycles of the add flow. The flow itself is GREEN, but at Marcus's scale, the repetition is YELLOW.
+
+**Flow 8 (Browse Clips): RED for Marcus.**
+Diane gave this YELLOW. Marcus gives it RED. With 15 chapters and a goal of 5-10 clips per chapter, Marcus anticipates 75-150 clips. A flat chronological list with search is not an organizational system -- it's a junk drawer. Marcus needs clips organized by chapter at minimum. Without chapter tagging or filtering, the Clips tab is unusable for his workflow. He'd never adopt it -- he'd continue using his Google Sheet index.
+
+**Scenario C (Research Session): RED for Marcus.**
+Same reasoning. A dedicated research session for Marcus means systematic extraction: read each source, pull relevant passages, tag them by chapter and theme, build a structured research base. The Clips tab's flat list doesn't support this. Marcus's reaction: "I'm spending an hour extracting research and it all goes into an unsorted pile? I'll stick with my spreadsheet."
+
+Marcus's overall verdict: The design is architecturally correct (three tabs, no sheet stacking, AI search) and he'd adopt the Sources and Ask tabs immediately. But the Clips tab needs chapter-level organization before he can use it as a real research management tool. His deal breaker is not AI quality (he assumes AI is imperfect and will verify everything) -- it's organizational capability. If he can't structure his research within DraftCrane, he'll keep his external system and DraftCrane becomes a writing-only tool that fulfills half its promise.

--- a/docs/design/source-review/design-spec.md
+++ b/docs/design/source-review/design-spec.md
@@ -1,0 +1,1599 @@
+# DraftCrane Source/Research UX: Final Design Specification
+
+> **Status:** Authoritative design document
+> **Mental Model:** Option B -- "Research Companion"
+> **Date:** 2026-02-19
+> **Phases:** 01-research, 02a-analysis, 02b-user-reactions, 03a-detailed-design, 03b-stress-test
+
+---
+
+## Table of Contents
+
+1. [Executive Summary](#1-executive-summary)
+2. [Design Principles](#2-design-principles)
+3. [Information Architecture](#3-information-architecture)
+4. [Mental Model](#4-mental-model)
+5. [Interaction Flows](#5-interaction-flows)
+6. [Panel Specifications](#6-panel-specifications)
+7. [Component Specifications](#7-component-specifications)
+8. [Data Model Changes](#8-data-model-changes)
+9. [API Specification](#9-api-specification)
+10. [Implementation Phases](#10-implementation-phases)
+11. [Decisions Log](#11-decisions-log)
+12. [Appendix: User Feedback Resolution Tracker](#12-appendix-user-feedback-resolution-tracker)
+
+---
+
+## 1. Executive Summary
+
+### Chosen Mental Model
+
+**Option B: "Research Companion"** -- a unified right-hand panel with three tabs (Sources, Ask, Clips) that serves as the author's research workspace alongside the writing editor.
+
+Both personas (Diane Mercer, first-time nonfiction author; Marcus Chen, experienced academic with 100+ documents) independently selected Option B. It was chosen over Option A ("Polished Library," which lacked AI search) and Option C ("Integrated Research Assistant," which buried source browsing behind a settings submenu and placed an all-or-nothing bet on AI quality).
+
+### Key Decisions Made During the Review
+
+1. **Chapter-source linking is eliminated.** The link/unlink concept confused both personas and provided invisible outcomes. Sources are project-level. Implicit references are tracked when snippets are inserted.
+2. **Sheet stacking is eliminated.** The current 4-layer chain (SourcesPanel > AddSourceSheet > DriveBrowserSheet > SourceViewerSheet) is replaced by inline view replacement within a single panel.
+3. **AI-powered search is the primary differentiator.** The Ask tab -- not the source browser -- is what makes DraftCrane more valuable than Google Drive tabs. Both personas identified this as the breakthrough capability.
+4. **Clips support chapter-level tagging.** The stress test exposed that a flat clip list is RED for Marcus at scale. Clips can be optionally tagged to chapters, with a chapter filter in the Clips tab.
+5. **A trust line is shown during source addition.** "Your originals are never changed" appears in the Source Add Flow to address Drive modification anxiety.
+6. **In-document search is always visible.** The original 10,000-word threshold was too high. Search is always available in the Source Detail View.
+7. **A first-use nudge surfaces the Research Panel.** A one-time tooltip on the Research toolbar button bridges the discoverability gap.
+
+### One-Paragraph Summary
+
+The current source management UX -- a 4-layer sheet stack with confusing chapter-source linking and a 133-line props interface -- is replaced by a single right-hand Research Panel containing three tabs. The Sources tab provides a project-level source list with inline Drive browsing and content viewing. The Ask tab enables natural-language queries across all project sources with AI-powered, cited results. The Clips tab collects useful passages with source attribution and supports one-tap insertion into the editor with automatic footnotes. The design ships in three phases: Foundation (panel + Sources tab, 2-3 weeks), AI Integration (Ask tab, 3-4 weeks), and Board + Editor (Clips tab + footnotes, 2-3 weeks).
+
+---
+
+## 2. Design Principles
+
+### Principle 1: One Panel, One Purpose
+
+**This means:** All research functionality lives in a single right-hand panel. The panel uses tabs for distinct activities (browse, ask, collect), and inline view replacement for drill-downs. No surface ever stacks on top of another. Maximum depth is 2 levels (panel open, then detail or add view).
+
+**This does NOT mean:** Cramming unrelated features into the panel. The panel is for research -- source management, AI queries, and snippet collection. Project settings, chapter management, and AI rewrite remain separate surfaces.
+
+### Principle 2: Ask First, Browse When Needed
+
+**This means:** The AI query interface (Ask tab) is the primary way users find information in their sources. It handles the "needle in a haystack" problem across 10-100+ documents that no human can browse efficiently. Manual source browsing (Sources tab) exists as a first-class alternative for users who know exactly which document they want or who need to survey their research landscape.
+
+**This does NOT mean:** Hiding or demoting source browsing. The Sources tab is the default tab. Users who prefer browsing over asking are fully supported. The Ask tab is an addition, not a replacement.
+
+### Principle 3: Your Files Are Yours
+
+**This means:** Trust messaging is explicit at every moment where users might worry about their Google Drive files. The Source Add Flow shows "Your originals are never changed." The remove confirmation says "The original file in Google Drive is not affected." Source content is cached and read-only. DraftCrane never writes to, modifies, or deletes files in the user's Google Drive.
+
+**This does NOT mean:** Excessive warnings or confirmation dialogs for non-destructive actions. Viewing a source, saving a clip, or asking a question require zero confirmations.
+
+### Principle 4: Clips Carry Their Provenance
+
+**This means:** Every clip (saved passage) permanently records its source document title and location. When a clip is inserted into the editor, the footnote is created automatically. The author never needs to manually track where a quote came from. Even if the source is later removed from the project, the clip retains its text and source title.
+
+**This does NOT mean:** Enforcing formal citation styles. Footnotes use a simple "[N] Source Title" format. Formal Chicago/APA/MLA citation formatting is a future enhancement, not Phase 0 scope.
+
+### Principle 5: iPad-First Means Constraint-First
+
+**This means:** Every interaction is designed for touch on a 10.9" iPad Air in both orientations. Landscape enables side-by-side (editor + panel). Portrait uses a full overlay. All touch targets are 44pt minimum. No hover states, no floating windows, no drag-and-drop (unreliable on iPad Safari). The software keyboard is accounted for in every input flow.
+
+**This does NOT mean:** Degrading the desktop experience. Desktop gets the same panel layout with more editor space. Desktop-specific enhancements (panel resizing, keyboard shortcuts) are layered on top, never required.
+
+---
+
+## 3. Information Architecture
+
+### Screen/Panel Inventory
+
+**Primary surfaces (always available):**
+
+| Surface | Type | Purpose | Status |
+|---------|------|---------|--------|
+| Chapter Sidebar | Persistent left panel (260pt) | Chapter navigation, word counts | Unchanged |
+| Editor | Central content area (flex, min 400pt) | Tiptap rich text editor | Unchanged |
+| Research Panel | Toggleable right panel (340pt) | Three-tab container for Sources, Ask, Clips | **New** |
+
+**Secondary surfaces (within Research Panel):**
+
+| Surface | Type | Purpose | Status |
+|---------|------|---------|--------|
+| Source Detail View | Inline replacement within Sources tab | Full source content viewer with always-visible search | **New** |
+| Source Add Flow | Inline replacement within Sources tab | Drive browser + local upload with trust messaging | **New** |
+
+**Confirmation dialogs (modal):**
+
+| Surface | Type | Purpose | Status |
+|---------|------|---------|--------|
+| Remove Source Confirmation | Center dialog | Confirm destructive source removal | **New** |
+
+**First-use elements:**
+
+| Surface | Type | Purpose | Status |
+|---------|------|---------|--------|
+| Research Panel Nudge | One-time tooltip on toolbar button | Bridge discoverability gap for new users | **New** |
+
+### Navigation Model
+
+```
+Level 0: Research Panel closed (editor takes full width)
+
+Level 1: Research Panel open with active tab
+          - Sources tab (source list with search/filter)
+          - Ask tab (AI query interface)
+          - Clips tab (saved snippet board with chapter filter)
+
+Level 2: Sources tab only -- drill-down views
+          - Source Detail View (replaces source list inline)
+          - Source Add Flow (replaces source list inline)
+
+Cross-tab navigation:
+          - Tapping a source title in Ask or Clips navigates to
+            Sources tab > Source Detail View, with a "Back to [Ask/Clips]"
+            breadcrumb for return navigation
+```
+
+```
+                                          +------------------+
+                                          |  Research Panel   |
+                 +--- Sources tab ------> |  [Source List]    |
+                 |     |                  |                   |
+Toolbar -------->+     +-- Detail view -> |  [Source Content] |
+[Research btn]   |     |                  |                   |
+                 |     +-- Add flow ----> |  [Drive Browser]  |
+                 |                        |                   |
+                 +--- Ask tab ----------> |  [Query + Results]|
+                 |                        |                   |
+                 +--- Clips tab --------> |  [Saved Snippets] |
+                                          +------------------+
+```
+
+### What Was Removed
+
+| Component/Concept | File(s) | Reason |
+|-------------------|---------|--------|
+| `SourcesPanel` | `web/src/components/drive/sources-panel.tsx` | Replaced by `ResearchPanel` > `SourcesTab` |
+| `AddSourceSheet` | `web/src/components/drive/add-source-sheet.tsx` | Merged into `SourceAddFlow` within Sources tab |
+| `DriveBrowserSheet` | `web/src/components/drive/drive-browser-sheet.tsx` | Merged into `SourceAddFlow` within Sources tab |
+| `SourceViewerSheet` | `web/src/components/drive/source-viewer-sheet.tsx` | Replaced by `SourceDetailView` within Sources tab |
+| `useChapterSources` hook | `web/src/hooks/use-chapter-sources.ts` | Chapter-source linking eliminated entirely |
+| Chapter-source linking (concept) | All link/unlink UI and endpoints | Both personas found it confusing; invisible outcomes |
+| Sheet stacking (z-50/z-60 layering) | `editor-dialogs.tsx` | Replaced by inline view replacement within panel |
+| ~50 EditorDialogsProps source-related props | `editor-dialogs.tsx` | Replaced by `ResearchPanelProvider` context |
+
+### What Was Added
+
+| Component/Concept | Purpose |
+|-------------------|---------|
+| Research Panel | Unified right-hand panel with tab navigation |
+| Sources tab | Source list, search, inline add flow, inline detail view |
+| Ask tab | AI natural-language query with streaming cited results |
+| Clips tab | Saved snippet board with chapter tagging and insertion |
+| Trust messaging | "Your originals are never changed" during source addition |
+| First-use nudge | One-time tooltip on Research toolbar button |
+| Always-visible search | Search field in Source Detail View regardless of document length |
+| Chapter tag on clips | Optional chapter association when saving clips |
+| Back-to-origin breadcrumb | "Back to Ask" / "Back to Clips" after cross-tab navigation |
+| `ResearchPanelProvider` | Context provider encapsulating all panel state |
+
+---
+
+## 4. Mental Model
+
+### The User's Words
+
+**How Diane describes what this does:**
+
+> "The right panel is my research workspace. The Sources tab is my bookshelf -- all my Google Docs are there and I can open any of them to read alongside my writing. The Ask tab is my research assistant -- I type a question and it finds the answer in my documents and tells me exactly where it came from. The Clips tab is my sticky notes -- passages I've saved from my research that I can drop into my chapter with one tap, and it adds the footnote for me."
+
+**How Marcus describes what this does:**
+
+> "It's a three-part research pipeline. Sources are raw materials -- I browse and add documents from my Drive. Ask is the query interface -- I search across all my documents at once, which I couldn't do before without opening each one individually. Clips are curated outputs -- the useful excerpts I've pulled from my research, tagged by chapter so I can find them when I'm writing each section."
+
+### Technical Mapping
+
+| User's mental model | Technical component | Data store |
+|---------------------|---------------------|------------|
+| "My bookshelf" (Sources tab) | `SourcesTab` + `SourceCard` list | `source_materials` table (D1) + content cache (R2) |
+| "Open a document" (Source Detail View) | `SourceDetailView` reading from R2 | `sources/{sourceId}/content.html` (R2) |
+| "Add from my Drive" (Source Add Flow) | `SourceAddFlow` using Drive API | Google Drive API + `source_materials` (D1) |
+| "Ask a question" (Ask tab) | `AskTab` > `POST /research/query` | Source content (R2) > LLM > SSE stream |
+| "It found the answer" (Result card) | `ResultCard` displaying parsed LLM response | Ephemeral (not stored; query metadata in `research_queries`) |
+| "Save for later" (Save to Clips) | `POST /research/clips` | `research_clips` table (D1) |
+| "My sticky notes" (Clips tab) | `ClipsTab` + `ClipCard` list | `research_clips` table (D1) |
+| "Drop it in with a footnote" (Insert) | `SnippetInsertButton` > Tiptap commands | Tiptap blockquote node + footnote node > Drive write-through |
+| "Tag it for Chapter 4" (Chapter tag) | `chapter_id` field on `research_clips` | `research_clips.chapter_id` (D1) |
+
+---
+
+## 5. Interaction Flows
+
+All flows revised based on stress test feedback. YELLOW resolutions are called out explicitly.
+
+### Flow 1: Add Source from Google Drive
+
+**Precondition:** User has at least one Google account connected. Research Panel is open with Sources tab active.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap [+ Add] button in Sources tab header | Sources tab | 1 |
+| 2 | Source Add Flow replaces source list. **Trust line visible: "DraftCrane reads your files to help you search and reference them. Your originals are never changed."** Shows connected accounts and "Upload from device." | Source Add Flow | 0 (transition) |
+| 3 | Tap a connected Google account row | Source Add Flow | 1 |
+| 4 | Inline Drive browser appears. Shows root of user's Drive. | Source Add Flow | 0 (transition) |
+| 5 | Navigate into target folder | Source Add Flow | 1-3 per level |
+| 6 | Tap checkbox on each Google Doc to select | Source Add Flow | 1 per file |
+| 7 | Tap "Add N Selected" footer button | Source Add Flow | 1 |
+| 8 | View transitions back to source list showing new sources with "Processing..." status | Sources tab | 0 (transition) |
+
+**Total: 4-8 taps across a single surface.**
+
+**Stress test resolution -- Trust line (YELLOW from Scenario A, Top 3 Change #1):** Step 2 now includes the trust message "Your originals are never changed" visible above the account list. This is always present, not just on first use.
+
+```
+STEP 2: Source Add Flow with trust messaging
++-----------------------------------+
+|  RESEARCH                         |
+|  [< Sources]  Add Source          |
+|  ================================ |
+|  DraftCrane reads your files to   |
+|  help you search and reference    |
+|  them. Your originals are never   |
+|  changed.                         |
+|  -------------------------------- |
+|  FROM GOOGLE DRIVE                |
+|  +-------------------------------+|
+|  | scott@email.com               ||
+|  | Browse Google Drive       [>] ||
+|  +-------------------------------+|
+|                                   |
+|  FROM DEVICE                      |
+|  +-------------------------------+|
+|  | Upload file (.txt .md .docx   ||
+|  |   .pdf)                   [>] ||
+|  +-------------------------------+|
+|                                   |
+|  Connect another Google account   |
++-----------------------------------+
+```
+
+**Error states:**
+- **No Google accounts connected:** Shows only "Upload from device" and prominent "Connect Google Account" button.
+- **Drive API error:** Inline error banner: "Could not access Google Drive. Please try again." with Retry.
+- **File already added:** Checkmark badge, disabled checkbox, "Already in your sources" label.
+- **Network failure during add:** Source card shows "Error -- could not process" with Retry/Remove.
+
+**iPad notes:**
+- All touch targets minimum 44pt height.
+- Checkboxes: 44x44pt tap area (visually 24x24px icon).
+- Folder rows: full-width tap targets.
+- "Add Selected" footer: 48pt height, full width, sticky at bottom.
+
+---
+
+### Flow 2: Add Source from Local Device
+
+**Precondition:** Research Panel is open with Sources tab active.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap [+ Add] in Sources tab header | Sources tab | 1 |
+| 2 | Source Add Flow appears with trust line | Source Add Flow | 0 |
+| 3 | Tap "Upload file" row | Source Add Flow | 1 |
+| 4 | iOS/iPadOS file picker opens (system UI) | System file picker | 0 |
+| 5 | Navigate to and select file(s) | System file picker | 2-4 |
+| 6 | File picker closes. Source appears with "Processing..." spinner. | Sources tab | 0 |
+
+**Total: 4-7 taps across 2 surfaces (Sources tab + system file picker).**
+
+**Error states:**
+- **Unsupported file type:** "Unsupported file format" with Remove action.
+- **File too large:** "File too large (max 5MB)" with Remove action.
+- **Upload fails:** "Upload failed" with Retry and Remove.
+- **Text extraction fails:** "Could not extract text" with Remove.
+
+---
+
+### Flow 3: View a Source While Writing
+
+**Precondition:** Research Panel open, Sources tab active, at least one source.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap a source card in the source list | Sources tab | 1 |
+| 2 | Source Detail View replaces source list. Content loads. **Search field always visible at top.** | Source Detail View | 0 (transition) |
+| 3 | User reads source content. In landscape, editor visible to left. | Source Detail View + Editor | 0 |
+| 4 | Tap [< Sources] to return to list | Source Detail View | 1 |
+
+**Total: 2 taps.**
+
+**Stress test resolution -- Always-visible search (Top 3 Change #2):** The original design showed a search field only for documents over 10,000 words. The stress test found this too high -- users wanted search at 2,000-3,000 words. The search field is now always visible in the Source Detail View header, regardless of document length. It performs instant-filter search within the displayed content.
+
+```
+STEP 2: Source Detail View with always-visible search
++--------+---------------------------+-------------------+
+| Sidebar| Editor                    |  RESEARCH         |
+|        |                           |  [< Sources]      |
+|        | Chapter 4: Case Studies   |  Interview-S.doc  |
+|        |                           |  1,240w | 2h ago  |
+|        | Lorem ipsum dolor sit     |  [Search in doc.] |
+|        | amet, consectetur...      |  ================ |
+|        |                           |                   |
+|        | adipiscing elit. Sed do   |  The key insight   |
+|        | eiusmod tempor incididunt |  from our conver-  |
+|        | ut labore et dolore magna |  sation was that   |
+|        | aliqua.                   |  leadership in     |
+|        |                           |  distributed teams |
+|        |                           |  requires funda-   |
+|        |                           |  mentally differ-  |
+|        |                           |  ent approaches... |
+|        |                           |                    |
+|        |                           |  [Import as Ch.]   |
++--------+---------------------------+-------------------+
+```
+
+**Error states:**
+- **Content not cached:** Loading spinner; if Drive API fails, "Could not load content" with Retry/Back.
+- **Account disconnected:** "This source's Google account has been disconnected. Reconnect to view content."
+
+**iPad notes:**
+- Landscape: editor visible alongside panel. Core value proposition.
+- Portrait: panel is overlay. User cannot see editor while viewing source. [< Sources] and panel close are primary navigation.
+- Text selection via long-press. Selected text shows "Save to Clips" in floating toolbar.
+- Scroll position preserved when switching tabs; lost when navigating back to list.
+
+---
+
+### Flow 4: Search Sources with Natural Language Query
+
+**Precondition:** Research Panel open, at least one source with cached content.
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Ask" tab | Research Panel tab bar | 1 |
+| 2 | Ask tab shows input at bottom and suggested queries (or conversation history) | Ask tab | 0 |
+| 3 | Tap input field. Keyboard appears. | Ask tab | 1 |
+| 4 | Type natural-language question | Ask tab | 0 (typing) |
+| 5 | Tap Send (or Cmd+Return) | Ask tab | 1 |
+| 6 | Loading: "Searching across N sources..." | Ask tab | 0 |
+| 7 | AI response streams in. Result cards appear with cited passages. | Ask tab | 0 |
+
+**Total: 3 taps + typing.**
+
+```
+STEP 7: AI response with result cards
++-----------------------------------+
+|  RESEARCH                         |
+|  Sources  [Ask]  Clips     [x]   |
+|  ================================ |
+|                                   |
+|  You: What did my workshop notes  |
+|  say about psychological safety?  |
+|                                   |
+|  -------------------------------- |
+|  AI: I found 2 relevant passages: |
+|                                   |
+|  +-------------------------------+|
+|  | "Psychological safety was the ||
+|  | strongest predictor of team   ||
+|  | performance, with 67% of     ||
+|  | teams reporting measurable    ||
+|  | improvement."                 ||
+|  |                               ||
+|  | Workshop Notes March 2024     ||
+|  | [Save to Clips] [Insert]     ||
+|  +-------------------------------+|
+|                                   |
+|  +-------------------------------+|
+|  | "Teams with high psychologi-  ||
+|  | cal safety scores showed 2.3x ||
+|  | faster decision-making..."    ||
+|  |                               ||
+|  | Q4-Report.doc                 ||
+|  | [Save to Clips] [Insert]     ||
+|  +-------------------------------+|
+|                                   |
+|  ================================ |
+|  [Ask a follow-up...]       [->] |
++-----------------------------------+
+```
+
+**Error states:**
+- **No sources in project:** "Add source documents first." with "Go to Sources" link.
+- **No cached content:** "Your sources haven't been processed yet. Try again in a moment."
+- **AI query fails:** "Something went wrong. Please try again." with Retry.
+- **No results:** "I couldn't find relevant information about that in your sources. Try rephrasing."
+- **Slow (>5s):** Skeleton loader with "Searching across N sources..."
+- **Streaming interrupted:** Partial response with "Response was interrupted. Tap to retry."
+
+**iPad notes:**
+- Input at bottom (iMessage/chat pattern). Keyboard pushes conversation up via `visualViewport` API.
+- Send button: 44x44pt minimum. Disabled when input empty.
+- Suggested queries: tappable full-width rows (44pt height). Tap populates input and auto-submits.
+- External keyboard: Cmd+Return submits.
+- Result card action buttons: 44pt minimum touch targets.
+
+---
+
+### Flow 5: Save a Snippet from Search Results
+
+**Path A: Save from AI result (1 tap)**
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Save to Clips" on a result card | Ask tab | 1 |
+| 2 | **Optional chapter tag popup: "Save to: [All] [Ch. 1] [Ch. 2]..."** Defaults to "All" if dismissed. | Inline dropdown | 0-1 |
+| 3 | Button changes to checkmark "Saved." Clips tab badge increments. | Ask tab | 0 |
+
+**Path B: Save from Source Detail View (2-3 taps)**
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Long-press on text to select | Source Detail View | 1 |
+| 2 | Adjust selection handles | Source Detail View | 0-2 |
+| 3 | **Floating toolbar appears with "Copy" and "Save to Clips" -- both prominently labeled, full-height buttons** | Floating toolbar | 0 |
+| 4 | Tap "Save to Clips" | Floating toolbar | 1 |
+| 5 | Toast: "Saved to Clips." Clips badge increments. | Source Detail View | 0 |
+
+**Stress test resolution -- Text selection discoverability (YELLOW, Flow 5):** The floating toolbar now uses full-height (44pt) labeled buttons rather than small text links. "Save to Clips" is visually prominent alongside the system "Copy" action. Additionally, the Source Detail View shows a subtle hint below the content: "Tip: Select text to save passages to Clips." This hint appears only on the first 3 source views, then disappears.
+
+**Stress test resolution -- Chapter tagging for power users (YELLOW from Flow 8, Marcus RED):** When saving a clip, an optional chapter tag dropdown appears briefly. It defaults to "All chapters" and auto-dismisses after 2 seconds if not interacted with. Users who want to tag (Marcus) can tap a chapter; users who want simplicity (Diane) can ignore it.
+
+**Error states:**
+- **Clip already saved:** Button shows "Already saved" -- no-op with feedback.
+- **API fails:** Toast: "Could not save clip. Please try again." Button reverts.
+
+---
+
+### Flow 6: Insert a Snippet into the Editor
+
+**Path A: Insert from Clips tab (2 taps)**
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Clips" tab | Research Panel tab bar | 1 |
+| 2 | Tap "Insert" on a clip card | Clips tab | 1 |
+| 3 | Text inserted at cursor. Footnote auto-created. Toast: "Inserted with footnote." | Editor + Clips tab | 0 |
+
+**Path B: Insert from AI result (1 tap)**
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Insert" on a result card | Ask tab | 1 |
+| 2 | Text inserted at cursor with footnote. Toast: "Inserted with footnote." | Editor + Ask tab | 0 |
+
+**Stress test resolution -- iPad cursor position uncertainty (YELLOW, Flow 6):** The editor stores its last known cursor position in a ref (`lastSelectionRef`) that persists even when the editor loses focus to the Research Panel. On insert:
+
+1. If the editor has a valid stored selection, insert at that position.
+2. If no stored selection exists, append to the end of the chapter content with a toast: "Inserted at end of chapter."
+3. The insert action calls `editor.commands.focus()` **without** triggering the software keyboard. On iPad, this uses `editor.commands.focus(null, { scrollIntoView: true })` with a `requestAnimationFrame` wrapper to prevent viewport jumping.
+4. The blockquote + footnote insertion is a single Tiptap transaction, ensuring undo removes both together.
+
+**Fallback for no cursor:** If no chapter is selected, the Insert button is disabled with tooltip "Select a chapter to insert into."
+
+```
+AFTER INSERT:
++--------+---------------------------+-------------------+
+| Sidebar| Editor                    |  RESEARCH         |
+|        |                           |  Sources Ask [Clips]
+|        | Chapter 4: Case Studies   |  ================ |
+|        |                           |                   |
+|        | Teams that invest in      |  "Psychological   |
+|        | coaching see measurable   |  safety was the   |
+|        | returns. "Psychological   |  strongest..."    |
+|        | safety was the strongest  |  -- Workshop Notes|
+|        | predictor of team per-    |  [Inserted] [Del] |
+|        | formance, with 67% of    |                   |
+|        | teams reporting meas-     |                   |
+|        | urable improvement." [1]  |                   |
+|        |                           |                   |
+|        | ---                       |                   |
+|        | [1] Workshop Notes March  |                   |
+|        |     2024                  |                   |
++--------+---------------------------+-------------------+
+```
+
+---
+
+### Flow 7: Remove a Source
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Swipe left on source card (or tap "..." overflow) | Sources tab | 1 |
+| 2 | Tap "Remove" (red text) | Source card action area | 1 |
+| 3 | Confirmation dialog: "Remove [Title]? This removes the source from your project. The original file in Google Drive is not affected. Related clips will keep their text but lose the source link." | Center dialog | 0 |
+| 4 | Tap "Remove" in dialog | Center dialog | 1 |
+| 5 | Source fades out. Clips retain text with "[Source removed]" reference. | Sources tab | 0 |
+
+**Total: 3 taps (including confirmation).**
+
+---
+
+### Flow 8: Browse Collected Snippets on Research Board
+
+| Step | Action | Surface | Taps |
+|------|--------|---------|------|
+| 1 | Tap "Clips" tab. Badge shows count. | Research Panel tab bar | 1 |
+| 2 | Clips tab shows all saved clips. **Chapter filter dropdown at top: "All Chapters" / "Chapter 1" / "Chapter 2" / ...** | Clips tab | 0 |
+| 3 | Scroll and review clips. | Clips tab | 0 |
+| 4 | (Optional) Tap source title on a clip | Clip card | 1 |
+| 5 | **Sources tab opens with Source Detail View. A "Back to Clips" breadcrumb appears at top.** | Source Detail View | 0 |
+| 6 | Tap "Back to Clips" to return | Source Detail View | 1 |
+
+**Stress test resolution -- Flat clip list scaling (YELLOW, Flow 8; RED for Marcus):** Two changes:
+
+1. **Chapter filter:** A dropdown at the top of the Clips tab filters clips by chapter tag. Options: "All Chapters" (default), then each chapter in the project. This gives Marcus the chapter-level organization he needs without adding complexity for Diane (who can leave it on "All").
+
+2. **Cross-tab breadcrumb:** When navigating from Clips to a source detail, a "Back to Clips" breadcrumb replaces the standard "< Sources" back button. This eliminates the cross-tab disorientation identified in the stress test. The breadcrumb returns the user to the Clips tab with their previous filter and scroll position preserved.
+
+```
+STEP 2: Clips tab with chapter filter
++-----------------------------------+
+|  RESEARCH                         |
+|  Sources  Ask  [Clips (12)]  [x] |
+|  ================================ |
+|  [All Chapters  v]               |
+|  [Search clips...]               |
+|                                   |
+|  +-------------------------------+|
+|  | "Psychological safety was the ||
+|  | strongest predictor of team   ||
+|  | performance..."               ||
+|  |                               ||
+|  | Workshop Notes March 2024     ||
+|  | Ch. 4 | Saved 2h ago          ||
+|  | [Insert]           [Delete]   ||
+|  +-------------------------------+|
+|                                   |
+|  +-------------------------------+|
+|  | "Q4 results showed a 23%     ||
+|  | increase in leadership        ||
+|  | effectiveness scores..."      ||
+|  |                               ||
+|  | Q4-Report.doc                 ||
+|  | Ch. 6 | Saved 1d ago          ||
+|  | [Insert]           [Delete]   ||
+|  +-------------------------------+|
++-----------------------------------+
+```
+
+**Stress test resolution -- Research session organization (YELLOW, Scenario C):** The chapter filter, combined with the chapter tag on save (Flow 5), enables organized research sessions. Marcus can filter to "Chapter 4," see only clips tagged for that chapter, and work systematically through his research for each section.
+
+---
+
+### First-Use Experience
+
+**Stress test resolution -- Panel discoverability gap (YELLOW, Scenario A; Top 3 Change #3):**
+
+When a user first opens a project that has no sources, a one-time tooltip appears on the Research toolbar button:
+
+```
++--------------------------------------------------+
+| Editor toolbar:  B  I  U  ...  [Research]        |
+|                                      |            |
+|                                 +----v---------+ |
+|                                 | Have research | |
+|                                 | files? Tap    | |
+|                                 | here to bring | |
+|                                 | them in.      | |
+|                                 +---------------+ |
++--------------------------------------------------+
+```
+
+The tooltip:
+- Appears once per project, only when the project has zero sources.
+- Dismisses on tap anywhere, or after 8 seconds.
+- Uses a pulsing dot indicator on the Research button that persists until the panel is opened for the first time.
+- Is stored in `localStorage` per project: `research-nudge-dismissed-{projectId}`.
+
+Additionally, the Sources tab empty state provides clear guidance:
+
+> "No sources yet. Add your Google Docs, PDFs, or other research files to search and reference them while you write."
+
+---
+
+## 6. Panel Specifications
+
+### Landscape Layout (1024pt+ viewport width)
+
+```
++--------+------------------------------------------+------------------+
+| Sidebar| Editor                                   | Research Panel   |
+| 260pt  | flex (min 400pt)                         | 340pt            |
++--------+------------------------------------------+------------------+
+```
+
+| Element | Width | Constraints |
+|---------|-------|-------------|
+| Chapter Sidebar | 260pt fixed | Collapsible to 0pt. When collapsed, editor expands. |
+| Editor | Flex (remaining) | **Minimum 400pt.** If panel would push below 400pt, panel opens as overlay instead. |
+| Research Panel | 340pt fixed | Opens from right. Pushes editor left (does not overlay). |
+
+**Device-specific viability:**
+
+| Device | Orientation | Viewport | Sidebar | Editor | Research | Mode |
+|--------|-------------|----------|---------|--------|----------|------|
+| iPad Air 11" | Landscape | 1180pt | 260pt | 580pt | 340pt | Side-by-side |
+| iPad Air 11" | Portrait | 820pt | 260pt | 220pt | 340pt | **Overlay** |
+| iPad Pro 13" | Landscape | 1366pt | 260pt | 766pt | 340pt | Side-by-side |
+| iPad Pro 13" | Portrait | 1024pt | 260pt | 424pt | 340pt | Side-by-side |
+| iPad Mini 6 | Landscape | 1133pt | 260pt | 533pt | 340pt | Side-by-side |
+| iPad Mini 6 | Portrait | 744pt | 260pt | 144pt | 340pt | **Overlay** |
+
+**Sidebar auto-collapse:** When the Research Panel is open and the sidebar is also visible, if the editor width falls below 400pt, the sidebar auto-collapses. When the panel closes, the sidebar restores.
+
+### Portrait Layout (768pt-1023pt viewport width)
+
+```
++--------+------------------------------------------+
+| Sidebar| Editor                                   |
+| 260pt  | flex                                     |
++--------+----------+-----------+-------------------+
+                     |           |
+                     | Research  |  <- Overlay panel
+                     | Panel     |     from right
+                     | 85% width |
+                     |           |
+                     +-----------+
+```
+
+| Element | Width | Behavior |
+|---------|-------|----------|
+| Research Panel | 85% of viewport | Overlay from right. Editor dimmed behind. |
+| Backdrop | 15% visible on left | Tapping dismisses panel. Visual "peek" at editor. |
+
+**Overlay behavior:**
+- Slides in from right over 200ms (`ease-out`). Backdrop fades in (`bg-black/30`).
+- Closes: slides out over 150ms (`ease-in`). Backdrop fades out.
+- Swipe-right on panel (delta > 60pt) dismisses.
+- `prefers-reduced-motion`: instant appear/disappear.
+
+### Desktop Layout (1200pt+)
+
+Identical to landscape iPad but with more editor space. No additional desktop-specific patterns in initial implementation. Panel resizing (300pt-480pt drag handle) is a Phase C+ enhancement, hidden on touch devices.
+
+### Responsive Breakpoints
+
+| Breakpoint | Behavior |
+|------------|----------|
+| < 768pt | Research Panel always overlay (full-screen). Sidebar hidden. |
+| 768pt - 1023pt | Research Panel overlay (85% width). Sidebar visible. |
+| 1024pt+ | Research Panel side-by-side (340pt). Sidebar visible. |
+
+### Animation Specifications
+
+| Animation | Duration | Easing | Reduced Motion |
+|-----------|----------|--------|----------------|
+| Panel slide open | 200ms | `ease-out` | Instant (0ms) |
+| Panel slide close | 150ms | `ease-in` | Instant (0ms) |
+| Backdrop fade in | 200ms | `ease-out` | Instant |
+| Backdrop fade out | 150ms | `ease-in` | Instant |
+| Inline view transition (list <-> detail) | 150ms | `ease-in-out` | Instant |
+| Source card fade-out (on remove) | 200ms | `ease-out` | Instant |
+| Toast appear/disappear | 150ms / 300ms | `ease-out` / `ease-in` | Instant |
+
+### Safe Area Handling
+
+```css
+.research-panel {
+  padding-right: env(safe-area-inset-right, 0);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+
+.research-panel-overlay {
+  height: 100dvh; /* NOT 100vh -- accounts for Safari address bar */
+  padding-top: env(safe-area-inset-top, 0);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+}
+```
+
+---
+
+## 7. Component Specifications
+
+### ResearchPanel
+
+- **Name:** `ResearchPanel`
+- **Type:** New
+- **Location:** `web/src/components/research/research-panel.tsx`
+- **Purpose:** Top-level container. Tab navigation shell + panel open/close.
+
+```typescript
+interface ResearchPanelProps {
+  projectId: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onInsertSnippet: (text: string, sourceTitle: string, sourceId: string | null) => void;
+  canInsert: boolean;
+}
+```
+
+**States:** Closed, Open/Sources, Open/Ask, Open/Clips
+
+**Accessibility:**
+- `role="complementary"` with `aria-label="Research panel"`
+- Tab bar: `role="tablist"`, tabs: `role="tab"` with `aria-selected`
+- Tab panels: `role="tabpanel"` with `aria-labelledby`
+- Escape closes panel
+- Focus trap in overlay mode (portrait)
+
+---
+
+### SourcesTab
+
+- **Name:** `SourcesTab`
+- **Type:** New
+- **Location:** `web/src/components/research/sources-tab.tsx`
+- **Purpose:** Source list with search, inline add flow, inline detail view.
+
+```typescript
+interface SourcesTabProps {
+  projectId: string;
+}
+```
+
+**States:** List (default), Detail view, Add view, Loading, Empty, Error
+
+**Accessibility:**
+- `role="list"` with `role="listitem"` per card
+- Search: `aria-label="Search sources"`, `aria-live="polite"` for result count
+- Empty state with guidance text
+
+---
+
+### AskTab
+
+- **Name:** `AskTab`
+- **Type:** New
+- **Location:** `web/src/components/research/ask-tab.tsx`
+- **Purpose:** AI natural-language query with streaming results.
+
+```typescript
+interface AskTabProps {
+  projectId: string;
+  onSaveClip: (clip: {
+    content: string;
+    sourceId: string | null;
+    sourceTitle: string;
+    sourceLocation: string | null;
+    chapterId?: string;
+  }) => Promise<void>;
+  onInsertSnippet: (text: string, sourceTitle: string, sourceId: string | null) => void;
+  canInsert: boolean;
+}
+```
+
+**States:** Empty (suggested queries), Input focused, Loading, Results, Conversation (multi-Q&A), Error, No sources
+
+**Accessibility:**
+- Query input: `aria-label="Ask about your sources"`
+- Submit: `aria-label="Submit query"` / `aria-label="Searching..."`
+- Responses: `aria-live="polite"`
+- Loading: `aria-busy="true"`
+
+---
+
+### ClipsTab
+
+- **Name:** `ClipsTab`
+- **Type:** New
+- **Location:** `web/src/components/research/clips-tab.tsx`
+- **Purpose:** Saved snippet board with chapter filter, search, insert, delete.
+
+```typescript
+interface ClipsTabProps {
+  projectId: string;
+  chapters: Array<{ id: string; title: string }>;
+  onInsertSnippet: (text: string, sourceTitle: string, sourceId: string | null) => void;
+  canInsert: boolean;
+}
+```
+
+**States:** Empty, List, Searching, Chapter-filtered
+
+**Accessibility:**
+- `role="list"` with `role="listitem"` per card
+- Chapter filter: `aria-label="Filter clips by chapter"`
+- Search: `aria-label="Search clips"`
+- Insert: `aria-label="Insert into chapter with footnote"`
+
+---
+
+### SourceCard
+
+- **Name:** `SourceCard`
+- **Type:** New (replaces current source rows)
+- **Location:** `web/src/components/research/source-card.tsx`
+
+```typescript
+interface SourceCardProps {
+  source: SourceMaterial;
+  onTap: () => void;
+  onRemove: () => void;
+  onImportAsChapter: () => void;
+}
+```
+
+**States:** Normal, Processing, Error, Archived (account disconnected)
+
+**Accessibility:** Card is `button` (entire card tappable). Overflow: `aria-haspopup="menu"`. Min height 56pt, min tap target 44pt.
+
+---
+
+### SourceAddFlow
+
+- **Name:** `SourceAddFlow`
+- **Type:** New (replaces `AddSourceSheet` + `DriveBrowserSheet`)
+- **Location:** `web/src/components/research/source-add-flow.tsx`
+
+```typescript
+interface SourceAddFlowProps {
+  projectId: string;
+  driveAccounts: DriveAccount[];
+  onSourcesAdded: () => void;
+  onBack: () => void;
+  onConnectAccount: () => void;
+}
+```
+
+**States:** Account selection (with trust message), Drive browsing, Uploading, Adding
+
+**Key requirement:** Trust message "DraftCrane reads your files to help you search and reference them. Your originals are never changed." visible in account selection view.
+
+---
+
+### SourceDetailView
+
+- **Name:** `SourceDetailView`
+- **Type:** New (replaces `SourceViewerSheet`)
+- **Location:** `web/src/components/research/source-detail-view.tsx`
+
+```typescript
+interface SourceDetailViewProps {
+  sourceId: string;
+  title: string;
+  onBack: () => void;
+  /** Custom back label for cross-tab navigation */
+  backLabel?: string;
+  onImportAsChapter: (sourceId: string) => void;
+  onSaveClip: (clip: {
+    content: string;
+    sourceId: string;
+    sourceTitle: string;
+    sourceLocation: string | null;
+  }) => Promise<void>;
+  /** Optional: scroll to this text position on load */
+  scrollToPosition?: number;
+}
+```
+
+**States:** Loading, Loaded, Error, Search active
+
+**Key requirement:** Search field always visible in header (no word-count threshold). `backLabel` prop enables "Back to Clips" / "Back to Ask" breadcrumbs for cross-tab navigation.
+
+---
+
+### QueryInput
+
+- **Name:** `QueryInput`
+- **Type:** New
+- **Location:** `web/src/components/research/query-input.tsx`
+
+```typescript
+interface QueryInputProps {
+  placeholder: string;
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  isLoading: boolean;
+  disabled?: boolean;
+}
+```
+
+**States:** Empty, Focused, Has value, Loading, Disabled
+
+**Key requirements:** `enterkeyhint="send"`, minimum 16px font size, 48pt container height.
+
+---
+
+### ResultCard
+
+- **Name:** `ResultCard`
+- **Type:** New
+- **Location:** `web/src/components/research/result-card.tsx`
+
+```typescript
+interface ResultCardProps {
+  content: string;
+  sourceTitle: string;
+  sourceId: string | null;
+  sourceLocation: string | null;
+  onSaveToClips: () => void;
+  onInsert: () => void;
+  onViewSource: () => void;
+  isSaved: boolean;
+  canInsert: boolean;
+}
+```
+
+**States:** Default, Saved ("Save to Clips" becomes checkmark), Insert disabled
+
+**Key requirement:** Source title is a tappable link (navigates to Source Detail View). Text is selectable.
+
+---
+
+### ClipCard
+
+- **Name:** `ClipCard`
+- **Type:** New
+- **Location:** `web/src/components/research/clip-card.tsx`
+
+```typescript
+interface ClipCardProps {
+  clip: ResearchClip;
+  onInsert: () => void;
+  onDelete: () => void;
+  onViewSource: () => void;
+  canInsert: boolean;
+}
+```
+
+**States:** Default, Expanded (full text), Inserted indicator, Source removed
+
+**Key requirement:** Shows chapter tag if assigned. Source title tappable. Truncated at 300 chars with "Show more."
+
+---
+
+### SnippetInsertButton
+
+- **Name:** `SnippetInsertButton`
+- **Type:** New
+- **Location:** `web/src/components/research/snippet-insert-button.tsx`
+
+```typescript
+interface SnippetInsertButtonProps {
+  text: string;
+  sourceTitle: string;
+  sourceId: string | null;
+  onInsert: (text: string, sourceTitle: string, sourceId: string | null) => void;
+  disabled?: boolean;
+  variant?: "default" | "compact";
+}
+```
+
+**States:** Default ("Insert"), Disabled, Success ("Inserted" -- 1.5s, then reverts)
+
+**Key requirement:** 44pt minimum tap target. `aria-label="Insert quote into chapter with footnote"`.
+
+---
+
+### ResearchPanelProvider
+
+- **Name:** `ResearchPanelProvider`
+- **Type:** New
+- **Location:** `web/src/components/research/research-panel-provider.tsx`
+
+```typescript
+interface ResearchPanelContextValue {
+  // Panel state
+  isOpen: boolean;
+  activeTab: "sources" | "ask" | "clips";
+  openPanel: (tab?: "sources" | "ask" | "clips") => void;
+  closePanel: () => void;
+  setActiveTab: (tab: "sources" | "ask" | "clips") => void;
+
+  // Sources
+  sources: SourceMaterial[];
+  isSourcesLoading: boolean;
+  sourcesError: string | null;
+  fetchSources: () => Promise<void>;
+  removeSource: (sourceId: string) => Promise<void>;
+
+  // Source navigation
+  sourcesView: "list" | "detail" | "add";
+  activeSourceId: string | null;
+  viewSource: (sourceId: string) => void;
+  backToSourceList: () => void;
+  startAddFlow: () => void;
+
+  // Cross-tab navigation
+  returnTab: "ask" | "clips" | null;
+  navigateToSourceFromTab: (sourceId: string, returnTo: "ask" | "clips") => void;
+  returnToPreviousTab: () => void;
+
+  // Clips
+  clips: ResearchClip[];
+  isClipsLoading: boolean;
+  saveClip: (clip: Omit<ResearchClip, "id" | "createdAt">) => Promise<void>;
+  deleteClip: (clipId: string) => Promise<void>;
+  clipCount: number;
+}
+```
+
+---
+
+### FirstUseNudge
+
+- **Name:** `FirstUseNudge`
+- **Type:** New
+- **Location:** `web/src/components/research/first-use-nudge.tsx`
+
+```typescript
+interface FirstUseNudgeProps {
+  projectId: string;
+  hasAnySources: boolean;
+  isResearchPanelOpen: boolean;
+  targetRef: React.RefObject<HTMLButtonElement>;
+}
+```
+
+**Purpose:** Shows tooltip on Research toolbar button when project has no sources and panel has never been opened. Persists pulsing dot until first panel open.
+
+**Storage:** `localStorage` key: `research-nudge-dismissed-{projectId}`
+
+---
+
+## 8. Data Model Changes
+
+### New Tables
+
+#### research_clips
+
+```sql
+-- Migration: 0014_create_research_clips.sql
+
+CREATE TABLE research_clips (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  source_id TEXT REFERENCES source_materials(id) ON DELETE SET NULL,
+  source_title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  source_location TEXT,
+  chapter_id TEXT REFERENCES chapters(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_research_clips_project ON research_clips(project_id);
+CREATE INDEX idx_research_clips_source ON research_clips(source_id);
+CREATE INDEX idx_research_clips_chapter ON research_clips(chapter_id);
+
+-- Dedup: same content + source within a project
+CREATE UNIQUE INDEX idx_research_clips_dedup
+  ON research_clips(project_id, source_id, content)
+  WHERE source_id IS NOT NULL;
+```
+
+**Key decisions:**
+- `source_id` uses `ON DELETE SET NULL` -- removing a source preserves the clip text and title.
+- `source_title` stored redundantly so clips display the title even after source removal.
+- `chapter_id` is nullable -- clips can be untagged ("All chapters") or tagged to a specific chapter. Uses `ON DELETE SET NULL` so deleting a chapter unlinks but preserves the clip.
+- `content` max 10KB enforced at API level.
+- `source_location` is a human-readable reference ("Section 3", "Near beginning"), not a byte offset.
+
+#### research_queries (Phase B)
+
+```sql
+-- Migration: 0015_create_research_queries.sql
+
+CREATE TABLE research_queries (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  query TEXT NOT NULL,
+  result_count INTEGER NOT NULL DEFAULT 0,
+  processing_time_ms INTEGER,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_research_queries_project ON research_queries(project_id);
+```
+
+**Key decisions:**
+- AI responses are NOT stored. They are ephemeral/streamed. Users save what they want as clips.
+- Only query text and metadata stored for conversation history and analytics.
+
+#### source_content_fts (Phase A)
+
+```sql
+-- Migration: 0016_create_source_content_fts.sql
+
+CREATE VIRTUAL TABLE source_content_fts USING fts5(
+  source_id,
+  title,
+  content,
+  tokenize='porter unicode61'
+);
+```
+
+**Key decisions:**
+- D1 supports FTS5. Enables fast keyword search in Sources tab without a vector database.
+- Populated when source content is cached (after text extraction). Rebuilt on content refresh.
+- NOT used for AI queries (AI uses full source text via LLM). FTS is for the Sources tab search.
+
+### Modified Tables
+
+#### source_materials
+
+No schema changes. The text extraction service (#124) will populate `r2_key` and `cached_at` for `.docx` and `.pdf` in addition to existing Google Docs. A plain-text version (`sources/{sourceId}/content.txt`) is also generated for AI queries and FTS indexing.
+
+### Deprecated Tables
+
+#### chapter_sources
+
+```sql
+-- Migration: 0017_deprecate_chapter_sources.sql
+
+-- Table preserved for data integrity and potential rollback.
+-- Application code stops reading/writing to this table.
+-- After 90 days with no issues, a follow-up migration drops the table.
+-- No schema changes in this migration.
+```
+
+### R2 Storage Patterns
+
+| Data | Key Pattern | Notes |
+|------|-------------|-------|
+| Source content (HTML, for viewer) | `sources/{sourceId}/content.html` | Existing, unchanged |
+| Source content (plain text, for AI + FTS) | `sources/{sourceId}/content.txt` | **New:** generated during text extraction |
+| Uploaded local files (original) | `sources/{sourceId}/original.{ext}` | Existing for .txt/.md, extended for .docx/.pdf |
+
+### KV Cache Patterns
+
+No new KV patterns. Existing rate-limit patterns apply to the new research query endpoint (KV sliding window, 20 queries/min/user).
+
+---
+
+## 9. API Specification
+
+### Existing Endpoints -- Disposition
+
+| Endpoint | Disposition | Notes |
+|----------|-------------|-------|
+| `POST /projects/:projectId/sources` | **Keep** | Add Drive sources. No changes. |
+| `POST /projects/:projectId/sources/upload` | **Modify** | Expand accepted types to `.docx`, `.pdf`. |
+| `GET /projects/:projectId/sources` | **Keep** | List project sources. No changes. |
+| `GET /sources/:sourceId/content` | **Keep** | Get cached content. No changes. |
+| `DELETE /sources/:sourceId` | **Modify** | On delete, set `source_id = NULL` on referencing `research_clips`. |
+| `POST /sources/:sourceId/import-as-chapter` | **Keep** | No changes. |
+| `GET /chapters/:chapterId/sources` | **Remove** | Chapter-source linking eliminated. |
+| `POST /chapters/:chapterId/sources/:sourceId/link` | **Remove** | Chapter-source linking eliminated. |
+| `DELETE /chapters/:chapterId/sources/:sourceId/link` | **Remove** | Chapter-source linking eliminated. |
+
+### New Endpoints
+
+#### POST /projects/:projectId/research/query
+
+Natural-language query against project sources. Streams structured results with source citations.
+
+```typescript
+// Request
+interface ResearchQueryRequest {
+  query: string;
+  /** Optional: limit search to specific source IDs */
+  sourceIds?: string[];
+}
+
+// Response (SSE stream, Content-Type: text/event-stream)
+//
+// event: result
+// data: {"content":"...","sourceId":"...","sourceTitle":"...","sourceLocation":"..."}
+//
+// event: result
+// data: {"content":"...","sourceId":"...","sourceTitle":"...","sourceLocation":"..."}
+//
+// event: done
+// data: {"resultCount":2,"processingTimeMs":2340}
+//
+// event: error
+// data: {"error":"...","code":"QUERY_FAILED"}
+
+// Non-streaming fallback (Accept: application/json)
+interface ResearchQueryResponse {
+  results: Array<{
+    content: string;
+    sourceId: string;
+    sourceTitle: string;
+    sourceLocation: string | null;
+  }>;
+  summary: string;
+  processingTimeMs: number;
+}
+```
+
+**Rate limit:** 20 queries/minute/user (KV sliding window).
+
+**Error codes:**
+
+| Code | HTTP | Description |
+|------|------|-------------|
+| `NO_SOURCES` | 400 | Project has no sources with cached content |
+| `QUERY_TOO_LONG` | 400 | Query exceeds 1000 characters |
+| `RATE_LIMITED` | 429 | Exceeded 20 queries/minute |
+| `AI_UNAVAILABLE` | 503 | LLM service unavailable |
+| `QUERY_FAILED` | 500 | Internal error during query processing |
+
+#### GET /projects/:projectId/research/clips
+
+List saved clips for a project. Supports chapter filtering.
+
+```typescript
+// Query params: ?chapterId=xxx (optional, filters by chapter tag)
+interface ClipsListResponse {
+  clips: Array<{
+    id: string;
+    projectId: string;
+    sourceId: string | null;
+    sourceTitle: string;
+    content: string;
+    sourceLocation: string | null;
+    chapterId: string | null;
+    chapterTitle: string | null;
+    createdAt: string;
+  }>;
+}
+```
+
+#### POST /projects/:projectId/research/clips
+
+Save a new clip.
+
+```typescript
+interface SaveClipRequest {
+  content: string;
+  sourceId?: string;
+  sourceTitle: string;
+  sourceLocation?: string;
+  chapterId?: string;
+}
+
+// Response (201 Created, or 200 if duplicate)
+interface SaveClipResponse {
+  clip: {
+    id: string;
+    projectId: string;
+    sourceId: string | null;
+    sourceTitle: string;
+    content: string;
+    sourceLocation: string | null;
+    chapterId: string | null;
+    createdAt: string;
+  };
+}
+```
+
+**Deduplication:** If identical `content` + `sourceId` exists for the project, returns existing clip with 200.
+
+#### DELETE /research/clips/:clipId
+
+```typescript
+// Response (200)
+interface DeleteClipResponse {
+  success: boolean;
+}
+```
+
+**Authorization:** Clip ownership verified via project membership.
+
+#### GET /projects/:projectId/research/sources/search
+
+Full-text search across source content. For Sources tab search field.
+
+```typescript
+// Query params: ?q=keyword
+interface SourceSearchResponse {
+  results: Array<{
+    sourceId: string;
+    title: string;
+    snippet: string;
+    position: number;
+  }>;
+}
+```
+
+**Implementation:** D1 FTS5 on `source_content_fts`. Falls back to LIKE if FTS unavailable.
+
+### TypeScript Interfaces (Complete)
+
+```typescript
+// === Core Types ===
+
+interface SourceMaterial {
+  id: string;
+  projectId: string;
+  title: string;
+  driveFileId: string | null;
+  driveConnectionId: string | null;
+  mimeType: string;
+  wordCount: number | null;
+  r2Key: string | null;
+  cachedAt: string | null;
+  status: "pending" | "processing" | "cached" | "error";
+  errorMessage: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface ResearchClip {
+  id: string;
+  projectId: string;
+  sourceId: string | null;
+  sourceTitle: string;
+  content: string;
+  sourceLocation: string | null;
+  chapterId: string | null;
+  chapterTitle?: string | null;
+  createdAt: string;
+}
+
+interface AISearchResult {
+  content: string;
+  sourceId: string | null;
+  sourceTitle: string;
+  sourceLocation: string | null;
+  isSaved: boolean;
+}
+
+interface ConversationEntry {
+  id: string;
+  type: "query" | "response";
+  content: string;
+  results?: AISearchResult[];
+  timestamp: string;
+}
+
+interface DriveAccount {
+  connectionId: string;
+  email: string;
+  provider: "google";
+}
+
+// === State Types ===
+
+type ResearchTab = "sources" | "ask" | "clips";
+type SourcesView = "list" | "detail" | "add";
+
+interface ResearchPanelState {
+  isOpen: boolean;
+  activeTab: ResearchTab;
+  sourcesView: SourcesView;
+  activeSourceId: string | null;
+  driveConnectionId: string | null;
+  returnTab: "ask" | "clips" | null;
+}
+
+type ResearchPanelAction =
+  | { type: "OPEN_PANEL"; tab?: ResearchTab }
+  | { type: "CLOSE_PANEL" }
+  | { type: "SET_TAB"; tab: ResearchTab }
+  | { type: "VIEW_SOURCE"; sourceId: string; returnTo?: "ask" | "clips" }
+  | { type: "BACK_TO_LIST" }
+  | { type: "RETURN_TO_TAB" }
+  | { type: "START_ADD_FLOW" }
+  | { type: "SET_DRIVE_CONNECTION"; connectionId: string }
+  | { type: "FINISH_ADD" };
+```
+
+---
+
+## 10. Implementation Phases
+
+### Phase A: Foundation (Sources Tab + Panel Infrastructure)
+
+**Estimated effort:** 2-3 weeks, one developer.
+
+**What ships:** The Research Panel with full Sources tab. Panel replaces all existing source management UI. Ask and Clips tabs show "Coming soon" placeholders. Immediate value: fixes sheet stacking, eliminates chapter-source linking confusion, provides panel infrastructure.
+
+**Components built:**
+- `ResearchPanel`, `ResearchPanelProvider`
+- `SourcesTab`, `SourceCard`
+- `SourceAddFlow` (inline Drive browser + upload + trust message)
+- `SourceDetailView` (inline viewer + always-visible search)
+- `QueryInput` (reusable -- source search in Phase A, AI query in Phase B)
+- `FirstUseNudge`
+- Ask/Clips tab placeholders
+
+**Components removed:**
+- `SourcesPanel`, `AddSourceSheet`, `DriveBrowserSheet`, `SourceViewerSheet`
+- `useChapterSources` hook
+- ~50 source-related props from `EditorDialogsProps`
+
+**API changes:**
+- Remove 3 chapter-source endpoints
+- Add `GET /projects/:projectId/research/sources/search`
+- Modify `POST /projects/:projectId/sources/upload` for `.docx`, `.pdf`
+- Modify `DELETE /sources/:sourceId` for clip cascade
+
+**DB changes:**
+- Migration 0014: `research_clips` table (created early, used in Phase C)
+- Migration 0016: `source_content_fts` virtual table
+- Migration 0017: `chapter_sources` deprecation
+
+**Ship criteria:**
+- [ ] Research Panel opens/closes correctly in landscape and portrait on iPad Air, Pro, Mini
+- [ ] Sources tab shows all project sources with search
+- [ ] Inline Drive browser works (navigate, select, add)
+- [ ] Source Detail View renders content with always-visible search
+- [ ] Trust message visible in add flow
+- [ ] First-use nudge appears for projects with no sources
+- [ ] All touch targets >= 44pt
+- [ ] No sheet stacking
+- [ ] EditorDialogsProps reduced to <= 5 research-related props
+- [ ] Existing auto-save and Drive write-through unaffected
+
+**Risks:**
+- `SourceAddFlow` reuses `useDriveBrowser` hook but renders inline. Minor hook adjustments may be needed.
+- Removing chapter-source linking is a breaking change for existing users. Phase 0 user count is very low; display a one-time notice.
+
+### Phase B: AI Integration (Ask Tab)
+
+**Estimated effort:** 3-4 weeks, one developer.
+
+**Prerequisite spikes:** #134 (prompt engineering), #135 (doc parsing), #136 (chunking strategy) must complete before Phase B begins.
+
+**What ships:** Ask tab becomes functional. Users type questions, receive streaming AI results with citations. "Save to Clips" on results. Source citation links navigate to Source Detail View.
+
+**Components built:**
+- `AskTab` (full implementation)
+- `ResultCard`
+- `SnippetInsertButton` (basic version -- full editor integration in Phase C)
+
+**API changes:**
+- Add `POST /projects/:projectId/research/query` (SSE streaming)
+- Add `POST /projects/:projectId/research/clips` (save clip)
+- Add `GET /projects/:projectId/research/clips` (for badge count)
+
+**DB changes:**
+- Migration 0015: `research_queries` table
+
+**Ship criteria:**
+- [ ] Ask tab accepts natural-language queries
+- [ ] Results stream in with source citations
+- [ ] "Save to Clips" works on result cards
+- [ ] Source title links navigate to Source Detail View with "Back to Ask" breadcrumb
+- [ ] Suggested queries appear on first visit
+- [ ] Error/empty/loading states all handled
+- [ ] Query latency < 5s for projects with up to 20 sources
+- [ ] Rate limiting enforced (20 queries/min)
+- [ ] iPad keyboard handling correct in Ask tab
+
+**Risks:**
+- AI query quality is the existential risk. Bad answers = product failure. Spike outputs must produce reliable approaches.
+- SSE streaming on Workers has execution time limits.
+- Performance at scale (100+ docs) requires testing. Chunking must handle large libraries.
+
+### Phase C: Board + Editor Integration (Clips Tab + Footnotes)
+
+**Estimated effort:** 2-3 weeks, one developer.
+
+**What ships:** Clips tab fully functional. Chapter filter, search, delete. Insert action creates blockquote + footnote in editor. Tiptap footnote extension built.
+
+**Components built:**
+- `ClipsTab` (full implementation with chapter filter)
+- `ClipCard`
+- `SnippetInsertButton` (full editor integration)
+- Tiptap footnote extension (new node type)
+- Footnote rendering in chapter content
+
+**API changes:**
+- Add `DELETE /research/clips/:clipId`
+- Clip save/list endpoints already exist from Phase B
+
+**Ship criteria:**
+- [ ] Clips tab shows all clips with chapter filter
+- [ ] Search filters clips by text and source title
+- [ ] Delete works (swipe or button)
+- [ ] Insert places blockquote at cursor with auto-footnote
+- [ ] Footnotes render at bottom of chapter
+- [ ] Undo removes blockquote + footnote together
+- [ ] Insert works from both Clips tab and Ask tab
+- [ ] Chapter tag dropdown appears when saving clips
+- [ ] Cross-tab navigation with "Back to Clips" breadcrumb works
+- [ ] Footnotes survive Drive write-through (HTML serialization)
+
+**Risks:**
+- Tiptap footnote extension is non-trivial. Must handle serialization, undo/redo, and Drive write-through.
+- Cursor position management between editor and Research Panel on iPad requires thorough testing.
+- Insert must not break three-tier save (local, R2, Drive).
+
+---
+
+## 11. Decisions Log
+
+### Decision 1: Option B over Option A and Option C
+
+**Decided:** Option B ("Research Companion") with three tabs.
+
+**Why:** Both personas independently selected it. Option A lacked AI search, which both identified as the breakthrough capability. Option C's all-or-nothing AI bet was too risky -- both personas wanted manual browsing as a first-class alternative.
+
+**Dissenting opinions:** None from personas. Option C's "ask-first" philosophy was admired but premature without proven AI quality.
+
+### Decision 2: Eliminate chapter-source linking
+
+**Decided:** Remove the link/unlink concept entirely. Sources are project-level.
+
+**Why:** The current state analysis (02a) found the action had invisible outcomes, the term "link" was overloaded and confusing, and neither persona used the feature as intended. Diane would "tap it, see nothing changed, tap again to unlink, give up." Marcus wanted the underlying concept (associate sources with chapters) but not the UI.
+
+**Resolution:** Implicit tracking via clip chapter tags replaces explicit linking. When a clip is tagged to a chapter, that's the chapter-source relationship.
+
+### Decision 3: Chapter tag on clips instead of chapter-source links
+
+**Decided:** Clips have an optional `chapter_id` field. Clips tab has a chapter filter dropdown.
+
+**Why:** The stress test rated Marcus's clip management as RED for the flat list. Marcus needs chapter-level organization. Rather than re-introducing chapter-source linking (which failed), the organization lives at the clip level, which is where it provides the most value: "these are the passages I've collected for Chapter 4."
+
+**Dissenting opinions:** Diane did not ask for this. The design makes it optional (default: "All chapters") so it adds zero complexity for users who don't need it.
+
+### Decision 4: Always-visible search in Source Detail View
+
+**Decided:** Search field is always visible, regardless of document length.
+
+**Why:** The original 10,000-word threshold was too high. Diane's stress test noted that scrolling through a 3,000-5,000 word document looking for one sentence was tedious. "Ctrl+F should always be available."
+
+**Dissenting opinions:** None.
+
+### Decision 5: Trust messaging in Source Add Flow
+
+**Decided:** Display "DraftCrane reads your files to help you search and reference them. Your originals are never changed." in the Source Add Flow, always visible.
+
+**Why:** The stress test identified Drive modification anxiety as a YELLOW trust issue. Both personas' deepest concern with any tool touching their Drive is "will it change my files?" The removal dialog already says "Drive is not affected," but the trust barrier is at the connection point.
+
+**Dissenting opinions:** None. Deemed zero-cost to implement with outsized trust impact.
+
+### Decision 6: First-use nudge for Research Panel
+
+**Decided:** One-time tooltip + pulsing dot on the Research toolbar button when project has zero sources.
+
+**Why:** The stress test rated Scenario A (first-time experience) as YELLOW specifically because "the Research Panel is hidden by default" and "without guidance, a new user might not find it for days." The entire value proposition requires users to add sources. Discoverability is a funnel problem.
+
+**Dissenting opinions:** None. One-time, non-intrusive, targeted.
+
+### Decision 7: Cross-tab breadcrumb for source navigation
+
+**Decided:** When navigating from Clips or Ask to a source detail, show "Back to Clips" / "Back to Ask" instead of "< Sources."
+
+**Why:** The stress test rated Flow 8 as YELLOW partly due to cross-tab navigation confusion. "I went from Clips to Sources without explicitly choosing to switch tabs. That's logical but disorienting." The breadcrumb preserves the user's mental context.
+
+**Dissenting opinions:** None.
+
+### Decision 8: Button-only insertion, no drag-and-drop
+
+**Decided:** Clips are inserted via "Insert" button, not drag-and-drop.
+
+**Why:** Drag-and-drop is unreliable on iPad Safari. The industry research (01-research) confirmed this. Button insertion is reliable, predictable, and accessible.
+
+**Dissenting opinions:** Marcus might prefer drag-and-drop on desktop. Reserved as a Phase C+ enhancement for pointer devices only.
+
+### Decision 9: Blockquote + footnote insertion format
+
+**Decided:** Inserted clips are wrapped in a Tiptap blockquote node with a superscript footnote reference. Footnotes render at bottom of chapter.
+
+**Why:** The stress test identified automatic footnotes as a "moment of delight." Diane: "I hate doing footnotes. The fact that tapping Insert creates a properly formatted footnote automatically -- that's magical."
+
+**Dissenting opinions:** Diane noted she sometimes wants to insert text without blockquote formatting (for paraphrasing). Future enhancement: "Insert as quote" vs. "Insert citation only."
+
+### Decision 10: Sources tab as default tab (not Ask)
+
+**Decided:** Sources tab is the default when the panel opens.
+
+**Why:** The Sources tab is the simplest, most concrete tab. It shows files the user recognizes. The Ask tab requires the user to formulate a question, which is a higher cognitive bar for first-time users. Starting with Sources builds familiarity before introducing AI.
+
+**Dissenting opinions:** Diane said she'd "live in the Ask tab" after learning it. But for onboarding, Sources-first is safer. Users can easily switch.
+
+---
+
+## 12. Appendix: User Feedback Resolution Tracker
+
+| # | Finding | Source | Rating | Resolution | Section |
+|---|---------|--------|--------|------------|---------|
+| 1 | Text selection discoverability for custom clips | Flow 5, Path B | YELLOW | Full-height labeled buttons in floating toolbar + "Tip: Select text to save passages" hint on first 3 views | [Flow 5](#flow-5-save-a-snippet-from-search-results) |
+| 2 | iPad cursor position uncertainty on insert | Flow 6 | YELLOW | `lastSelectionRef` stores position; `requestAnimationFrame` wrapper prevents viewport jumping; fallback to append-to-end | [Flow 6](#flow-6-insert-a-snippet-into-the-editor) |
+| 3 | Flat clip list doesn't scale for Marcus (100+ docs) | Flow 8, Marcus RED | YELLOW/RED | Chapter filter dropdown in Clips tab; optional chapter tag when saving clips | [Flow 8](#flow-8-browse-collected-snippets-on-research-board) |
+| 4 | Panel discoverability gap for new users | Scenario A | YELLOW | One-time tooltip + pulsing dot on Research toolbar button; clear Sources tab empty state | [First-Use Experience](#first-use-experience) |
+| 5 | Flat clip list doesn't support research session organization | Scenario C | YELLOW | Chapter filter + chapter tag enable per-chapter clip organization | [Flow 8](#flow-8-browse-collected-snippets-on-research-board) |
+| 6 | Trust line needed during source addition | Top 3 Change #1 | Requested | "Your originals are never changed" in Source Add Flow | [Flow 1](#flow-1-add-source-from-google-drive) |
+| 7 | In-document search threshold too high (10,000 words) | Top 3 Change #2 | Requested | Always-visible search in Source Detail View | [Flow 3](#flow-3-view-a-source-while-writing) |
+| 8 | First-use nudge for Research Panel | Top 3 Change #3 | Requested | Tooltip + pulsing dot for projects with zero sources | [First-Use Experience](#first-use-experience) |
+| 9 | Cross-tab navigation confusion (Clips to Sources) | Flow 8, Scenario concern | YELLOW | "Back to Clips" / "Back to Ask" breadcrumb in Source Detail View | [Flow 8](#flow-8-browse-collected-snippets-on-research-board) |
+| 10 | "Cached" terminology unclear | Terminology review | Observation | Changed to "Updated Xh ago" in display text | [Component Specs: SourceCard](#sourcecard) |
+| 11 | Clips terminology slightly confusing at first | Terminology review | Observation | Clear empty state: "Save passages from your sources to reference them later" | [Component Specs: ClipsTab](#clipstab) |
+| 12 | Portrait mode: 15% editor strip may be wasted space | iPad-specific concern | YELLOW | Maintained as visual context cue. Full-screen with "Back to editor" is a future option if testing confirms. | [Panel Specifications](#portrait-layout-768pt-1023pt-viewport-width) |
+| 13 | Marcus wants "select entire folder" for bulk add | Flow 1, Marcus YELLOW | Observation | Deferred to post-Phase A. Current design handles folder-by-folder addition. | [Decisions Log](#decisions-log) |
+| 14 | Blockquote-only insertion; sometimes want plain text + citation | Flow 6, Diane note | Observation | Deferred. Future: "Insert as quote" vs. "Insert citation only" options. | [Decision 9](#decision-9-blockquote--footnote-insertion-format) |

--- a/docs/design/source-review/revised-issues.md
+++ b/docs/design/source-review/revised-issues.md
@@ -1,0 +1,1029 @@
+# Revised Issues: DraftCrane Source/Research UX
+
+> Companion to `design-spec.md`
+> Covers all backlog issues #121-137 plus new issues discovered during the design review
+> Date: 2026-02-19
+
+---
+
+## Summary Table
+
+| Original # | Disposition | New Title | Phase | Effort |
+|-------------|-------------|-----------|-------|--------|
+| #121 | Keep | Authorize Google Drive access for source file reading | A | S |
+| #122 | Rewrite | Select Google Drive files as project sources via inline Drive browser | A | M |
+| #123 | Rewrite | Upload local files (.txt, .md, .docx, .pdf) as project sources | A | S |
+| #124 | Keep (extend) | Backend text extraction service for .docx, .pdf, .txt with FTS indexing | A | L |
+| #125 | Rewrite | AI natural language query endpoint with SSE streaming | B | L |
+| #126 | Keep | Chunk source text and build effective LLM prompts | B | M |
+| #127 | Keep | Parse LLM responses into structured snippet list with source references | B | M |
+| #128 | Rewrite | Research Panel with tab navigation and toolbar toggle | A | L |
+| #129 | Rewrite | Ask tab with query input, streaming results, and result cards | B | L |
+| #130 | Rewrite | Tappable source citations that navigate to source detail with breadcrumb | B | S |
+| #131 | Rewrite | Save snippets to Clips from AI results and source text selection | C | M |
+| #132 | Rewrite | Clips tab with chapter filter, search, and management | C | M |
+| #133 | Rewrite | Insert clips into editor with automatic footnote creation | C | L |
+| #134 | Keep | SPIKE: LLM prompt engineering for structured snippet output | Pre-B | S |
+| #135 | Keep | SPIKE: Document parsing library evaluation for .pdf and .docx | Pre-A | S |
+| #136 | Keep | SPIKE: Content chunking strategy and context window management | Pre-B | S |
+| #137 | Rewrite | SPIKE: Source content renderer with scroll-to-position for Research Panel | A | S |
+| NEW-1 | New | Research Panel infrastructure: context provider and state machine | A | M |
+| NEW-2 | New | Trust messaging in Source Add Flow | A | XS |
+| NEW-3 | New | First-use nudge for Research Panel discovery | A | S |
+| NEW-4 | New | Always-visible search in Source Detail View | A | S |
+| NEW-5 | New | Cross-tab navigation with breadcrumb for source citations | B | S |
+| NEW-6 | New | Chapter tag on clips for power user organization | C | S |
+| NEW-7 | New | Tiptap footnote extension for auto-citation | C | L |
+| NEW-8 | New | Remove chapter-source linking (deprecate endpoints and table) | A | S |
+| NEW-9 | New | Full-text search endpoint for Sources tab | A | M |
+| NEW-10 | New | Research clips CRUD API | B-C | M |
+
+---
+
+## Issue #121: Authorize Google Drive access for source file reading
+
+**Replaces/Updates:** #121
+**Type:** story
+**Phase:** A
+**Dependencies:** None
+**Effort:** S
+
+### Story
+As a user, I want to connect my Google Drive account so DraftCrane can read my source documents for research purposes.
+
+### Acceptance Criteria
+- [ ] OAuth flow connects user's Google Drive with read-only scope
+- [ ] Connected accounts appear in the Source Add Flow
+- [ ] Multiple Google accounts supported
+- [ ] Disconnect flow removes access tokens
+- [ ] Existing Drive OAuth implementation preserved
+
+### Technical Notes
+No changes from current implementation. This issue is a prerequisite for #122.
+
+### Design References
+- design-spec.md, Section 5: Flow 1 (precondition: Google account connected)
+
+---
+
+## Issue #122: Select Google Drive files as project sources via inline Drive browser
+
+**Replaces/Updates:** #122
+**Type:** story
+**Phase:** A
+**Dependencies:** #121 (Drive auth), #128 (Research Panel), NEW-2 (trust messaging)
+**Effort:** M
+
+### Story
+As a user, I want to browse my Google Drive within the Research Panel's Sources tab and select files to add as project sources, without any sheet stacking or modal layering.
+
+### Acceptance Criteria
+- [ ] [+ Add] button in Sources tab header opens inline Source Add Flow
+- [ ] Source Add Flow replaces source list content (no sheet/modal overlay)
+- [ ] Trust message visible: "DraftCrane reads your files to help you search and reference them. Your originals are never changed."
+- [ ] Connected Drive accounts shown with "Browse Google Drive" option
+- [ ] Selecting an account opens inline folder browser
+- [ ] Folder browser shows folders (navigable via tap) and Google Docs (selectable via checkbox)
+- [ ] Files already in project show "Already added" with disabled checkbox
+- [ ] "Add N Selected" button adds all checked files as project sources
+- [ ] After adding, view transitions back to source list with new sources showing "Processing..."
+- [ ] [< Sources] back button at every level for navigation
+- [ ] All touch targets minimum 44pt
+- [ ] Checkboxes: 44x44pt tap area (visually 24x24px)
+- [ ] "Add Selected" footer: 48pt height, full width, sticky at bottom
+
+### Technical Notes
+- Replaces `AddSourceSheet` and `DriveBrowserSheet` components
+- Reuses existing `useDriveBrowser` hook, rendered inline within Sources tab instead of as sheets
+- The `SourceAddFlow` component manages its own sub-navigation (account list > folder browser)
+- DraftCrane stack: Next.js frontend, Cloudflare Workers backend, Google Drive API
+
+### Design References
+- design-spec.md, Section 5: Flow 1 (Add Source from Google Drive)
+- design-spec.md, Section 7: SourceAddFlow component spec
+
+---
+
+## Issue #123: Upload local files (.txt, .md, .docx, .pdf) as project sources
+
+**Replaces/Updates:** #123
+**Type:** story
+**Phase:** A
+**Dependencies:** #124 (text extraction for .docx/.pdf), #128 (Research Panel)
+**Effort:** S
+
+### Story
+As a user, I want to upload files from my device as project sources via the Source Add Flow, so I can include research documents that are not in Google Drive.
+
+### Acceptance Criteria
+- [ ] "Upload from device" option in Source Add Flow alongside Drive accounts
+- [ ] Tapping opens iPadOS/iOS system file picker
+- [ ] File picker accepts `.txt`, `.md`, `.docx`, `.pdf`
+- [ ] Uploaded file appears in source list with "Processing..." spinner
+- [ ] After text extraction, source shows word count and "Updated" timestamp
+- [ ] File size limit: 5MB (clear error for larger files)
+- [ ] Unsupported file types show clear error message
+- [ ] Upload failure shows "Upload failed" with Retry/Remove actions
+- [ ] Text extraction failure shows "Could not extract text" with Remove action
+
+### Technical Notes
+- System file picker is native iPadOS -- handles its own touch targets
+- `accept` attribute: `.txt,.md,.docx,.pdf,application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+- "Upload from device" row: 56pt minimum height, full-width tap target
+- Backend: existing upload endpoint expanded for new file types
+
+### Design References
+- design-spec.md, Section 5: Flow 2 (Add Source from Local Device)
+
+---
+
+## Issue #124: Backend text extraction service for .docx, .pdf, .txt with FTS indexing
+
+**Replaces/Updates:** #124
+**Type:** story
+**Phase:** A
+**Dependencies:** #135 (doc parsing spike)
+**Effort:** L
+
+### Story
+As the system, I need to extract plain text from uploaded and Drive-sourced documents so that source content can be displayed in the viewer, searched in the Sources tab, and queried by the AI.
+
+### Acceptance Criteria
+- [ ] Extract text from Google Docs (existing, via Drive API export)
+- [ ] Extract text from .docx files (new, via parsing library from spike #135)
+- [ ] Extract text from .pdf files (new, via parsing library from spike #135)
+- [ ] Extract text from .txt and .md files (existing)
+- [ ] Store HTML version in R2 at `sources/{sourceId}/content.html` (for viewer display)
+- [ ] Store plain text version in R2 at `sources/{sourceId}/content.txt` (for AI queries and FTS)
+- [ ] Populate `source_content_fts` FTS5 virtual table after extraction
+- [ ] Update `source_materials.word_count`, `r2_key`, and `cached_at` after extraction
+- [ ] Handle extraction failures gracefully (set source status to "error" with message)
+- [ ] Re-extraction on content refresh (update FTS index)
+
+### Technical Notes
+- Spike #135 output determines the parsing library
+- FTS5 table creation is Migration 0016 (see design-spec.md, Section 8)
+- Plain text version is critical path for Phase B (AI queries)
+- DraftCrane stack: Cloudflare Workers (Hono), R2 for storage, D1 for metadata/FTS
+
+### Design References
+- design-spec.md, Section 8: Data Model (source_content_fts, R2 storage patterns)
+
+---
+
+## Issue #125: AI natural language query endpoint with SSE streaming
+
+**Replaces/Updates:** #125
+**Type:** story
+**Phase:** B
+**Dependencies:** #124 (text extraction), #126 (chunking), #127 (response parsing), #134 (prompt engineering spike)
+**Effort:** L
+
+### Story
+As the Ask tab frontend, I need an API endpoint that accepts a natural language query and returns structured results with source citations, streamed as SSE events.
+
+### Acceptance Criteria
+- [ ] `POST /projects/:projectId/research/query` endpoint
+- [ ] Accepts `{ query: string, sourceIds?: string[] }`
+- [ ] Collects source content from R2 (plain text versions)
+- [ ] Applies chunking strategy from spike #136 output
+- [ ] Sends chunks + query to LLM (Workers AI or OpenAI per project tier)
+- [ ] Parses response into individual cited results (per spike #134 output)
+- [ ] Streams results as SSE: `event: result`, `event: done`, `event: error`
+- [ ] Each result includes `content`, `sourceId`, `sourceTitle`, `sourceLocation`
+- [ ] Rate limited: 20 queries/minute/user (KV sliding window)
+- [ ] Saves query metadata to `research_queries` table
+- [ ] Returns 400 if project has no sources with cached content
+- [ ] Returns 400 if query exceeds 1000 characters
+- [ ] Non-streaming fallback for `Accept: application/json`
+- [ ] Query processing time measured and included in `done` event
+
+### Technical Notes
+- SSE streaming on Cloudflare Workers has execution time limits -- stream and close promptly
+- Rate limiting uses existing KV sliding window pattern (see MEMORY.md)
+- LLM selection: Workers AI (Mistral Small 3.1) for edge tier, OpenAI (gpt-4o) for frontier tier
+- AI responses are ephemeral (not stored in D1). Only query metadata stored.
+
+### Design References
+- design-spec.md, Section 9: API Specification (POST /research/query)
+
+---
+
+## Issue #126: Chunk source text and build effective LLM prompts
+
+**Replaces/Updates:** #126
+**Type:** story
+**Phase:** B
+**Dependencies:** #136 (chunking strategy spike)
+**Effort:** M
+
+### Story
+As the research query backend, I need a chunking service that breaks source content into appropriately sized pieces for LLM context windows, preserving document boundaries and metadata.
+
+### Acceptance Criteria
+- [ ] Chunk plain text source content into segments appropriate for LLM context window
+- [ ] Preserve source document boundaries (no cross-document chunks)
+- [ ] Include source metadata (title, ID) with each chunk
+- [ ] Handle variable document lengths (500 words to 10,000+ words)
+- [ ] Chunking strategy informed by spike #136 output
+- [ ] Chunks suitable for both Workers AI (smaller context) and OpenAI (larger context)
+
+### Technical Notes
+- Chunking approach determined by spike #136
+- Must handle Marcus scenario: 100+ documents, potentially millions of words total
+- Context window management is critical for answer quality
+
+### Design References
+- design-spec.md, Section 9: API Specification (query endpoint implementation notes)
+
+---
+
+## Issue #127: Parse LLM responses into structured snippet list with source references
+
+**Replaces/Updates:** #127
+**Type:** story
+**Phase:** B
+**Dependencies:** #134 (prompt engineering spike)
+**Effort:** M
+
+### Story
+As the research query backend, I need a response parser that extracts structured results (passage text + source citation) from LLM output, matching the `ResultCard` data format.
+
+### Acceptance Criteria
+- [ ] Parse LLM response into individual cited results
+- [ ] Each result has: `content`, `sourceId`, `sourceTitle`, `sourceLocation`
+- [ ] Handle cases where LLM cites multiple sources in one passage
+- [ ] Handle cases where LLM finds no relevant results
+- [ ] Handle malformed LLM output gracefully (fallback to raw text with best-effort citation)
+- [ ] Response format informed by spike #134 output
+
+### Technical Notes
+- Prompt format and expected response structure from spike #134
+- Parser must be resilient to LLM output variations
+- Source location is human-readable ("Section 3", "Near beginning"), not byte offset
+
+### Design References
+- design-spec.md, Section 9: TypeScript interfaces (AISearchResult)
+
+---
+
+## Issue #128: Research Panel with tab navigation and toolbar toggle
+
+**Replaces/Updates:** #128
+**Type:** story
+**Phase:** A
+**Dependencies:** NEW-1 (context provider)
+**Effort:** L
+
+### Story
+As a user, I want a Research button in the editor toolbar that toggles a right-hand panel with three tabs (Sources, Ask, Clips), providing a unified research workspace alongside my writing.
+
+### Acceptance Criteria
+- [ ] Research icon/button in editor toolbar toggles panel open/close
+- [ ] Panel has three tabs: Sources, Ask, Clips
+- [ ] Keyboard shortcut: Cmd+Shift+R toggles panel
+- [ ] Escape key closes panel
+- [ ] Landscape (1024pt+): panel is 340pt, pushes editor (editor minimum 400pt)
+- [ ] Portrait (<1024pt): panel is 85% overlay with dimmed backdrop
+- [ ] Swipe-right on overlay panel dismisses it (delta > 60pt)
+- [ ] Tapping backdrop in overlay mode closes panel
+- [ ] Panel uses `100dvh` and `env(safe-area-inset-*)`
+- [ ] Tab state persists while panel is open (switching tabs doesn't reset content)
+- [ ] `prefers-reduced-motion` disables slide animations
+- [ ] Panel does not break editor auto-save or Drive write-through
+- [ ] All text minimum 16px (prevents iOS auto-zoom)
+- [ ] Panel accessibility: `role="complementary"`, `aria-label="Research panel"`
+- [ ] Tab bar: `role="tablist"`, tabs: `role="tab"` with `aria-selected`
+- [ ] Tab panels: `role="tabpanel"` with `aria-labelledby`
+- [ ] Focus trap in overlay mode
+- [ ] Ask and Clips tabs show "Coming soon" placeholder in Phase A
+
+### Technical Notes
+- Replaces: `SourcesPanel`, `AddSourceSheet`, `DriveBrowserSheet`, `SourceViewerSheet`
+- `EditorDialogsProps` reduced from ~100 props to <= 5 research-related props
+- Panel layout is CSS Grid or Flexbox with fixed widths
+- Sidebar auto-collapse: when panel open and sidebar visible, if editor < 400pt, sidebar collapses
+
+### Design References
+- design-spec.md, Section 3: Information Architecture
+- design-spec.md, Section 6: Panel Specifications
+
+---
+
+## Issue #129: Ask tab with query input, streaming results, and result cards
+
+**Replaces/Updates:** #129
+**Type:** story
+**Phase:** B
+**Dependencies:** #125 (query endpoint), #128 (panel infrastructure)
+**Effort:** L
+
+### Story
+As a user, I want to type natural-language questions about my source documents in the Ask tab and see streaming results with cited passages and action buttons.
+
+### Acceptance Criteria
+- [ ] Query input at bottom of Ask tab (iMessage/chat pattern)
+- [ ] Send button: 44pt minimum, disabled when input empty
+- [ ] Cmd+Return keyboard shortcut submits query
+- [ ] `enterkeyhint="send"` on input for mobile keyboards
+- [ ] Input minimum 16px font size (prevents iOS zoom)
+- [ ] Empty state shows 3 suggested queries (tappable, auto-submit)
+- [ ] Loading: skeleton loader with "Searching across N sources..."
+- [ ] Results stream in as SSE events, appearing progressively
+- [ ] Each `ResultCard` shows: passage text, source title (tappable), source location
+- [ ] "Save to Clips" action on each card (updates to checkmark "Saved")
+- [ ] "Insert" action on each card (inserts at editor cursor with footnote)
+- [ ] Error state: "Something went wrong" with Retry button
+- [ ] No-results state: helpful message with rephrasing suggestions
+- [ ] No-sources state: "Add source documents first" with link to Sources tab
+- [ ] Conversation history persists within session (scrollable Q&A pairs)
+- [ ] Virtual keyboard handling: conversation scrolls up via `visualViewport` API
+- [ ] Result card action buttons: 44pt minimum touch targets
+
+### Technical Notes
+- Uses `useAIResearch` hook for query state, streaming, conversation
+- SSE consumption via `EventSource` or `fetch` with stream reader
+- Source title taps use cross-tab navigation (see NEW-5)
+
+### Design References
+- design-spec.md, Section 5: Flow 4 (Search Sources with Natural Language Query)
+- design-spec.md, Section 7: AskTab, QueryInput, ResultCard components
+
+---
+
+## Issue #130: Tappable source citations that navigate to source detail with breadcrumb
+
+**Replaces/Updates:** #130
+**Type:** story
+**Phase:** B
+**Dependencies:** #128 (panel infrastructure), #137 (preview component spike), NEW-5 (cross-tab navigation)
+**Effort:** S
+
+### Story
+As a user, when I see a source title in an AI result card or clip card, I want to tap it and see the full source document, scrolled near the cited passage, with a clear way to return to where I was.
+
+### Acceptance Criteria
+- [ ] Source title in `ResultCard` is a tappable link (44pt minimum)
+- [ ] Source title in `ClipCard` is a tappable link (44pt minimum)
+- [ ] Tapping navigates to Sources tab > Source Detail View for that source
+- [ ] If `sourceLocation` is available, detail view scrolls to approximate position
+- [ ] If `sourceLocation` is null, detail view opens at top
+- [ ] "Back to Ask" or "Back to Clips" breadcrumb replaces standard "< Sources" back button
+- [ ] Tapping breadcrumb returns to the originating tab with state preserved
+- [ ] Source titles for removed sources show "[Source removed]" -- not tappable
+
+### Technical Notes
+- Cross-tab navigation managed by `ResearchPanelProvider` (`returnTab` state)
+- Scroll-to-position uses text search matching from spike #137 output
+- `SourceDetailView.backLabel` prop controls breadcrumb text
+
+### Design References
+- design-spec.md, Section 5: Flow 8 (cross-tab navigation resolution)
+- design-spec.md, Section 7: SourceDetailView (`backLabel` prop)
+
+---
+
+## Issue #131: Save snippets to Clips from AI results and source text selection
+
+**Replaces/Updates:** #131
+**Type:** story
+**Phase:** C
+**Dependencies:** #128 (panel infrastructure), #125 (for AI result saving path), NEW-6 (chapter tags), NEW-10 (clips API)
+**Effort:** M
+
+### Story
+As a user, I want to save useful passages to my Clips collection from two paths: tapping "Save to Clips" on an AI result, and selecting text in the Source Detail View.
+
+### Acceptance Criteria
+- [ ] "Save to Clips" button on each AI `ResultCard`
+- [ ] Button changes to checkmark "Saved" after saving
+- [ ] Duplicate detection: same content + source does not create second clip
+- [ ] Long-press text selection in Source Detail View triggers iOS selection handles
+- [ ] Floating toolbar appears above selection with "Copy" and "Save to Clips" (both 44pt height)
+- [ ] "Save to Clips" in floating toolbar is prominently labeled, full-height button
+- [ ] Optional chapter tag dropdown appears briefly after save action (2s auto-dismiss)
+- [ ] Chapter dropdown defaults to "All chapters"
+- [ ] Saved clip includes: content, sourceId, sourceTitle, sourceLocation, optional chapterId
+- [ ] Clips tab badge updates to show new count
+- [ ] Toast notification: "Saved to Clips"
+- [ ] Source Detail View shows hint on first 3 views: "Tip: Select text to save passages to Clips"
+- [ ] API: `POST /projects/:projectId/research/clips`
+
+### Technical Notes
+- Floating toolbar uses `position: fixed` based on `getSelection().getRangeAt(0).getBoundingClientRect()`
+- Toolbar must appear above selection, not behind panel header
+- Chapter tag dropdown is a lightweight inline element, not a modal
+- Hint stored in `localStorage`: `source-detail-hint-count-{projectId}`
+
+### Design References
+- design-spec.md, Section 5: Flow 5 (Save a Snippet)
+- design-spec.md, Section 12: Feedback Resolution #1 (text selection discoverability)
+
+---
+
+## Issue #132: Clips tab with chapter filter, search, and management
+
+**Replaces/Updates:** #132
+**Type:** story
+**Phase:** C
+**Dependencies:** #131 (save clips), NEW-6 (chapter tags), NEW-10 (clips API)
+**Effort:** M
+
+### Story
+As a user, I want to view, search, filter, and manage my saved clips in the Clips tab, organized by chapter when needed.
+
+### Acceptance Criteria
+- [ ] Clips tab shows all saved clips, most recent first
+- [ ] Chapter filter dropdown at top: "All Chapters" / per-chapter options
+- [ ] Filtering by chapter shows only clips tagged to that chapter
+- [ ] Search field filters clips by text content and source title
+- [ ] Each `ClipCard` shows: snippet text (truncated 300 chars, "Show more"), source title (tappable), chapter tag (if assigned), save date
+- [ ] Delete action via swipe-left or overflow menu (no modal confirmation for clips)
+- [ ] Empty state: "No clips yet. Save passages from AI results or select text in source documents to build your research board."
+- [ ] Clips with removed sources show "[Source removed]" in gray (not tappable)
+- [ ] Clip text exceeding 300 chars truncated with "Show more" toggle (inline expand)
+- [ ] All action buttons: 44pt minimum height
+- [ ] API: `GET /projects/:projectId/research/clips?chapterId=xxx`, `DELETE /research/clips/:clipId`
+
+### Technical Notes
+- Chapter filter uses project's chapter list from existing sidebar data
+- Search is client-side filtering (clips loaded in memory -- typically < 200 clips)
+- Swipe-to-delete follows same pattern as Flow 7 (source removal)
+
+### Design References
+- design-spec.md, Section 5: Flow 8 (Browse Collected Snippets)
+- design-spec.md, Section 7: ClipsTab, ClipCard components
+- design-spec.md, Section 12: Feedback Resolution #3 (flat clip list scaling)
+
+---
+
+## Issue #133: Insert clips into editor with automatic footnote creation
+
+**Replaces/Updates:** #133
+**Type:** story
+**Phase:** C
+**Dependencies:** #131 (save clips), #132 (clips tab), NEW-7 (Tiptap footnote extension)
+**Effort:** L
+
+### Story
+As a user, I want to insert a saved clip into my chapter at the cursor position, with the text wrapped in a blockquote and a footnote automatically created referencing the source document.
+
+### Acceptance Criteria
+- [ ] "Insert" button on each `ClipCard` and `ResultCard`
+- [ ] Tapping Insert: focuses editor, inserts blockquote at stored cursor position
+- [ ] Footnote auto-created with source title as reference text
+- [ ] Footnote rendered at bottom of chapter content
+- [ ] If no cursor position stored, text appended to end of chapter with toast: "Inserted at end of chapter"
+- [ ] If no chapter selected, Insert button disabled with tooltip
+- [ ] Success toast: "Inserted with footnote"
+- [ ] Undo (Cmd+Z) removes blockquote and footnote together (single transaction)
+- [ ] Inserted content participates in Drive write-through (auto-saves normally)
+- [ ] Footnotes serialize to HTML correctly for Drive export
+- [ ] No viewport jumping or keyboard flickering on iPad during insertion
+- [ ] `lastSelectionRef` tracks editor cursor position even when Research Panel has focus
+- [ ] `requestAnimationFrame` wrapper on `editor.commands.focus()` prevents iPad viewport issues
+- [ ] **NOT** drag-and-drop. Button-only insertion. (iPad Safari limitation)
+
+### Technical Notes
+- Tiptap footnote extension (NEW-7) must be complete before this issue
+- Insert is a single Tiptap transaction: `chain().insertContent(blockquote).insertContent(footnoteRef).run()`
+- Footnote node type must handle: serialization to HTML, deserialization, undo/redo, Drive write-through
+- `editor.commands.focus(null, { scrollIntoView: true })` with `requestAnimationFrame` for iPad
+- The three-tier save architecture (local > R2 > Drive) requires footnote HTML to be valid
+
+### Design References
+- design-spec.md, Section 5: Flow 6 (Insert a Snippet)
+- design-spec.md, Section 12: Feedback Resolution #2 (cursor position)
+
+---
+
+## Issue #134: SPIKE: LLM prompt engineering for structured snippet output
+
+**Replaces/Updates:** #134
+**Type:** spike
+**Phase:** Pre-B
+**Dependencies:** None
+**Effort:** S
+
+### Story
+As an engineer, I need to determine the optimal prompt format and expected response structure for the research query endpoint, ensuring the LLM returns individually cited passages rather than free-form text.
+
+### Acceptance Criteria
+- [ ] Test prompt formats with both Workers AI (Mistral Small 3.1) and OpenAI (gpt-4o)
+- [ ] Define a response format that can be reliably parsed into `{ content, sourceTitle, sourceLocation }` tuples
+- [ ] Test with real-world source content (interviews, reports, notes) of varying quality
+- [ ] Document hallucination rate: what percentage of citations are incorrect?
+- [ ] Document the prompt template and parsing strategy for use in #125 and #127
+- [ ] Evaluate: can the LLM distinguish between sources when multiple documents discuss the same topic?
+
+### Technical Notes
+- Output directly informs #125 (query endpoint) and #127 (response parsing)
+- Consider JSON-mode output for reliable parsing
+- Test with 5, 20, and 50+ source documents to evaluate scale behavior
+
+### Design References
+- design-spec.md, Section 9: API Specification (ResearchQueryRequest/Response types)
+
+---
+
+## Issue #135: SPIKE: Document parsing library evaluation for .pdf and .docx
+
+**Replaces/Updates:** #135
+**Type:** spike
+**Phase:** Pre-A
+**Dependencies:** None
+**Effort:** S
+
+### Story
+As an engineer, I need to evaluate document parsing libraries that run on Cloudflare Workers for extracting plain text from .pdf and .docx files.
+
+### Acceptance Criteria
+- [ ] Evaluate at least 3 parsing approaches for .docx (e.g., mammoth, docx-parser, custom XML)
+- [ ] Evaluate at least 3 parsing approaches for .pdf (e.g., pdf-parse, pdfjs-dist, external service)
+- [ ] Test each with 5+ real-world documents of varying complexity
+- [ ] Measure: extraction quality, performance on Workers, bundle size impact
+- [ ] Determine if any require external services (not pure Workers runtime)
+- [ ] Recommend a parsing library for each format
+- [ ] Document limitations and edge cases
+
+### Technical Notes
+- Output directly informs #124 (text extraction service)
+- Workers runtime constraints: no Node.js native modules, limited CPU time
+- Consider WebAssembly-based parsers for Workers compatibility
+
+### Design References
+- design-spec.md, Section 8: Data Model (R2 storage patterns for content.txt)
+
+---
+
+## Issue #136: SPIKE: Content chunking strategy and context window management
+
+**Replaces/Updates:** #136
+**Type:** spike
+**Phase:** Pre-B
+**Dependencies:** None
+**Effort:** S
+
+### Story
+As an engineer, I need to determine how to chunk source document content for LLM context windows, balancing search quality against token limits.
+
+### Acceptance Criteria
+- [ ] Evaluate chunking strategies: fixed-size, paragraph-based, semantic
+- [ ] Test with source libraries of 5, 20, 50, and 100+ documents
+- [ ] Measure retrieval quality: does the LLM find the right passages?
+- [ ] Determine chunk size appropriate for Workers AI (128K context) and OpenAI (128K context)
+- [ ] Handle the "too many documents for one context window" scenario (Marcus with 100+ docs)
+- [ ] Document the recommended chunking strategy for use in #126
+- [ ] Evaluate: do we need vector embeddings, or can we use keyword search + full-document context?
+
+### Technical Notes
+- Output directly informs #126 (chunking implementation)
+- Consider hybrid approach: keyword search to narrow, then full context for selected documents
+- D1 FTS5 provides keyword search; vector search would require additional infrastructure
+
+### Design References
+- design-spec.md, Section 9: API Specification (query endpoint implementation notes)
+
+---
+
+## Issue #137: SPIKE: Source content renderer with scroll-to-position for Research Panel
+
+**Replaces/Updates:** #137
+**Type:** spike
+**Phase:** A
+**Dependencies:** None
+**Effort:** S
+
+### Story
+As an engineer, I need to build a proof-of-concept for the Source Detail View component that renders source content within the Research Panel's 340pt width, supports text selection, always-visible search, and scroll-to-position.
+
+### Acceptance Criteria
+- [ ] Renders HTML content in a scrollable container at 340pt width
+- [ ] Supports programmatic scroll to a text position (for citation link navigation)
+- [ ] Text selection works on iPad (long-press activates iOS selection handles)
+- [ ] Performance acceptable for 10,000+ word documents on iPad Safari
+- [ ] Always-visible search field in header (type to highlight matches, navigate between them)
+- [ ] Minimum 16px text size
+- [ ] Test with real source content of varying lengths (500, 2000, 5000, 10000+ words)
+
+### Technical Notes
+- Search implementation: client-side text matching with `window.find()` or custom highlight
+- Scroll-to-position: use `element.scrollIntoView()` after finding text match
+- Performance concern: very long documents may need virtualized rendering
+- DraftCrane stack: React component, rendered within Research Panel
+
+### Design References
+- design-spec.md, Section 5: Flow 3 (always-visible search resolution)
+- design-spec.md, Section 7: SourceDetailView component spec
+
+---
+
+## NEW-1: Research Panel infrastructure: context provider and state machine
+
+**Replaces/Updates:** New issue
+**Type:** tech-debt
+**Phase:** A
+**Dependencies:** None
+**Effort:** M
+
+### Story
+As a developer, I need a `ResearchPanelProvider` context and `useResearchPanel` state machine hook that encapsulate all Research Panel state, replacing the current 50+ source-related props threaded through `EditorDialogsProps`.
+
+### Acceptance Criteria
+- [ ] `ResearchPanelProvider` context created at `web/src/components/research/research-panel-provider.tsx`
+- [ ] `useResearchPanel` hook uses `useReducer` with typed actions
+- [ ] State machine has exactly 6 valid states: Closed, Sources-List, Sources-Detail, Sources-Add, Ask, Clips
+- [ ] Invalid state transitions are impossible (reducer enforces)
+- [ ] All source-related props removed from `EditorDialogsProps` (~50 props)
+- [ ] `EditorDialogsProps` receives at most 3 research-related props: `isResearchPanelOpen`, `onCloseResearchPanel`, `projectId`
+- [ ] Cross-tab navigation state (`returnTab`) managed by provider
+- [ ] `useChapterSources` hook deleted entirely
+- [ ] Old source components (`SourcesPanel`, `AddSourceSheet`, `DriveBrowserSheet`, `SourceViewerSheet`) removed from `EditorDialogs` rendering
+
+### Technical Notes
+
+State machine reducer:
+```typescript
+type ResearchPanelAction =
+  | { type: "OPEN_PANEL"; tab?: ResearchTab }
+  | { type: "CLOSE_PANEL" }
+  | { type: "SET_TAB"; tab: ResearchTab }
+  | { type: "VIEW_SOURCE"; sourceId: string; returnTo?: "ask" | "clips" }
+  | { type: "BACK_TO_LIST" }
+  | { type: "RETURN_TO_TAB" }
+  | { type: "START_ADD_FLOW" }
+  | { type: "SET_DRIVE_CONNECTION"; connectionId: string }
+  | { type: "FINISH_ADD" };
+```
+
+### Design References
+- design-spec.md, Section 7: ResearchPanelProvider
+- design-spec.md, Section 3: Information Architecture (What Gets Removed)
+
+---
+
+## NEW-2: Trust messaging in Source Add Flow
+
+**Replaces/Updates:** New issue (from stress test Top 3 Change #1)
+**Type:** story
+**Phase:** A
+**Dependencies:** #122 (Source Add Flow)
+**Effort:** XS
+
+### Story
+As a user connecting my Google Drive, I want to see a clear message that DraftCrane will not modify my files, so I feel confident adding my source documents.
+
+### Acceptance Criteria
+- [ ] Text "DraftCrane reads your files to help you search and reference them. Your originals are never changed." visible in Source Add Flow
+- [ ] Appears above the account list, always visible (not dismissible, not first-time-only)
+- [ ] Styled as a subtle trust indicator (muted text, small icon), not an alert or warning
+- [ ] Present on every visit to the add flow (builds trust through repetition)
+
+### Technical Notes
+- Simple static text element in `SourceAddFlow` component
+- No backend changes
+- Informed by stress test: both personas' deepest concern is "will it change my files?"
+
+### Design References
+- design-spec.md, Section 5: Flow 1 (Step 2 with trust messaging)
+- design-spec.md, Section 12: Feedback Resolution #6
+
+---
+
+## NEW-3: First-use nudge for Research Panel discovery
+
+**Replaces/Updates:** New issue (from stress test Top 3 Change #3)
+**Type:** story
+**Phase:** A
+**Dependencies:** #128 (Research Panel)
+**Effort:** S
+
+### Story
+As a new user, I want a subtle prompt indicating the Research panel exists so I discover it without needing external instructions.
+
+### Acceptance Criteria
+- [ ] When a project has zero sources AND the Research Panel has never been opened, show a tooltip on the Research toolbar button
+- [ ] Tooltip text: "Have research files? Tap here to bring them in."
+- [ ] Tooltip dismisses on tap anywhere, or after 8 seconds
+- [ ] Pulsing dot indicator on Research button persists until panel is opened for first time
+- [ ] Nudge state stored in `localStorage`: `research-nudge-dismissed-{projectId}`
+- [ ] Appears once per project (not once per session)
+- [ ] Does not appear if user has already opened the panel or has sources
+
+### Technical Notes
+- `FirstUseNudge` component positioned relative to the Research toolbar button via `targetRef`
+- Uses `createPortal` to render above other content
+- Pulsing dot: CSS animation, `prefers-reduced-motion` disables animation (static dot instead)
+
+### Design References
+- design-spec.md, Section 5: First-Use Experience
+- design-spec.md, Section 7: FirstUseNudge component spec
+- design-spec.md, Section 12: Feedback Resolution #4 and #8
+
+---
+
+## NEW-4: Always-visible search in Source Detail View
+
+**Replaces/Updates:** New issue (from stress test Top 3 Change #2)
+**Type:** story
+**Phase:** A
+**Dependencies:** #137 (preview component spike)
+**Effort:** S
+
+### Story
+As a user viewing a source document, I want a search field always visible so I can quickly find specific passages regardless of document length.
+
+### Acceptance Criteria
+- [ ] Search field in Source Detail View header, always visible (no word-count threshold)
+- [ ] Type to search: highlights matching text in the document content
+- [ ] Navigate between matches (up/down arrows or next/previous buttons)
+- [ ] Match count displayed: "3 of 12 matches"
+- [ ] Search is instant (client-side text matching)
+- [ ] Search field: `aria-label="Search within document"`
+- [ ] Works on documents of all lengths (500 to 10,000+ words)
+- [ ] Keyboard shortcut: Cmd+F focuses the search field (when Source Detail View is active)
+
+### Technical Notes
+- Client-side implementation: highlight matching text nodes in rendered HTML
+- Use `mark` element or custom highlight for matches
+- Previous design used 10,000-word threshold; removed per stress test feedback
+
+### Design References
+- design-spec.md, Section 5: Flow 3 (always-visible search)
+- design-spec.md, Section 12: Feedback Resolution #7
+
+---
+
+## NEW-5: Cross-tab navigation with breadcrumb for source citations
+
+**Replaces/Updates:** New issue (from stress test Flow 8 YELLOW)
+**Type:** story
+**Phase:** B
+**Dependencies:** #128 (panel infrastructure), #130 (source citation navigation)
+**Effort:** S
+
+### Story
+As a user who taps a source title in the Ask or Clips tab, I want to see the source document with a clear "Back to Ask" or "Back to Clips" breadcrumb so I can return to where I was without confusion.
+
+### Acceptance Criteria
+- [ ] When navigating to Source Detail View from Ask tab, back button reads "Back to Ask"
+- [ ] When navigating from Clips tab, back button reads "Back to Clips"
+- [ ] Tapping the breadcrumb returns to the originating tab with scroll position and state preserved
+- [ ] When navigating directly within Sources tab, standard "< Sources" back button shown
+- [ ] `ResearchPanelProvider` tracks `returnTab` state ("ask" | "clips" | null)
+- [ ] Tab content is preserved in memory during cross-tab navigation (not unmounted)
+
+### Technical Notes
+- `SourceDetailView` receives `backLabel` prop to customize back button text
+- `ResearchPanelProvider` manages `returnTab` via `VIEW_SOURCE` and `RETURN_TO_TAB` actions
+- Tab components use `display: none` instead of conditional rendering to preserve state
+
+### Design References
+- design-spec.md, Section 5: Flow 8 (cross-tab breadcrumb resolution)
+- design-spec.md, Section 12: Feedback Resolution #9
+
+---
+
+## NEW-6: Chapter tag on clips for power user organization
+
+**Replaces/Updates:** New issue (from stress test: Marcus RED on flat clips)
+**Type:** story
+**Phase:** C
+**Dependencies:** #131 (save clips), #132 (clips tab)
+**Effort:** S
+
+### Story
+As a power user with many clips, I want to optionally tag clips to specific chapters so I can filter and organize my research by chapter.
+
+### Acceptance Criteria
+- [ ] When saving a clip, optional chapter tag dropdown appears briefly (2 second auto-dismiss)
+- [ ] Dropdown shows: "All chapters" (default), then each project chapter
+- [ ] If user does not interact, clip is saved without chapter tag ("All chapters")
+- [ ] If user taps a chapter, clip is tagged to that chapter
+- [ ] Clips tab chapter filter dropdown shows only chapters that have tagged clips (plus "All")
+- [ ] `research_clips.chapter_id` column stores the tag (nullable FK to chapters)
+- [ ] Deleting a chapter sets `chapter_id = NULL` on affected clips (ON DELETE SET NULL)
+- [ ] Chapter tag displayed on `ClipCard` as a small label (e.g., "Ch. 4")
+
+### Technical Notes
+- `research_clips` table already has `chapter_id` column (Migration 0014)
+- Chapter list comes from existing project chapters data
+- Auto-dismiss dropdown: 2s timeout, cancelled if user interacts
+- Simple UX for Diane (ignore it) and useful for Marcus (tap a chapter)
+
+### Design References
+- design-spec.md, Section 5: Flow 5 (chapter tag on save)
+- design-spec.md, Section 5: Flow 8 (chapter filter in Clips tab)
+- design-spec.md, Section 11: Decision 3
+- design-spec.md, Section 12: Feedback Resolution #3
+
+---
+
+## NEW-7: Tiptap footnote extension for auto-citation
+
+**Replaces/Updates:** New issue
+**Type:** story
+**Phase:** C
+**Dependencies:** None (can start in parallel with other Phase C work)
+**Effort:** L
+
+### Story
+As a developer, I need a Tiptap footnote extension that supports auto-generated footnote references when clips are inserted into the editor.
+
+### Acceptance Criteria
+- [ ] New Tiptap node type: `footnoteRef` (inline, superscript number in text)
+- [ ] New Tiptap node type: `footnoteContent` (block, rendered at bottom of chapter)
+- [ ] Footnotes numbered sequentially within a chapter
+- [ ] Renumbering on insert/delete (if footnote 2 is deleted, footnote 3 becomes 2)
+- [ ] Serialization to HTML: `<sup>[N]</sup>` for reference, `<div class="footnotes">` section at bottom
+- [ ] Deserialization from HTML: correctly parses footnotes on chapter load
+- [ ] Undo/redo: removing a footnoteRef also removes the footnoteContent (and vice versa)
+- [ ] Footnote content format: "[N] Source Title" (simple format, not formal citation style)
+- [ ] Works with Drive write-through (HTML output is valid for Google Docs import)
+- [ ] No cursor positioning issues when footnote is at end of blockquote
+
+### Technical Notes
+- Follow Tiptap extension patterns from existing codebase (check `web/src/components/` for Tiptap config)
+- Footnote renumbering uses ProseMirror decorations or computed node attributes
+- HTML serialization must produce clean output for Drive write-through
+- Consider: footnote section separated by `<hr>` at bottom of chapter content
+
+### Design References
+- design-spec.md, Section 5: Flow 6 (insert with footnote)
+- design-spec.md, Section 11: Decision 9 (blockquote + footnote format)
+
+---
+
+## NEW-8: Remove chapter-source linking (deprecate endpoints and table)
+
+**Replaces/Updates:** New issue
+**Type:** tech-debt
+**Phase:** A
+**Dependencies:** None
+**Effort:** S
+
+### Story
+As a developer, I need to remove the chapter-source linking feature (endpoints, hooks, UI) and deprecate the `chapter_sources` table.
+
+### Acceptance Criteria
+- [ ] Remove `GET /chapters/:chapterId/sources` endpoint
+- [ ] Remove `POST /chapters/:chapterId/sources/:sourceId/link` endpoint
+- [ ] Remove `DELETE /chapters/:chapterId/sources/:sourceId/link` endpoint
+- [ ] Delete `useChapterSources` hook (`web/src/hooks/use-chapter-sources.ts`)
+- [ ] Remove all "Link to Chapter" / "Unlink" UI from source components
+- [ ] Migration 0017: document `chapter_sources` table deprecation (table preserved, no writes)
+- [ ] `chapter_sources` table NOT dropped (preserved for 90-day rollback window)
+- [ ] One-time notice for users who had linked sources: "Source organization has been simplified. Your sources are now available project-wide."
+
+### Technical Notes
+- Low user count in Phase 0 makes this safe
+- Table preserved for data integrity; future migration drops after 90 days
+- Removes 3 API routes from `workers/dc-api/src/routes/chapters.ts`
+
+### Design References
+- design-spec.md, Section 3: What Was Removed
+- design-spec.md, Section 8: chapter_sources (deprecated)
+- design-spec.md, Section 11: Decision 2
+
+---
+
+## NEW-9: Full-text search endpoint for Sources tab
+
+**Replaces/Updates:** New issue
+**Type:** story
+**Phase:** A
+**Dependencies:** #124 (text extraction with FTS indexing)
+**Effort:** M
+
+### Story
+As a user, I want to search across my source documents by keyword in the Sources tab, finding documents that contain specific terms.
+
+### Acceptance Criteria
+- [ ] `GET /projects/:projectId/research/sources/search?q=keyword` endpoint
+- [ ] Searches source titles and content using D1 FTS5
+- [ ] Returns: sourceId, title, matching snippet, approximate position
+- [ ] Results ordered by relevance (FTS5 rank)
+- [ ] Falls back to LIKE search if FTS not available
+- [ ] Returns empty array for no matches
+- [ ] Query minimum 2 characters
+- [ ] Frontend: Sources tab search field calls this endpoint (debounced 300ms)
+- [ ] Search results replace the source list, showing matching sources with snippets
+
+### Technical Notes
+- D1 FTS5 virtual table `source_content_fts` created in Migration 0016
+- FTS populated by text extraction service (#124)
+- Snippet extraction: FTS5 `snippet()` function or manual extraction around match
+
+### Design References
+- design-spec.md, Section 8: source_content_fts table
+- design-spec.md, Section 9: GET /research/sources/search endpoint
+
+---
+
+## NEW-10: Research clips CRUD API
+
+**Replaces/Updates:** New issue
+**Type:** story
+**Phase:** B (save/list), C (delete)
+**Dependencies:** Migration 0014 (research_clips table)
+**Effort:** M
+
+### Story
+As the Research Panel frontend, I need API endpoints for creating, listing, and deleting research clips.
+
+### Acceptance Criteria
+- [ ] `POST /projects/:projectId/research/clips` -- save a clip
+  - [ ] Accepts: content, sourceId, sourceTitle, sourceLocation, chapterId (all optional except content and sourceTitle)
+  - [ ] Deduplication: same content + sourceId returns existing clip (200) instead of creating duplicate (201)
+  - [ ] Content max 10KB (400 error for larger)
+  - [ ] Returns created clip with id, timestamps
+- [ ] `GET /projects/:projectId/research/clips` -- list clips
+  - [ ] Optional query param: `?chapterId=xxx` for chapter filtering
+  - [ ] Returns clips ordered by `created_at DESC`
+  - [ ] Includes `chapterTitle` from joined chapters table
+  - [ ] Clips with removed sources show `sourceId: null`, `sourceTitle` preserved
+- [ ] `DELETE /research/clips/:clipId` -- delete a clip
+  - [ ] Authorization: verify clip belongs to user's project
+  - [ ] Returns `{ success: true }`
+- [ ] All endpoints require authentication (Clerk)
+- [ ] All endpoints use parameterized queries (`.bind()` for D1)
+
+### Technical Notes
+- `research_clips` table created in Migration 0014
+- Dedup index: `idx_research_clips_dedup` on (project_id, source_id, content) WHERE source_id IS NOT NULL
+- Routes mounted at `/research/clips` in `workers/dc-api/src/routes/research.ts` (new route file)
+
+### Design References
+- design-spec.md, Section 8: research_clips table
+- design-spec.md, Section 9: Clips API endpoints
+
+---
+
+## Dependency Graph
+
+```
+Pre-Phase A:
+  #135 (doc parsing spike)
+  #137 (preview component spike)
+
+Phase A (Foundation):
+  NEW-1 (context provider) ──────────────┐
+  #121 (Drive auth) ─────────────────────┤
+  #128 (Research Panel) ←── NEW-1        │
+  #122 (Drive browser) ←── #121, #128   │
+  NEW-2 (trust messaging) ←── #122      │
+  NEW-3 (first-use nudge) ←── #128      │
+  #124 (text extraction) ←── #135        │
+  #123 (local upload) ←── #124, #128    │
+  NEW-4 (always-visible search) ←── #137 │
+  NEW-8 (remove linking) ←── (none)      │
+  NEW-9 (FTS endpoint) ←── #124          │
+                                          │
+Pre-Phase B:                              │
+  #134 (prompt engineering spike)         │
+  #136 (chunking strategy spike)          │
+                                          │
+Phase B (AI Integration):                 │
+  #126 (chunking) ←── #136               │
+  #127 (response parsing) ←── #134       │
+  #125 (query endpoint) ←── #124, #126,  │
+       #127, #134                         │
+  #129 (Ask tab UI) ←── #125, #128       │
+  NEW-5 (cross-tab nav) ←── #128         │
+  #130 (citation links) ←── #128, #137,  │
+       NEW-5                              │
+  NEW-10 (clips API, save/list) ←── 0014 │
+                                          │
+Phase C (Board + Editor):                 │
+  NEW-7 (footnote extension) ←── (none)  │
+  #131 (save clips) ←── #128, NEW-6,    │
+       NEW-10                             │
+  #132 (clips tab) ←── #131, NEW-6,     │
+       NEW-10                             │
+  NEW-6 (chapter tags) ←── #131, #132   │
+  #133 (insert + footnote) ←── #131,    │
+       #132, NEW-7                        │
+```
+
+---
+
+## Effort Key
+
+| Size | Approximate Duration | Description |
+|------|---------------------|-------------|
+| XS | < 1 day | Trivial change, no backend |
+| S | 1-3 days | Focused single-component or endpoint |
+| M | 3-5 days | Multi-component or multi-endpoint |
+| L | 5-10 days | Complex feature spanning frontend + backend |
+| XL | 10+ days | Major system change (none in this set) |
+
+## Phase Effort Totals
+
+| Phase | Issue Count | Estimated Days | Calendar Weeks |
+|-------|-------------|----------------|----------------|
+| Pre-A Spikes | 2 | 2-4 days | Can parallel with Phase A planning |
+| Phase A: Foundation | 10 issues | 10-15 days | 2-3 weeks |
+| Pre-B Spikes | 2 | 2-4 days | Can parallel with Phase A dev |
+| Phase B: AI Integration | 8 issues | 15-20 days | 3-4 weeks |
+| Phase C: Board + Editor | 6 issues | 10-15 days | 2-3 weeks |
+| **Total** | **28 issues** | **39-58 days** | **7-10 weeks** |


### PR DESCRIPTION
## Summary

- Multi-agent UX design review for source documents panel and AI research integration
- Replaces the current 4-layer sheet stack (SourcesPanel → AddSourceSheet → DriveBrowserSheet → SourceViewerSheet) with a unified **Research Companion** panel (Sources | Ask | Clips tabs)
- Both user personas (Diane Mercer, Marcus Chen) selected Option B; stress test produced 6 GREEN, 5 YELLOW, 0 RED
- Covers all 17 backlog issues (#121-137) plus 10 new issues, mapped across 3 implementation phases

## Deliverables

| File | Purpose |
|------|---------|
| `01-research.md` | Industry pattern analysis (Scrivener, Notion, Google Docs, Ulysses, Obsidian, Bear, Zotero, ChatGPT Projects) |
| `02a-analysis.md` | Current state analysis + 3 mental model proposals |
| `02b-user-reactions.md` | Diane Mercer / Marcus Chen persona reactions |
| `03a-detailed-design.md` | 8 interaction flows with ASCII diagrams and tap counts |
| `03b-stress-test.md` | Persona stress test walkthrough |
| `design-spec.md` | Final 12-section design specification |
| `revised-issues.md` | 27 revised/new GitHub issues with acceptance criteria |

## Key Decisions

1. **Research Companion (Option B)** — single right-hand panel with Sources, Ask, and Clips tabs
2. **Chapter-source linking removed** — sources are project-wide; `chapter_sources` table deprecated
3. **EditorDialogs props reduced from 133 to ~15** via `ResearchPanelProvider` context
4. **3 phases**: Foundation (2-3 wks) → AI Integration (3-4 wks) → Board + Editor (2-3 wks)

## Test plan

- [ ] Review design-spec.md for completeness (all 12 sections)
- [ ] Review revised-issues.md for full #121-137 coverage
- [ ] Verify stress test YELLOW items are addressed in final spec
- [ ] Confirm mental model passes PRD "10-second test"
- [ ] Captain approval before creating GitHub issues from revised-issues.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)