### PR TITLE
feat: research clips CRUD API (#195)

### DIFF
--- a/workers/dc-api/migrations/0016_create_research_clips.sql
+++ b/workers/dc-api/migrations/0016_create_research_clips.sql
@@ -1,0 +1,28 @@
+-- Migration 0016: Create research_clips table (#195)
+--
+-- Research clips are user-saved snippets from source materials, linked to
+-- a project and optionally to a specific chapter. They support the Research
+-- Panel workflow where users highlight/save content from source documents.
+--
+-- Deduplication: A unique partial index prevents duplicate clips with the
+-- same content + source within a project (source_id IS NOT NULL case).
+
+CREATE TABLE research_clips (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  source_id TEXT REFERENCES source_materials(id) ON DELETE SET NULL,
+  source_title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  source_location TEXT,
+  chapter_id TEXT REFERENCES chapters(id) ON DELETE SET NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_research_clips_project ON research_clips(project_id);
+CREATE INDEX idx_research_clips_source ON research_clips(source_id);
+CREATE INDEX idx_research_clips_chapter ON research_clips(chapter_id);
+
+-- Dedup: same content + source within a project
+CREATE UNIQUE INDEX idx_research_clips_dedup
+  ON research_clips(project_id, source_id, content)
+  WHERE source_id IS NOT NULL;

--- a/workers/dc-api/src/index.ts
+++ b/workers/dc-api/src/index.ts
@@ -11,6 +11,7 @@ import { chapters } from "./routes/chapters.js";
 import { ai } from "./routes/ai.js";
 import { exportRoutes } from "./routes/export.js";
 import { sources } from "./routes/sources.js";
+import { research } from "./routes/research.js";
 import type { ErrorCode } from "./types/index.js";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -88,6 +89,7 @@ app.route("/ai", ai);
 app.route("/", exportRoutes);
 app.route("/", chapters);
 app.route("/", sources);
+app.route("/", research);
 
 // 404 fallback
 app.notFound((c) => {

--- a/workers/dc-api/src/routes/research.ts
+++ b/workers/dc-api/src/routes/research.ts
@@ -1,0 +1,88 @@
+/**
+ * Research clip routes -- CRUD for user-saved research snippets.
+ *
+ * Routes:
+ * - POST /projects/:projectId/research/clips - Save a clip
+ * - GET /projects/:projectId/research/clips - List clips (optional ?chapterId=xxx)
+ * - DELETE /research/clips/:clipId - Delete a clip
+ *
+ * All routes require authentication (enforced globally in index.ts).
+ */
+
+import { Hono } from "hono";
+import type { Env } from "../types/index.js";
+import { standardRateLimit } from "../middleware/rate-limit.js";
+import { validationError } from "../middleware/error-handler.js";
+import { ResearchClipService, type CreateClipInput } from "../services/research-clip.js";
+
+const research = new Hono<{ Bindings: Env }>();
+
+// Auth is enforced globally in index.ts
+research.use("*", standardRateLimit);
+
+/**
+ * POST /projects/:projectId/research/clips
+ * Save a research clip.
+ *
+ * Deduplication: same content + sourceId returns existing clip (200)
+ * instead of creating a duplicate (201).
+ */
+research.post("/projects/:projectId/research/clips", async (c) => {
+  const { userId } = c.get("auth");
+  const projectId = c.req.param("projectId");
+  const body = (await c.req.json().catch(() => ({}))) as Partial<CreateClipInput>;
+
+  if (!body.content || typeof body.content !== "string") {
+    validationError("content is required");
+  }
+
+  if (!body.sourceTitle || typeof body.sourceTitle !== "string") {
+    validationError("sourceTitle is required");
+  }
+
+  const service = new ResearchClipService(c.env.DB);
+  const { clip, existed } = await service.createClip(userId, projectId, {
+    content: body.content,
+    sourceTitle: body.sourceTitle,
+    sourceId: body.sourceId ?? null,
+    sourceLocation: body.sourceLocation ?? null,
+    chapterId: body.chapterId ?? null,
+  });
+
+  return c.json(clip, existed ? 200 : 201);
+});
+
+/**
+ * GET /projects/:projectId/research/clips
+ * List research clips for a project.
+ *
+ * Optional query param: ?chapterId=xxx for chapter filtering.
+ */
+research.get("/projects/:projectId/research/clips", async (c) => {
+  const { userId } = c.get("auth");
+  const projectId = c.req.param("projectId");
+  const chapterId = c.req.query("chapterId") || undefined;
+
+  const service = new ResearchClipService(c.env.DB);
+  const clips = await service.listClips(userId, projectId, chapterId);
+
+  return c.json({ clips });
+});
+
+/**
+ * DELETE /research/clips/:clipId
+ * Delete a research clip.
+ *
+ * Authorization: verifies clip belongs to user's project.
+ */
+research.delete("/research/clips/:clipId", async (c) => {
+  const { userId } = c.get("auth");
+  const clipId = c.req.param("clipId");
+
+  const service = new ResearchClipService(c.env.DB);
+  await service.deleteClip(userId, clipId);
+
+  return c.json({ success: true });
+});
+
+export { research };

--- a/workers/dc-api/src/services/research-clip.ts
+++ b/workers/dc-api/src/services/research-clip.ts
@@ -1,0 +1,227 @@
+/**
+ * Research clip service -- CRUD operations for saved research snippets.
+ *
+ * Research clips are user-saved snippets from source materials, linked to
+ * a project and optionally to a chapter. Deduplication prevents duplicate
+ * clips with the same content + source within a project.
+ */
+
+import { notFound, validationError } from "../middleware/error-handler.js";
+
+/** Maximum clip content size: 10KB */
+const MAX_CONTENT_BYTES = 10 * 1024;
+
+/** Row shape from D1 for a research clip. */
+export interface ResearchClipRow {
+  id: string;
+  project_id: string;
+  source_id: string | null;
+  source_title: string;
+  content: string;
+  source_location: string | null;
+  chapter_id: string | null;
+  created_at: string;
+}
+
+/** Row shape when joined with chapters for chapterTitle. */
+export interface ResearchClipWithChapterRow extends ResearchClipRow {
+  chapter_title: string | null;
+}
+
+/** Public API model returned from the service. */
+export interface ResearchClip {
+  id: string;
+  projectId: string;
+  sourceId: string | null;
+  sourceTitle: string;
+  content: string;
+  sourceLocation: string | null;
+  chapterId: string | null;
+  chapterTitle: string | null;
+  createdAt: string;
+}
+
+/** Input for creating a clip. */
+export interface CreateClipInput {
+  content: string;
+  sourceTitle: string;
+  sourceId?: string | null;
+  sourceLocation?: string | null;
+  chapterId?: string | null;
+}
+
+function rowToClip(row: ResearchClipWithChapterRow): ResearchClip {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    sourceId: row.source_id,
+    sourceTitle: row.source_title,
+    content: row.content,
+    sourceLocation: row.source_location,
+    chapterId: row.chapter_id,
+    chapterTitle: row.chapter_title ?? null,
+    createdAt: row.created_at,
+  };
+}
+
+export class ResearchClipService {
+  constructor(private readonly db: D1Database) {}
+
+  /**
+   * Create a research clip.
+   *
+   * Deduplication: if a clip with the same content + sourceId already exists
+   * in the project, returns the existing clip with `existed: true`.
+   *
+   * @returns `{ clip, existed }` — existed=true means dedup match found.
+   */
+  async createClip(
+    userId: string,
+    projectId: string,
+    input: CreateClipInput,
+  ): Promise<{ clip: ResearchClip; existed: boolean }> {
+    // Validate content
+    if (!input.content || input.content.trim().length === 0) {
+      validationError("content is required");
+    }
+
+    if (!input.sourceTitle || input.sourceTitle.trim().length === 0) {
+      validationError("sourceTitle is required");
+    }
+
+    // Enforce 10KB limit
+    const contentBytes = new TextEncoder().encode(input.content).byteLength;
+    if (contentBytes > MAX_CONTENT_BYTES) {
+      validationError(`Content exceeds maximum size of ${MAX_CONTENT_BYTES} bytes`);
+    }
+
+    // Verify project ownership
+    const project = await this.db
+      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`)
+      .bind(projectId, userId)
+      .first<{ id: string }>();
+
+    if (!project) {
+      notFound("Project not found");
+    }
+
+    // Dedup check: same content + sourceId in this project (only when sourceId is provided)
+    if (input.sourceId) {
+      const existing = await this.db
+        .prepare(
+          `SELECT rc.*, c.title AS chapter_title
+           FROM research_clips rc
+           LEFT JOIN chapters c ON c.id = rc.chapter_id
+           WHERE rc.project_id = ? AND rc.source_id = ? AND rc.content = ?`,
+        )
+        .bind(projectId, input.sourceId, input.content)
+        .first<ResearchClipWithChapterRow>();
+
+      if (existing) {
+        return { clip: rowToClip(existing), existed: true };
+      }
+    }
+
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    await this.db
+      .prepare(
+        `INSERT INTO research_clips (id, project_id, source_id, source_title, content, source_location, chapter_id, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id,
+        projectId,
+        input.sourceId ?? null,
+        input.sourceTitle,
+        input.content,
+        input.sourceLocation ?? null,
+        input.chapterId ?? null,
+        now,
+      )
+      .run();
+
+    // Fetch the created clip with chapter title join
+    const created = await this.db
+      .prepare(
+        `SELECT rc.*, c.title AS chapter_title
+         FROM research_clips rc
+         LEFT JOIN chapters c ON c.id = rc.chapter_id
+         WHERE rc.id = ?`,
+      )
+      .bind(id)
+      .first<ResearchClipWithChapterRow>();
+
+    if (!created) {
+      throw new Error("Failed to read back created clip");
+    }
+
+    return { clip: rowToClip(created), existed: false };
+  }
+
+  /**
+   * List research clips for a project, ordered by created_at DESC.
+   *
+   * Optionally filters by chapterId. Includes chapterTitle from joined chapters.
+   */
+  async listClips(userId: string, projectId: string, chapterId?: string): Promise<ResearchClip[]> {
+    // Verify project ownership
+    const project = await this.db
+      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`)
+      .bind(projectId, userId)
+      .first<{ id: string }>();
+
+    if (!project) {
+      notFound("Project not found");
+    }
+
+    let query: string;
+    let params: (string | null)[];
+
+    if (chapterId) {
+      query = `SELECT rc.*, c.title AS chapter_title
+               FROM research_clips rc
+               LEFT JOIN chapters c ON c.id = rc.chapter_id
+               WHERE rc.project_id = ? AND rc.chapter_id = ?
+               ORDER BY rc.created_at DESC`;
+      params = [projectId, chapterId];
+    } else {
+      query = `SELECT rc.*, c.title AS chapter_title
+               FROM research_clips rc
+               LEFT JOIN chapters c ON c.id = rc.chapter_id
+               WHERE rc.project_id = ?
+               ORDER BY rc.created_at DESC`;
+      params = [projectId];
+    }
+
+    const stmt = this.db.prepare(query);
+    const bound = params.length === 2 ? stmt.bind(params[0], params[1]) : stmt.bind(params[0]);
+    const result = await bound.all<ResearchClipWithChapterRow>();
+
+    return (result.results ?? []).map(rowToClip);
+  }
+
+  /**
+   * Delete a research clip.
+   *
+   * Authorization: verifies the clip belongs to a project owned by the user.
+   */
+  async deleteClip(userId: string, clipId: string): Promise<void> {
+    // Verify ownership via project join
+    const clip = await this.db
+      .prepare(
+        `SELECT rc.id FROM research_clips rc
+         JOIN projects p ON p.id = rc.project_id
+         WHERE rc.id = ? AND p.user_id = ?`,
+      )
+      .bind(clipId, userId)
+      .first<{ id: string }>();
+
+    if (!clip) {
+      notFound("Clip not found");
+    }
+
+    await this.db.prepare(`DELETE FROM research_clips WHERE id = ?`).bind(clipId).run();
+  }
+}

--- a/workers/dc-api/test/helpers/seed.ts
+++ b/workers/dc-api/test/helpers/seed.ts
@@ -113,6 +113,34 @@ export async function seedSource(
   return { id, projectId, driveFileId, title };
 }
 
+export async function seedClip(
+  projectId: string,
+  overrides?: {
+    id?: string;
+    sourceId?: string | null;
+    sourceTitle?: string;
+    content?: string;
+    sourceLocation?: string | null;
+    chapterId?: string | null;
+    createdAt?: string;
+  },
+) {
+  const id = overrides?.id ?? crypto.randomUUID();
+  const sourceTitle = overrides?.sourceTitle ?? "Test Source";
+  const content = overrides?.content ?? "Test clip content";
+  const sourceId = overrides?.sourceId !== undefined ? overrides.sourceId : null;
+  const sourceLocation = overrides?.sourceLocation ?? null;
+  const chapterId = overrides?.chapterId ?? null;
+  const createdAt = overrides?.createdAt ?? now();
+  await env.DB.prepare(
+    `INSERT INTO research_clips (id, project_id, source_id, source_title, content, source_location, chapter_id, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(id, projectId, sourceId, sourceTitle, content, sourceLocation, chapterId, createdAt)
+    .run();
+  return { id, projectId, sourceId, sourceTitle, content };
+}
+
 /**
  * Remove all rows from test tables in reverse FK order.
  */
@@ -120,6 +148,7 @@ export async function cleanAll() {
   await env.DB.batch([
     env.DB.prepare("DELETE FROM ai_interactions"),
     env.DB.prepare("DELETE FROM export_jobs"),
+    env.DB.prepare("DELETE FROM research_clips"),
     env.DB.prepare("DELETE FROM source_content_fts"),
     env.DB.prepare("DELETE FROM source_materials"),
     env.DB.prepare("DELETE FROM chapters"),

--- a/workers/dc-api/test/research-clips.test.ts
+++ b/workers/dc-api/test/research-clips.test.ts
@@ -1,0 +1,520 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import { ResearchClipService } from "../src/services/research-clip.js";
+import {
+  seedUser,
+  seedProject,
+  seedSource,
+  seedChapter,
+  seedClip,
+  cleanAll,
+} from "./helpers/seed.js";
+
+const BASE = "http://localhost";
+
+/** Convenience helper: build headers that authenticate as the given userId. */
+function authHeaders(userId: string, extra?: Record<string, string>): Record<string, string> {
+  return {
+    "X-Test-User-Id": userId,
+    ...extra,
+  };
+}
+
+/** JSON request helper. */
+async function jsonRequest(
+  method: string,
+  path: string,
+  userId: string,
+  body?: unknown,
+): Promise<Response> {
+  const init: RequestInit = {
+    method,
+    headers: authHeaders(userId, { "Content-Type": "application/json" }),
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+  }
+  return SELF.fetch(`${BASE}${path}`, init);
+}
+
+// ---------------------------------------------------------------------------
+// Service-level tests
+// ---------------------------------------------------------------------------
+describe("ResearchClipService", () => {
+  let service: ResearchClipService;
+  let userId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    await cleanAll();
+    service = new ResearchClipService(env.DB);
+    const user = await seedUser();
+    userId = user.id;
+    const project = await seedProject(userId);
+    projectId = project.id;
+  });
+
+  describe("createClip", () => {
+    it("creates a clip with required fields", async () => {
+      const { clip, existed } = await service.createClip(userId, projectId, {
+        content: "Important finding from research",
+        sourceTitle: "Interview Notes",
+      });
+
+      expect(existed).toBe(false);
+      expect(clip.id).toBeTruthy();
+      expect(clip.projectId).toBe(projectId);
+      expect(clip.content).toBe("Important finding from research");
+      expect(clip.sourceTitle).toBe("Interview Notes");
+      expect(clip.sourceId).toBeNull();
+      expect(clip.sourceLocation).toBeNull();
+      expect(clip.chapterId).toBeNull();
+      expect(clip.chapterTitle).toBeNull();
+      expect(clip.createdAt).toBeTruthy();
+    });
+
+    it("creates a clip with all optional fields", async () => {
+      const source = await seedSource(projectId, { title: "Research Paper" });
+      const chapter = await seedChapter(projectId, { title: "Chapter 3" });
+
+      const { clip, existed } = await service.createClip(userId, projectId, {
+        content: "Key insight about methodology",
+        sourceTitle: "Research Paper",
+        sourceId: source.id,
+        sourceLocation: "Page 42, paragraph 3",
+        chapterId: chapter.id,
+      });
+
+      expect(existed).toBe(false);
+      expect(clip.sourceId).toBe(source.id);
+      expect(clip.sourceLocation).toBe("Page 42, paragraph 3");
+      expect(clip.chapterId).toBe(chapter.id);
+      expect(clip.chapterTitle).toBe("Chapter 3");
+    });
+
+    it("deduplicates same content + sourceId in a project", async () => {
+      const source = await seedSource(projectId);
+
+      const first = await service.createClip(userId, projectId, {
+        content: "Duplicate content",
+        sourceTitle: "Source Doc",
+        sourceId: source.id,
+      });
+      expect(first.existed).toBe(false);
+
+      const second = await service.createClip(userId, projectId, {
+        content: "Duplicate content",
+        sourceTitle: "Source Doc",
+        sourceId: source.id,
+      });
+      expect(second.existed).toBe(true);
+      expect(second.clip.id).toBe(first.clip.id);
+    });
+
+    it("allows same content from different sources", async () => {
+      const source1 = await seedSource(projectId, { title: "Source A", driveFileId: "a1" });
+      const source2 = await seedSource(projectId, {
+        title: "Source B",
+        driveFileId: "b1",
+        sortOrder: 2,
+      });
+
+      const first = await service.createClip(userId, projectId, {
+        content: "Same content",
+        sourceTitle: "Source A",
+        sourceId: source1.id,
+      });
+
+      const second = await service.createClip(userId, projectId, {
+        content: "Same content",
+        sourceTitle: "Source B",
+        sourceId: source2.id,
+      });
+
+      expect(first.existed).toBe(false);
+      expect(second.existed).toBe(false);
+      expect(first.clip.id).not.toBe(second.clip.id);
+    });
+
+    it("allows duplicate content when sourceId is null (no dedup)", async () => {
+      const first = await service.createClip(userId, projectId, {
+        content: "Unlinked content",
+        sourceTitle: "Manual Clip",
+      });
+
+      const second = await service.createClip(userId, projectId, {
+        content: "Unlinked content",
+        sourceTitle: "Manual Clip",
+      });
+
+      expect(first.existed).toBe(false);
+      expect(second.existed).toBe(false);
+      expect(first.clip.id).not.toBe(second.clip.id);
+    });
+
+    it("rejects empty content", async () => {
+      await expect(
+        service.createClip(userId, projectId, {
+          content: "",
+          sourceTitle: "Source",
+        }),
+      ).rejects.toThrow("content is required");
+    });
+
+    it("rejects whitespace-only content", async () => {
+      await expect(
+        service.createClip(userId, projectId, {
+          content: "   ",
+          sourceTitle: "Source",
+        }),
+      ).rejects.toThrow("content is required");
+    });
+
+    it("rejects empty sourceTitle", async () => {
+      await expect(
+        service.createClip(userId, projectId, {
+          content: "Some content",
+          sourceTitle: "",
+        }),
+      ).rejects.toThrow("sourceTitle is required");
+    });
+
+    it("rejects content exceeding 10KB", async () => {
+      const largeContent = "x".repeat(10 * 1024 + 1);
+
+      await expect(
+        service.createClip(userId, projectId, {
+          content: largeContent,
+          sourceTitle: "Source",
+        }),
+      ).rejects.toThrow("Content exceeds maximum size");
+    });
+
+    it("allows content at exactly 10KB", async () => {
+      const maxContent = "x".repeat(10 * 1024);
+
+      const { clip, existed } = await service.createClip(userId, projectId, {
+        content: maxContent,
+        sourceTitle: "Source",
+      });
+
+      expect(existed).toBe(false);
+      expect(clip.content).toBe(maxContent);
+    });
+
+    it("throws NOT_FOUND for non-existent project", async () => {
+      await expect(
+        service.createClip(userId, "nonexistent", {
+          content: "Content",
+          sourceTitle: "Source",
+        }),
+      ).rejects.toThrow("Project not found");
+    });
+
+    it("throws NOT_FOUND for project owned by another user", async () => {
+      const other = await seedUser({ id: "other-user" });
+
+      await expect(
+        service.createClip(other.id, projectId, {
+          content: "Content",
+          sourceTitle: "Source",
+        }),
+      ).rejects.toThrow("Project not found");
+    });
+  });
+
+  describe("listClips", () => {
+    it("lists clips ordered by created_at DESC", async () => {
+      await seedClip(projectId, {
+        content: "Older clip",
+        sourceTitle: "S1",
+        createdAt: "2026-01-01T00:00:00Z",
+      });
+      await seedClip(projectId, {
+        content: "Newer clip",
+        sourceTitle: "S2",
+        createdAt: "2026-02-01T00:00:00Z",
+      });
+
+      const clips = await service.listClips(userId, projectId);
+
+      expect(clips).toHaveLength(2);
+      expect(clips[0].content).toBe("Newer clip");
+      expect(clips[1].content).toBe("Older clip");
+    });
+
+    it("returns empty array when no clips exist", async () => {
+      const clips = await service.listClips(userId, projectId);
+      expect(clips).toHaveLength(0);
+    });
+
+    it("filters by chapterId", async () => {
+      const chapter = await seedChapter(projectId, { title: "Ch1" });
+      await seedClip(projectId, {
+        content: "Linked clip",
+        chapterId: chapter.id,
+      });
+      await seedClip(projectId, { content: "Unlinked clip" });
+
+      const filtered = await service.listClips(userId, projectId, chapter.id);
+
+      expect(filtered).toHaveLength(1);
+      expect(filtered[0].content).toBe("Linked clip");
+    });
+
+    it("includes chapterTitle from joined chapters", async () => {
+      const chapter = await seedChapter(projectId, { title: "My Chapter" });
+      await seedClip(projectId, {
+        content: "Clip with chapter",
+        chapterId: chapter.id,
+      });
+
+      const clips = await service.listClips(userId, projectId);
+
+      expect(clips[0].chapterTitle).toBe("My Chapter");
+    });
+
+    it("preserves sourceTitle when source is removed (sourceId becomes null)", async () => {
+      const source = await seedSource(projectId, { title: "Original Source" });
+      await seedClip(projectId, {
+        content: "Clip from source",
+        sourceId: source.id,
+        sourceTitle: "Original Source",
+      });
+
+      // Simulate ON DELETE SET NULL by updating the clip
+      await env.DB.prepare(`UPDATE research_clips SET source_id = NULL WHERE source_id = ?`)
+        .bind(source.id)
+        .run();
+
+      const clips = await service.listClips(userId, projectId);
+
+      expect(clips[0].sourceId).toBeNull();
+      expect(clips[0].sourceTitle).toBe("Original Source");
+    });
+
+    it("throws NOT_FOUND for non-existent project", async () => {
+      await expect(service.listClips(userId, "nonexistent")).rejects.toThrow("Project not found");
+    });
+  });
+
+  describe("deleteClip", () => {
+    it("deletes a clip", async () => {
+      const clip = await seedClip(projectId, { content: "To delete" });
+
+      await service.deleteClip(userId, clip.id);
+
+      const clips = await service.listClips(userId, projectId);
+      expect(clips).toHaveLength(0);
+    });
+
+    it("hard deletes from the database", async () => {
+      const clip = await seedClip(projectId);
+
+      await service.deleteClip(userId, clip.id);
+
+      const row = await env.DB.prepare(`SELECT id FROM research_clips WHERE id = ?`)
+        .bind(clip.id)
+        .first();
+      expect(row).toBeNull();
+    });
+
+    it("throws NOT_FOUND for non-existent clip", async () => {
+      await expect(service.deleteClip(userId, "nonexistent")).rejects.toThrow("Clip not found");
+    });
+
+    it("throws NOT_FOUND for clip in another user's project", async () => {
+      const other = await seedUser({ id: "other-user" });
+      const otherProject = await seedProject(other.id, { title: "Other Project" });
+      const clip = await seedClip(otherProject.id, { content: "Other's clip" });
+
+      await expect(service.deleteClip(userId, clip.id)).rejects.toThrow("Clip not found");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests (HTTP layer)
+// ---------------------------------------------------------------------------
+describe("Integration: Research Clips", () => {
+  let userId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    await cleanAll();
+    const user = await seedUser();
+    userId = user.id;
+    const project = await seedProject(userId);
+    projectId = project.id;
+  });
+
+  describe("POST /projects/:projectId/research/clips", () => {
+    it("201 on new clip", async () => {
+      const res = await jsonRequest("POST", `/projects/${projectId}/research/clips`, userId, {
+        content: "Important finding",
+        sourceTitle: "Interview Notes",
+      });
+
+      expect(res.status).toBe(201);
+
+      const body = (await res.json()) as { id: string; content: string; sourceTitle: string };
+      expect(body.id).toBeTruthy();
+      expect(body.content).toBe("Important finding");
+      expect(body.sourceTitle).toBe("Interview Notes");
+    });
+
+    it("200 on deduplicated clip", async () => {
+      const source = await seedSource(projectId);
+
+      const first = await jsonRequest("POST", `/projects/${projectId}/research/clips`, userId, {
+        content: "Duplicate",
+        sourceTitle: "Source Doc",
+        sourceId: source.id,
+      });
+      expect(first.status).toBe(201);
+
+      const second = await jsonRequest("POST", `/projects/${projectId}/research/clips`, userId, {
+        content: "Duplicate",
+        sourceTitle: "Source Doc",
+        sourceId: source.id,
+      });
+      expect(second.status).toBe(200);
+
+      const firstBody = (await first.json()) as { id: string };
+      const secondBody = (await second.json()) as { id: string };
+      expect(secondBody.id).toBe(firstBody.id);
+    });
+
+    it("400 when content is missing", async () => {
+      const res = await jsonRequest("POST", `/projects/${projectId}/research/clips`, userId, {
+        sourceTitle: "Source",
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("400 when sourceTitle is missing", async () => {
+      const res = await jsonRequest("POST", `/projects/${projectId}/research/clips`, userId, {
+        content: "Some content",
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("400 when content exceeds 10KB", async () => {
+      const res = await jsonRequest("POST", `/projects/${projectId}/research/clips`, userId, {
+        content: "x".repeat(10 * 1024 + 1),
+        sourceTitle: "Source",
+      });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("404 for non-existent project", async () => {
+      const res = await jsonRequest("POST", `/projects/nonexistent/research/clips`, userId, {
+        content: "Content",
+        sourceTitle: "Source",
+      });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("401 without auth", async () => {
+      const res = await SELF.fetch(`${BASE}/projects/${projectId}/research/clips`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ content: "Content", sourceTitle: "Source" }),
+      });
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("GET /projects/:projectId/research/clips", () => {
+    it("200 with clips array", async () => {
+      await seedClip(projectId, { content: "Clip 1", sourceTitle: "S1" });
+      await seedClip(projectId, { content: "Clip 2", sourceTitle: "S2" });
+
+      const res = await SELF.fetch(`${BASE}/projects/${projectId}/research/clips`, {
+        headers: authHeaders(userId),
+      });
+
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as { clips: Array<{ content: string }> };
+      expect(body.clips).toHaveLength(2);
+    });
+
+    it("filters by chapterId query param", async () => {
+      const chapter = await seedChapter(projectId, { title: "Ch1" });
+      await seedClip(projectId, {
+        content: "Linked",
+        chapterId: chapter.id,
+      });
+      await seedClip(projectId, { content: "Unlinked" });
+
+      const res = await SELF.fetch(
+        `${BASE}/projects/${projectId}/research/clips?chapterId=${chapter.id}`,
+        {
+          headers: authHeaders(userId),
+        },
+      );
+
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as { clips: Array<{ content: string }> };
+      expect(body.clips).toHaveLength(1);
+      expect(body.clips[0].content).toBe("Linked");
+    });
+
+    it("200 empty array when no clips", async () => {
+      const res = await SELF.fetch(`${BASE}/projects/${projectId}/research/clips`, {
+        headers: authHeaders(userId),
+      });
+
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as { clips: unknown[] };
+      expect(body.clips).toHaveLength(0);
+    });
+  });
+
+  describe("DELETE /research/clips/:clipId", () => {
+    it("200 with success: true", async () => {
+      const clip = await seedClip(projectId, { content: "To delete" });
+
+      const res = await jsonRequest("DELETE", `/research/clips/${clip.id}`, userId);
+
+      expect(res.status).toBe(200);
+
+      const body = (await res.json()) as { success: boolean };
+      expect(body.success).toBe(true);
+    });
+
+    it("clip is gone after deletion", async () => {
+      const clip = await seedClip(projectId, { content: "Will be deleted" });
+
+      await jsonRequest("DELETE", `/research/clips/${clip.id}`, userId);
+
+      const listRes = await SELF.fetch(`${BASE}/projects/${projectId}/research/clips`, {
+        headers: authHeaders(userId),
+      });
+      const body = (await listRes.json()) as { clips: unknown[] };
+      expect(body.clips).toHaveLength(0);
+    });
+
+    it("404 for non-existent clip", async () => {
+      const res = await jsonRequest("DELETE", `/research/clips/nonexistent`, userId);
+      expect(res.status).toBe(404);
+    });
+
+    it("404 for clip owned by another user", async () => {
+      const other = await seedUser({ id: "other-user" });
+      const otherProject = await seedProject(other.id);
+      const clip = await seedClip(otherProject.id);
+
+      const res = await jsonRequest("DELETE", `/research/clips/${clip.id}`, userId);
+      expect(res.status).toBe(404);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add CRUD API endpoints for research clips -- user-saved snippets from source materials used in the Research Panel workflow.

## Changes
- Migration 0016: `research_clips` table with indexes and dedup unique partial index
- `ResearchClipService` with `createClip`, `listClips`, `deleteClip` methods
- Routes: `POST /projects/:projectId/research/clips` (create with dedup), `GET /projects/:projectId/research/clips` (list with optional `?chapterId` filter), `DELETE /research/clips/:clipId` (delete with auth check)
- Routes mounted in `index.ts` under the global auth barrier
- 35 tests covering service-level logic and integration HTTP layer
- Updated `seedClip` helper and `cleanAll` in test seed helpers

## Test Plan
- [x] `npm run typecheck` -- passes
- [x] `npm run lint` -- passes (pre-existing warning only)
- [x] `npm run format:check` -- passes
- [x] `npm run test` -- 358 tests pass (21 files), including 35 new research clip tests
- [ ] POST creates clip with 201, dedup returns 200
- [ ] GET lists clips with chapterTitle join, filters by chapterId
- [ ] DELETE removes clip, returns 404 for other user's clips
- [ ] 400 for missing content/sourceTitle, content >10KB
- [ ] 401 without auth, 404 for non-existent project

Closes #195

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>