### PR TITLE
fix: restore web test/typecheck gate (#162)

### DIFF
--- a/web/src/extensions/footnote-content.ts
+++ b/web/src/extensions/footnote-content.ts
@@ -9,11 +9,13 @@ import { Node, mergeAttributes } from "@tiptap/core";
  *
  * Format: "[N] Source Title" per design-spec.md Principle 4.
  *
- * Renders as: `<div class="footnote-content" data-footnote-id="...">
- *               <span class="footnote-label">[N]</span> Source Title
+ * Renders as: `<div class="footnote-content" data-footnote-id="..." data-footnote-label="N">
+ *               Source Title
  *             </div>`
  *
- * Serializes to HTML with data attributes for round-trip deserialization.
+ * The label prefix "[N]" is displayed via CSS `::before` using the data-footnote-label
+ * attribute. ProseMirror requires the content hole to be the sole child of its parent,
+ * so the label cannot be rendered as a sibling DOM element in renderHTML.
  */
 export const FootnoteContent = Node.create({
   name: "footnoteContent",
@@ -52,13 +54,10 @@ export const FootnoteContent = Node.create({
     ];
   },
 
-  renderHTML({ node, HTMLAttributes }) {
-    const label = (node.attrs.label as string) || "0";
-    return [
-      "div",
-      mergeAttributes(HTMLAttributes, { class: "footnote-content" }),
-      ["span", { class: "footnote-label" }, `[${label}]`],
-      0,
-    ];
+  renderHTML({ HTMLAttributes }) {
+    // The label is stored as data-footnote-label and rendered via CSS ::before.
+    // ProseMirror requires the content hole (0) to be the sole child of its parent,
+    // so we cannot place a sibling <span> alongside it here.
+    return ["div", mergeAttributes(HTMLAttributes, { class: "footnote-content" }), 0];
   },
 });


### PR DESCRIPTION
## Summary
Fixes the 15 failing footnote tests caused by an invalid ProseMirror `renderHTML` spec in `FootnoteContent`, restoring the web test and typecheck quality gates.

## Changes
- Removed the inline `<span class="footnote-label">` from `FootnoteContent.renderHTML` -- ProseMirror requires the content hole (`0`) to be the sole child of its parent node, and the sibling span caused `RangeError: Content hole must be the only child of its parent node` in all tests that instantiate a Tiptap editor with footnotes
- The label is already stored as `data-footnote-label` attribute and should be rendered via CSS `::before` pseudo-element
- Updated JSDoc to reflect the corrected render output

## Test runtime strategy
- **web** uses `vitest@^4.0.18` (Vitest 4.x) -- the latest major version with native `@testing-library/jest-dom/vitest` matcher integration
- **workers/dc-api** uses `vitest@~3.2.0` (Vitest 3.x) -- pinned because `@cloudflare/vitest-pool-workers` requires Vitest 3.x and is not compatible with 4.x
- This intentional version split is correct; each workspace resolves its own Vitest runtime through npm workspaces

## Test Plan
- [x] `npm run typecheck -w web` passes
- [x] `npm run test -w web` passes (222 tests, 15 test files)
- [x] `npm run typecheck` passes (all workspaces)
- [x] `npm run test` passes (358 tests, 21 test files across both workspaces)
- [x] `npm run lint` passes (no new warnings)

Closes #162

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>