### PR TITLE
fix: remove ambiguous Drive token fallback in multi-account flows (#166)

### DIFF
--- a/workers/dc-api/src/routes/sources.ts
+++ b/workers/dc-api/src/routes/sources.ts
@@ -23,6 +23,7 @@ import { validationError } from "../middleware/error-handler.js";
 import { SourceMaterialService, type AddSourceInput } from "../services/source-material.js";
 import { DriveService } from "../services/drive.js";
 import { validateDriveId } from "../utils/drive-query.js";
+import { resolveProjectConnection } from "../services/drive-connection-resolver.js";
 
 const sources = new Hono<{ Bindings: Env }>();
 
@@ -151,40 +152,45 @@ sources.post("/sources/:sourceId/import-as-chapter", async (c) => {
   const driveService = new DriveService(c.env);
   const result = await service.importAsChapter(userId, sourceId, driveService);
 
-  // Fire-and-forget: create Drive file for the new chapter (same pattern as chapter POST)
-  driveService
-    .getValidTokens(userId)
-    .then(async (tokens) => {
-      if (!tokens) return;
+  // Fire-and-forget: create Drive file for the new chapter (same pattern as chapter POST).
+  // Uses project.drive_connection_id for multi-account token resolution.
+  // Skips silently if no connection can be resolved (fire-and-forget, non-blocking).
+  (async () => {
+    const project = await c.env.DB.prepare(
+      `SELECT drive_folder_id, drive_connection_id FROM projects WHERE id = ? AND user_id = ?`,
+    )
+      .bind(result.projectId, userId)
+      .first<{ drive_folder_id: string | null; drive_connection_id: string | null }>();
 
-      const project = await c.env.DB.prepare(
-        `SELECT drive_folder_id FROM projects WHERE id = ? AND user_id = ?`,
-      )
-        .bind(result.projectId, userId)
-        .first<{ drive_folder_id: string | null }>();
+    if (!project?.drive_folder_id) return;
 
-      if (!project?.drive_folder_id) return;
+    // Resolve connection via project binding; skip on failure (fire-and-forget)
+    const resolved = await resolveProjectConnection(
+      driveService.tokenService,
+      userId,
+      project.drive_connection_id,
+    ).catch(() => null);
+    if (!resolved) return;
 
-      // Upload the chapter content to Drive
-      const encoder = new TextEncoder();
-      const content = await c.env.EXPORTS_BUCKET.get(result.r2Key);
-      const html = content ? await content.text() : "";
-      const driveFile = await driveService.uploadFile(
-        tokens.accessToken,
-        project.drive_folder_id,
-        `${result.title}.html`,
-        "text/html",
-        encoder.encode(html).buffer as ArrayBuffer,
-      );
+    // Upload the chapter content to Drive
+    const encoder = new TextEncoder();
+    const content = await c.env.EXPORTS_BUCKET.get(result.r2Key);
+    const html = content ? await content.text() : "";
+    const driveFile = await driveService.uploadFile(
+      resolved.tokens.accessToken,
+      project.drive_folder_id,
+      `${result.title}.html`,
+      "text/html",
+      encoder.encode(html).buffer as ArrayBuffer,
+    );
 
-      // Store drive_file_id on the chapter
-      await c.env.DB.prepare(`UPDATE chapters SET drive_file_id = ? WHERE id = ?`)
-        .bind(driveFile.id, result.chapterId)
-        .run();
-    })
-    .catch((err) => {
-      console.error("Drive file creation on source import failed (non-blocking):", err);
-    });
+    // Store drive_file_id on the chapter
+    await c.env.DB.prepare(`UPDATE chapters SET drive_file_id = ? WHERE id = ?`)
+      .bind(driveFile.id, result.chapterId)
+      .run();
+  })().catch((err) => {
+    console.error("Drive file creation on source import failed (non-blocking):", err);
+  });
 
   return c.json(
     {

--- a/workers/dc-api/src/services/drive-connection-resolver.ts
+++ b/workers/dc-api/src/services/drive-connection-resolver.ts
@@ -1,0 +1,141 @@
+/**
+ * Drive connection resolver -- deterministic connection selection for multi-account safety.
+ *
+ * ## Connection Selection Rules
+ *
+ * For mutating Drive operations (file writes, uploads, renames, deletes):
+ *
+ *   1. **Project-bound**: Use `project.drive_connection_id` when the operation is
+ *      associated with a project (chapters, exports, folder creation).
+ *
+ *   2. **Request-explicit**: Use `connectionId` from the request when the caller
+ *      specifies which connection to use (e.g., source import, browse).
+ *
+ *   3. **Fail fast**: If neither is available and the user has multiple connections,
+ *      reject with 409 DRIVE_AMBIGUOUS. If the user has exactly one connection,
+ *      use it (unambiguous).
+ *
+ * For read-only operations (browse, picker-token without connectionId):
+ *   - Single-connection users: use the only connection (safe, unambiguous).
+ *   - Multi-connection users: require explicit connectionId.
+ *
+ * ## Why This Exists
+ *
+ * Before this resolver, several code paths used `getValidTokens(userId)` which
+ * calls `getStoredTokensByUser()` with `LIMIT 1`. When a user has multiple Drive
+ * connections, this selects nondeterministically, potentially writing to the wrong
+ * Google account's Drive. See issue #166.
+ */
+
+import { AppError } from "../middleware/error-handler.js";
+import type { DriveTokenService, ValidTokens } from "./drive-token.js";
+
+/** Result of resolving a Drive connection for an operation. */
+export interface ResolvedConnection {
+  connectionId: string;
+  tokens: ValidTokens;
+}
+
+/**
+ * Resolve the Drive connection for a project-scoped mutating operation.
+ *
+ * Resolution order:
+ *   1. project.drive_connection_id (from DB)
+ *   2. Explicit connectionId parameter (from request)
+ *   3. Single-connection fallback (unambiguous)
+ *   4. Reject with DRIVE_AMBIGUOUS if multiple connections exist
+ *
+ * @param tokenService - DriveTokenService for token retrieval
+ * @param userId - Authenticated user ID
+ * @param projectConnectionId - project.drive_connection_id from the project row (may be null)
+ * @param requestConnectionId - connectionId from the request body/query (may be undefined)
+ * @returns Resolved connection with valid tokens
+ * @throws AppError 422 DRIVE_NOT_CONNECTED if no connections exist
+ * @throws AppError 409 DRIVE_AMBIGUOUS if multiple connections and no explicit binding
+ * @throws AppError 422 DRIVE_NOT_CONNECTED if resolved connection tokens are invalid
+ */
+export async function resolveProjectConnection(
+  tokenService: DriveTokenService,
+  userId: string,
+  projectConnectionId: string | null,
+  requestConnectionId?: string,
+): Promise<ResolvedConnection> {
+  // 1. Prefer project-bound connection
+  if (projectConnectionId) {
+    const tokens = await tokenService.getValidTokensByConnection(projectConnectionId);
+    if (!tokens) {
+      throw new AppError(
+        422,
+        "DRIVE_NOT_CONNECTED",
+        "Project Drive connection is invalid or expired. Reconnect Google Drive.",
+      );
+    }
+    return { connectionId: projectConnectionId, tokens };
+  }
+
+  // 2. Explicit request parameter
+  if (requestConnectionId) {
+    // Verify the connection belongs to this user
+    const connections = await tokenService.getConnectionsForUser(userId);
+    if (!connections.some((c) => c.id === requestConnectionId)) {
+      throw new AppError(422, "DRIVE_NOT_CONNECTED", "Connection not found for this user.");
+    }
+    const tokens = await tokenService.getValidTokensByConnection(requestConnectionId);
+    if (!tokens) {
+      throw new AppError(
+        422,
+        "DRIVE_NOT_CONNECTED",
+        "Drive connection is invalid or expired. Reconnect Google Drive.",
+      );
+    }
+    return { connectionId: requestConnectionId, tokens };
+  }
+
+  // 3. Single-connection fallback (unambiguous)
+  const connections = await tokenService.getConnectionsForUser(userId);
+
+  if (connections.length === 0) {
+    throw new AppError(422, "DRIVE_NOT_CONNECTED", "Google Drive is not connected.");
+  }
+
+  if (connections.length > 1) {
+    // 4. Reject ambiguous state
+    throw new AppError(
+      409,
+      "DRIVE_AMBIGUOUS",
+      "Multiple Google Drive accounts connected. Specify which connection to use or bind the project to a Drive account.",
+    );
+  }
+
+  // Exactly one connection -- unambiguous
+  const tokens = await tokenService.getValidTokensByConnection(connections[0].id);
+  if (!tokens) {
+    throw new AppError(
+      422,
+      "DRIVE_NOT_CONNECTED",
+      "Drive connection is invalid or expired. Reconnect Google Drive.",
+    );
+  }
+  return { connectionId: connections[0].id, tokens };
+}
+
+/**
+ * Resolve Drive connection for a read-only operation (no project context).
+ *
+ * Resolution order:
+ *   1. Explicit connectionId parameter
+ *   2. Single-connection fallback (unambiguous)
+ *   3. Reject with DRIVE_AMBIGUOUS if multiple connections exist
+ *
+ * @param tokenService - DriveTokenService for token retrieval
+ * @param userId - Authenticated user ID
+ * @param connectionId - Explicit connectionId (may be undefined)
+ * @returns Resolved connection with valid tokens
+ */
+export async function resolveReadOnlyConnection(
+  tokenService: DriveTokenService,
+  userId: string,
+  connectionId?: string,
+): Promise<ResolvedConnection> {
+  return resolveProjectConnection(tokenService, userId, null, connectionId);
+}

--- a/workers/dc-api/src/services/drive-token.ts
+++ b/workers/dc-api/src/services/drive-token.ts
@@ -211,8 +211,9 @@ export class DriveTokenService {
   }
 
   /**
-   * Gets stored tokens for a user's first connection (legacy fallback).
-   * Used when we only have userId, not a specific connectionId.
+   * @deprecated Use resolveProjectConnection() or resolveReadOnlyConnection() instead.
+   * Gets stored tokens for a user's first connection via LIMIT 1 (nondeterministic
+   * when multiple connections exist). See #166.
    *
    * @param userId - The user ID
    * @returns Decrypted tokens or null if not connected
@@ -288,8 +289,9 @@ export class DriveTokenService {
   }
 
   /**
-   * Gets valid tokens for a user's first connection (legacy fallback).
-   * Used by fire-and-forget write-through code that only has userId.
+   * @deprecated Use resolveProjectConnection() or resolveReadOnlyConnection() instead.
+   * This method selects nondeterministically when users have multiple Drive connections.
+   * Retained for backward compatibility but no production code should call it. See #166.
    *
    * @param userId - The user ID
    * @returns Valid tokens with connectionId, or null if not connected

--- a/workers/dc-api/src/services/drive.ts
+++ b/workers/dc-api/src/services/drive.ts
@@ -20,6 +20,7 @@ import { DriveFileService } from "./drive-files.js";
 // Re-export public types so existing imports from "./drive.js" still work
 export type { DriveFile } from "./drive-files.js";
 export type { ValidTokens, DriveConnection, GoogleTokenResponse } from "./drive-token.js";
+export { DriveTokenService } from "./drive-token.js";
 
 /**
  * DriveService composes token management and file operations into a single
@@ -33,6 +34,11 @@ export class DriveService {
   constructor(private readonly env: Env) {
     this.tokens = new DriveTokenService(env);
     this.files = new DriveFileService();
+  }
+
+  /** Access the underlying token service for connection resolution. */
+  get tokenService(): DriveTokenService {
+    return this.tokens;
   }
 
   // ── OAuth & Token management (delegated to DriveTokenService) ──
@@ -69,6 +75,11 @@ export class DriveService {
     return this.tokens.getValidTokensByConnection(connectionId);
   }
 
+  /**
+   * @deprecated Use resolveProjectConnection() or resolveReadOnlyConnection() instead.
+   * This method selects nondeterministically when users have multiple Drive connections.
+   * Retained for backward compatibility but no production code should call it. See #166.
+   */
   getValidTokens(userId: string) {
     return this.tokens.getValidTokens(userId);
   }

--- a/workers/dc-api/src/types/api.ts
+++ b/workers/dc-api/src/types/api.ts
@@ -12,6 +12,7 @@ export type ErrorCode =
   | "RATE_LIMITED"
   | "DRIVE_ERROR"
   | "DRIVE_NOT_CONNECTED"
+  | "DRIVE_AMBIGUOUS"
   | "VALIDATION_ERROR"
   | "LAST_CHAPTER"
   | "AI_ERROR"

--- a/workers/dc-api/test/drive-connection-resolver.test.ts
+++ b/workers/dc-api/test/drive-connection-resolver.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { DriveTokenService } from "../src/services/drive-token.js";
+import type { GoogleTokenResponse } from "../src/services/drive-token.js";
+import {
+  resolveProjectConnection,
+  resolveReadOnlyConnection,
+} from "../src/services/drive-connection-resolver.js";
+import { seedUser, seedProject, cleanAll } from "./helpers/seed.js";
+
+/**
+ * Drive connection resolver tests.
+ *
+ * Validates that mutating Drive operations use explicit connection resolution
+ * and reject ambiguous states in multi-account scenarios (issue #166).
+ *
+ * Test matrix:
+ *   - Single-connection users: implicit resolution works
+ *   - Multi-connection users: explicit binding required, ambiguous rejected
+ *   - Project-bound connections: project.drive_connection_id takes precedence
+ *   - Invalid/expired connections: proper error responses
+ */
+describe("Drive Connection Resolver", () => {
+  let tokenService: DriveTokenService;
+  let userId: string;
+
+  const mockTokens = (suffix: string): GoogleTokenResponse => ({
+    access_token: `ya29.token-${suffix}`,
+    refresh_token: `1//refresh-${suffix}`,
+    expires_in: 3600,
+    token_type: "Bearer",
+    scope: "https://www.googleapis.com/auth/drive.file",
+  });
+
+  beforeEach(async () => {
+    await cleanAll();
+    tokenService = new DriveTokenService(env as unknown as import("../src/types/index.js").Env);
+    const user = await seedUser();
+    userId = user.id;
+  });
+
+  // ── resolveProjectConnection ──
+
+  describe("resolveProjectConnection", () => {
+    describe("single-connection user", () => {
+      beforeEach(async () => {
+        await tokenService.storeTokens(userId, "conn-1", mockTokens("1"), "user@gmail.com");
+      });
+
+      it("resolves via project.drive_connection_id when available", async () => {
+        const result = await resolveProjectConnection(tokenService, userId, "conn-1");
+
+        expect(result.connectionId).toBe("conn-1");
+        expect(result.tokens.accessToken).toBe("ya29.token-1");
+      });
+
+      it("resolves via single-connection fallback when no project binding", async () => {
+        const result = await resolveProjectConnection(tokenService, userId, null);
+
+        expect(result.connectionId).toBe("conn-1");
+        expect(result.tokens.accessToken).toBe("ya29.token-1");
+      });
+
+      it("resolves via request connectionId when no project binding", async () => {
+        const result = await resolveProjectConnection(tokenService, userId, null, "conn-1");
+
+        expect(result.connectionId).toBe("conn-1");
+        expect(result.tokens.accessToken).toBe("ya29.token-1");
+      });
+
+      it("project binding takes precedence over request connectionId", async () => {
+        // Even if a different connectionId is passed, project binding wins
+        const result = await resolveProjectConnection(tokenService, userId, "conn-1", "conn-other");
+
+        expect(result.connectionId).toBe("conn-1");
+      });
+    });
+
+    describe("multi-connection user", () => {
+      beforeEach(async () => {
+        await tokenService.storeTokens(userId, "conn-1", mockTokens("1"), "personal@gmail.com");
+        await tokenService.storeTokens(userId, "conn-2", mockTokens("2"), "work@company.com");
+      });
+
+      it("resolves via project.drive_connection_id (deterministic)", async () => {
+        const result = await resolveProjectConnection(tokenService, userId, "conn-2");
+
+        expect(result.connectionId).toBe("conn-2");
+        expect(result.tokens.accessToken).toBe("ya29.token-2");
+      });
+
+      it("resolves via request connectionId when no project binding", async () => {
+        const result = await resolveProjectConnection(tokenService, userId, null, "conn-1");
+
+        expect(result.connectionId).toBe("conn-1");
+        expect(result.tokens.accessToken).toBe("ya29.token-1");
+      });
+
+      it("rejects with DRIVE_AMBIGUOUS when no explicit binding", async () => {
+        await expect(resolveProjectConnection(tokenService, userId, null)).rejects.toThrow(
+          "Multiple Google Drive accounts connected",
+        );
+      });
+
+      it("DRIVE_AMBIGUOUS error has 409 status code", async () => {
+        try {
+          await resolveProjectConnection(tokenService, userId, null);
+          expect.fail("Should have thrown");
+        } catch (err: unknown) {
+          const error = err as { statusCode: number; code: string };
+          expect(error.statusCode).toBe(409);
+          expect(error.code).toBe("DRIVE_AMBIGUOUS");
+        }
+      });
+
+      it("rejects request connectionId that belongs to another user", async () => {
+        const otherUser = await seedUser({ id: "other-user" });
+        await tokenService.storeTokens(
+          otherUser.id,
+          "conn-other",
+          mockTokens("other"),
+          "other@gmail.com",
+        );
+
+        await expect(
+          resolveProjectConnection(tokenService, userId, null, "conn-other"),
+        ).rejects.toThrow("Connection not found for this user");
+      });
+    });
+
+    describe("no connections", () => {
+      it("rejects with DRIVE_NOT_CONNECTED", async () => {
+        await expect(resolveProjectConnection(tokenService, userId, null)).rejects.toThrow(
+          "Google Drive is not connected",
+        );
+      });
+
+      it("rejects with 422 status code", async () => {
+        try {
+          await resolveProjectConnection(tokenService, userId, null);
+          expect.fail("Should have thrown");
+        } catch (err: unknown) {
+          const error = err as { statusCode: number; code: string };
+          expect(error.statusCode).toBe(422);
+          expect(error.code).toBe("DRIVE_NOT_CONNECTED");
+        }
+      });
+    });
+
+    describe("invalid connection", () => {
+      it("rejects with DRIVE_NOT_CONNECTED when project connection is missing", async () => {
+        await expect(
+          resolveProjectConnection(tokenService, userId, "deleted-conn"),
+        ).rejects.toThrow("Project Drive connection is invalid or expired");
+      });
+    });
+  });
+
+  // ── resolveReadOnlyConnection ──
+
+  describe("resolveReadOnlyConnection", () => {
+    it("resolves via explicit connectionId", async () => {
+      await tokenService.storeTokens(userId, "conn-1", mockTokens("1"), "user@gmail.com");
+
+      const result = await resolveReadOnlyConnection(tokenService, userId, "conn-1");
+
+      expect(result.connectionId).toBe("conn-1");
+      expect(result.tokens.accessToken).toBe("ya29.token-1");
+    });
+
+    it("resolves single-connection user without explicit connectionId", async () => {
+      await tokenService.storeTokens(userId, "conn-1", mockTokens("1"), "user@gmail.com");
+
+      const result = await resolveReadOnlyConnection(tokenService, userId);
+
+      expect(result.connectionId).toBe("conn-1");
+    });
+
+    it("rejects multi-connection user without explicit connectionId", async () => {
+      await tokenService.storeTokens(userId, "conn-1", mockTokens("1"), "personal@gmail.com");
+      await tokenService.storeTokens(userId, "conn-2", mockTokens("2"), "work@company.com");
+
+      await expect(resolveReadOnlyConnection(tokenService, userId)).rejects.toThrow(
+        "Multiple Google Drive accounts connected",
+      );
+    });
+
+    it("rejects when no connections exist", async () => {
+      await expect(resolveReadOnlyConnection(tokenService, userId)).rejects.toThrow(
+        "Google Drive is not connected",
+      );
+    });
+  });
+
+  // ── Multi-account project binding scenarios ──
+
+  describe("project connect/disconnect scenarios", () => {
+    it("project with explicit connection continues working after other connections added", async () => {
+      // User starts with one connection, project is bound to it
+      await tokenService.storeTokens(userId, "conn-1", mockTokens("1"), "personal@gmail.com");
+
+      // Project is bound to conn-1
+      const result1 = await resolveProjectConnection(tokenService, userId, "conn-1");
+      expect(result1.connectionId).toBe("conn-1");
+
+      // User adds a second connection -- project should still resolve to conn-1
+      await tokenService.storeTokens(userId, "conn-2", mockTokens("2"), "work@company.com");
+
+      const result2 = await resolveProjectConnection(tokenService, userId, "conn-1");
+      expect(result2.connectionId).toBe("conn-1");
+      expect(result2.tokens.accessToken).toBe("ya29.token-1");
+    });
+
+    it("project with deleted connection fails fast", async () => {
+      await tokenService.storeTokens(userId, "conn-1", mockTokens("1"), "user@gmail.com");
+      await tokenService.storeTokens(userId, "conn-2", mockTokens("2"), "work@company.com");
+
+      // Delete the connection the project was bound to
+      await tokenService.deleteConnectionById("conn-1", userId);
+
+      // Should fail fast -- the project's connection is gone
+      await expect(resolveProjectConnection(tokenService, userId, "conn-1")).rejects.toThrow(
+        "Project Drive connection is invalid or expired",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Replaces nondeterministic `getValidTokens(userId)` calls across all mutating Drive operations with a new connection resolver utility that enforces explicit connection binding and fails fast with `409 DRIVE_AMBIGUOUS` when multiple connections exist without explicit selection.

## Changes
- Created `drive-connection-resolver.ts` with `resolveProjectConnection()` and `resolveReadOnlyConnection()` utilities that enforce deterministic connection selection
- Updated `export-delivery.ts` `saveToDrive` to resolve via `project.drive_connection_id`
- Updated `drive.ts` routes: `POST /folders`, `GET /folders/:folderId/children`, legacy `GET /picker-token`, `GET /browse` to use resolver
- Updated `chapters.ts`: create, rename, delete, and write-through fire-and-forget paths to use resolver
- Updated `sources.ts`: import-as-chapter fire-and-forget to use resolver
- Updated `source-drive.ts`: `fetchAndCache` to reject ambiguous state instead of silently falling back
- Updated `projects.ts`: `POST /connect-drive` to use resolver
- Added `DRIVE_AMBIGUOUS` error code to API types
- Deprecated `getValidTokens()` and `getStoredTokensByUser()` methods with JSDoc annotations
- Exposed `DriveTokenService` via `DriveService.tokenService` getter for resolver access
- Added 17 tests covering multi-account resolution: single-connection fallback, multi-connection rejection, project binding precedence, invalid connection handling, connect/disconnect scenarios

## Test Plan
- [x] All 376 existing tests pass (no regressions)
- [x] 17 new tests for connection resolver covering all resolution paths
- [x] Lint clean, typecheck clean, format clean
- [ ] Manual test: single-connection user workflow unchanged
- [ ] Manual test: multi-connection user gets 409 DRIVE_AMBIGUOUS when no explicit binding
- [ ] Manual test: project-bound connection continues working after adding second connection

Closes #166

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>