### PR TITLE
feat: inline Drive browser for selecting project sources

### DIFF
--- a/web/src/components/research/sources-tab.tsx
+++ b/web/src/components/research/sources-tab.tsx
@@ -214,7 +214,7 @@ export function SourcesTab() {
   );
 
   const handleAddDriveFiles = useCallback(
-    (
+    async (
       files: Array<{ driveFileId: string; title: string; mimeType: string }>,
       connectionId: string,
     ) => {
@@ -224,7 +224,7 @@ export function SourcesTab() {
         title: f.title,
         mimeType: f.mimeType,
       }));
-      addSources(pickerFiles, connectionId);
+      await addSources(pickerFiles, connectionId);
       finishAdd();
     },
     [addSources, finishAdd],
@@ -238,7 +238,6 @@ export function SourcesTab() {
   if (sourcesView === "add") {
     return (
       <SourceAddFlow
-        projectId={projectId}
         driveAccounts={driveAccounts}
         existingDriveFileIds={existingDriveFileIds}
         onBack={backToSourceList}


### PR DESCRIPTION
## Summary
- Expanded SourceAddFlow with internal sub-navigation: account selection view transitions to inline folder browser when a Drive account is tapped
- Inline folder browser shows folders (navigable via tap) and Google Docs (selectable via checkbox), reusing the existing `useDriveBrowser` hook
- Files already in the project display "Already added" with disabled checkboxes
- "Add N Selected" sticky footer (48pt height) enables batch source addition
- Trust message ("Your originals are never changed") visible in account selection view
- Back navigation at every level: folder parent, back to account list, back to sources

## Test Plan
- [ ] Tap [+ Add] in Sources tab, verify inline add flow replaces list
- [ ] Verify trust message is visible
- [ ] Select a Drive account, verify folder browser opens inline
- [ ] Navigate into folders via tap, verify folders and Google Docs display correctly
- [ ] Select files via checkboxes, verify "Add N Selected" count updates
- [ ] Verify "Already added" files have checked, disabled checkboxes with label
- [ ] Tap "Add N Selected", verify sources added and view returns to source list
- [ ] Verify back navigation works at every level (folder -> parent -> accounts -> sources)
- [ ] Verify all touch targets are minimum 44pt
- [ ] Verify checkbox tap area is 44x44pt (visually 24x24px)
- [ ] Verify sticky footer is 48pt height

Closes #183

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>