### PR TITLE
feat: clips tab with chapter filter, search, and management

### DIFF
--- a/web/src/components/research/__tests__/clip-card.test.tsx
+++ b/web/src/components/research/__tests__/clip-card.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ClipCard } from "../clip-card";
+import type { ResearchClip } from "@/hooks/use-research-clips";
+
+// Mock @clerk/nextjs since the component doesn't use it directly but it may be required
+vi.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({ getToken: vi.fn() }),
+}));
+
+function makeClip(overrides: Partial<ResearchClip> = {}): ResearchClip {
+  return {
+    id: "clip-1",
+    projectId: "project-1",
+    sourceId: "source-1",
+    chapterId: null,
+    sourceTitle: "Interview Notes",
+    snippetText: "This is a short snippet.",
+    chapterTitle: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("ClipCard", () => {
+  it("renders snippet text and source title", () => {
+    const clip = makeClip();
+    render(<ClipCard clip={clip} onDelete={vi.fn()} />);
+
+    expect(screen.getByText("This is a short snippet.")).toBeInTheDocument();
+    expect(screen.getByText("Interview Notes")).toBeInTheDocument();
+  });
+
+  it("shows '[Source removed]' when sourceId is null", () => {
+    const clip = makeClip({ sourceId: null });
+    render(<ClipCard clip={clip} onDelete={vi.fn()} />);
+
+    expect(screen.getByText("[Source removed]")).toBeInTheDocument();
+  });
+
+  it("source title is not tappable when sourceId is null", () => {
+    const clip = makeClip({ sourceId: null });
+    render(<ClipCard clip={clip} onDelete={vi.fn()} />);
+
+    const removed = screen.getByText("[Source removed]");
+    expect(removed.tagName).toBe("SPAN"); // span, not button
+  });
+
+  it("source title is tappable when sourceId exists", () => {
+    const onSourceTap = vi.fn();
+    const clip = makeClip();
+    render(<ClipCard clip={clip} onDelete={vi.fn()} onSourceTap={onSourceTap} />);
+
+    const sourceButton = screen.getByText("Interview Notes");
+    expect(sourceButton.tagName).toBe("BUTTON");
+    fireEvent.click(sourceButton);
+    expect(onSourceTap).toHaveBeenCalledWith("source-1");
+  });
+
+  it("truncates text over 300 chars with 'Show more' toggle", () => {
+    const longText = "A".repeat(350);
+    const clip = makeClip({ snippetText: longText });
+    render(<ClipCard clip={clip} onDelete={vi.fn()} />);
+
+    // Should show truncated text
+    expect(screen.getByText("Show more")).toBeInTheDocument();
+
+    // Click to expand
+    fireEvent.click(screen.getByText("Show more"));
+    expect(screen.getByText("Show less")).toBeInTheDocument();
+
+    // Click to collapse
+    fireEvent.click(screen.getByText("Show less"));
+    expect(screen.getByText("Show more")).toBeInTheDocument();
+  });
+
+  it("does not show 'Show more' for text under 300 chars", () => {
+    const clip = makeClip({ snippetText: "Short text" });
+    render(<ClipCard clip={clip} onDelete={vi.fn()} />);
+
+    expect(screen.queryByText("Show more")).not.toBeInTheDocument();
+  });
+
+  it("displays chapter tag as compact label", () => {
+    const clip = makeClip({ chapterId: "ch-1", chapterTitle: "Chapter 3: Discussion" });
+    render(<ClipCard clip={clip} onDelete={vi.fn()} />);
+
+    expect(screen.getByText("Ch. 3")).toBeInTheDocument();
+  });
+
+  it("truncates non-standard chapter title at 20 chars", () => {
+    const clip = makeClip({
+      chapterId: "ch-1",
+      chapterTitle: "A Very Long Chapter Title That Exceeds Twenty Characters",
+    });
+    render(<ClipCard clip={clip} onDelete={vi.fn()} />);
+
+    expect(screen.getByText("A Very Long Chapter ...")).toBeInTheDocument();
+  });
+
+  it("does not show chapter tag when chapterId is null", () => {
+    const clip = makeClip({ chapterId: null, chapterTitle: null });
+    render(<ClipCard clip={clip} onDelete={vi.fn()} />);
+
+    expect(screen.queryByText(/Ch\./)).not.toBeInTheDocument();
+  });
+
+  it("calls onDelete when overflow menu delete is clicked", () => {
+    const onDelete = vi.fn();
+    const clip = makeClip();
+    render(<ClipCard clip={clip} onDelete={onDelete} />);
+
+    // Open overflow menu
+    fireEvent.click(screen.getByLabelText("Clip actions"));
+
+    // Click delete
+    fireEvent.click(screen.getByText("Delete"));
+    expect(onDelete).toHaveBeenCalledWith("clip-1");
+  });
+
+  it("displays formatted date", () => {
+    const clip = makeClip({ createdAt: new Date().toISOString() });
+    render(<ClipCard clip={clip} onDelete={vi.fn()} />);
+
+    expect(screen.getByText("Today")).toBeInTheDocument();
+  });
+
+  it("all action buttons meet 44pt minimum height", () => {
+    const clip = makeClip({ sourceId: "src-1", snippetText: "A".repeat(400) });
+    render(<ClipCard clip={clip} onDelete={vi.fn()} onSourceTap={vi.fn()} />);
+
+    // Source title button
+    const sourceBtn = screen.getByText("Interview Notes");
+    expect(sourceBtn.style.minHeight).toBe("44px");
+
+    // Overflow menu button
+    const menuBtn = screen.getByLabelText("Clip actions");
+    expect(menuBtn.style.minHeight).toBe("44px");
+
+    // Show more button
+    const showMore = screen.getByText("Show more");
+    expect(showMore.style.minHeight).toBe("44px");
+  });
+});

--- a/web/src/components/research/__tests__/clips-tab.test.tsx
+++ b/web/src/components/research/__tests__/clips-tab.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ClipsTab } from "../clips-tab";
+import type { ResearchClip } from "@/hooks/use-research-clips";
+
+// Mock @clerk/nextjs
+vi.mock("@clerk/nextjs", () => ({
+  useAuth: () => ({ getToken: vi.fn() }),
+}));
+
+function makeClip(overrides: Partial<ResearchClip> = {}): ResearchClip {
+  return {
+    id: `clip-${Math.random().toString(36).slice(2)}`,
+    projectId: "project-1",
+    sourceId: "source-1",
+    chapterId: null,
+    sourceTitle: "Test Source",
+    snippetText: "A test clip snippet.",
+    chapterTitle: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  clips: [] as ResearchClip[],
+  isLoading: false,
+  error: null,
+  chapters: [],
+  onFetchClips: vi.fn().mockResolvedValue(undefined),
+  onDeleteClip: vi.fn().mockResolvedValue(undefined),
+};
+
+describe("ClipsTab", () => {
+  it("shows empty state when no clips", () => {
+    render(<ClipsTab {...defaultProps} />);
+
+    expect(screen.getByText(/No clips yet\. Save passages from AI results/)).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    render(<ClipsTab {...defaultProps} isLoading={true} />);
+
+    expect(screen.getByText("Loading clips...")).toBeInTheDocument();
+  });
+
+  it("shows error state with retry button", () => {
+    const onFetchClips = vi.fn().mockResolvedValue(undefined);
+    render(<ClipsTab {...defaultProps} error="Network error" onFetchClips={onFetchClips} />);
+
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+    expect(screen.getByText("Try again")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Try again"));
+    // One call from useEffect on mount, one from retry click
+    expect(onFetchClips).toHaveBeenCalled();
+  });
+
+  it("renders clip cards", () => {
+    const clips = [
+      makeClip({ id: "c1", snippetText: "First clip text" }),
+      makeClip({ id: "c2", snippetText: "Second clip text" }),
+    ];
+
+    render(<ClipsTab {...defaultProps} clips={clips} />);
+
+    expect(screen.getByText("First clip text")).toBeInTheDocument();
+    expect(screen.getByText("Second clip text")).toBeInTheDocument();
+  });
+
+  it("filters clips by search query (snippet text)", () => {
+    const clips = [
+      makeClip({ id: "c1", snippetText: "Alpha beta gamma" }),
+      makeClip({ id: "c2", snippetText: "Delta epsilon" }),
+    ];
+
+    render(<ClipsTab {...defaultProps} clips={clips} />);
+
+    const searchInput = screen.getByPlaceholderText("Search clips...");
+    fireEvent.change(searchInput, { target: { value: "alpha" } });
+
+    expect(screen.getByText("Alpha beta gamma")).toBeInTheDocument();
+    expect(screen.queryByText("Delta epsilon")).not.toBeInTheDocument();
+  });
+
+  it("filters clips by search query (source title)", () => {
+    const clips = [
+      makeClip({ id: "c1", sourceTitle: "Interview Notes", snippetText: "Clip A" }),
+      makeClip({ id: "c2", sourceTitle: "Research Paper", snippetText: "Clip B" }),
+    ];
+
+    render(<ClipsTab {...defaultProps} clips={clips} />);
+
+    const searchInput = screen.getByPlaceholderText("Search clips...");
+    fireEvent.change(searchInput, { target: { value: "interview" } });
+
+    expect(screen.getByText("Clip A")).toBeInTheDocument();
+    expect(screen.queryByText("Clip B")).not.toBeInTheDocument();
+  });
+
+  it("shows no results message for empty search", () => {
+    const clips = [makeClip({ snippetText: "Alpha" })];
+
+    render(<ClipsTab {...defaultProps} clips={clips} />);
+
+    const searchInput = screen.getByPlaceholderText("Search clips...");
+    fireEvent.change(searchInput, { target: { value: "zzz" } });
+
+    expect(screen.getByText(/No clips match/)).toBeInTheDocument();
+  });
+
+  it("clears search with clear button", () => {
+    const clips = [
+      makeClip({ id: "c1", snippetText: "Alpha" }),
+      makeClip({ id: "c2", snippetText: "Beta" }),
+    ];
+
+    render(<ClipsTab {...defaultProps} clips={clips} />);
+
+    const searchInput = screen.getByPlaceholderText("Search clips...");
+    fireEvent.change(searchInput, { target: { value: "alpha" } });
+    expect(screen.queryByText("Beta")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText("Clear search"));
+    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Beta")).toBeInTheDocument();
+  });
+
+  it("chapter filter dropdown shows only chapters with clips", () => {
+    const clips = [
+      makeClip({ id: "c1", chapterId: "ch-1", chapterTitle: "Chapter 1" }),
+      makeClip({ id: "c2", chapterId: null }),
+    ];
+    const chapters = [
+      { id: "ch-1", title: "Chapter 1" },
+      { id: "ch-2", title: "Chapter 2" },
+    ];
+
+    render(<ClipsTab {...defaultProps} clips={clips} chapters={chapters} />);
+
+    const select = screen.getByLabelText("Filter by chapter");
+    // "All Chapters" + "Chapter 1" only (ch-2 has no clips)
+    const options = select.querySelectorAll("option");
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent).toBe("All Chapters");
+    expect(options[1].textContent).toBe("Chapter 1");
+  });
+
+  it("calls onFetchClips with chapterId when chapter filter changes", () => {
+    const onFetchClips = vi.fn().mockResolvedValue(undefined);
+    const clips = [makeClip({ chapterId: "ch-1", chapterTitle: "Chapter 1" })];
+    const chapters = [{ id: "ch-1", title: "Chapter 1" }];
+
+    render(
+      <ClipsTab {...defaultProps} clips={clips} chapters={chapters} onFetchClips={onFetchClips} />,
+    );
+
+    const select = screen.getByLabelText("Filter by chapter");
+    fireEvent.change(select, { target: { value: "ch-1" } });
+
+    expect(onFetchClips).toHaveBeenCalledWith("ch-1");
+  });
+
+  it("calls onFetchClips on mount", () => {
+    const onFetchClips = vi.fn().mockResolvedValue(undefined);
+
+    render(<ClipsTab {...defaultProps} onFetchClips={onFetchClips} />);
+
+    expect(onFetchClips).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/research/clip-card.tsx
+++ b/web/src/components/research/clip-card.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useState, useRef } from "react";
+import type { ResearchClip } from "@/hooks/use-research-clips";
+
+const TRUNCATE_LIMIT = 300;
+
+interface ClipCardProps {
+  clip: ResearchClip;
+  onDelete: (clipId: string) => void;
+  onSourceTap?: (sourceId: string) => void;
+}
+
+/**
+ * ClipCard -- displays a saved text snippet with source info, chapter tag, and actions.
+ *
+ * Features:
+ * - Snippet text truncated at 300 chars with "Show more" / "Show less" toggle
+ * - Source title (tappable if source exists, "[Source removed]" in gray otherwise)
+ * - Chapter tag badge if assigned
+ * - Delete via overflow menu or swipe-left gesture
+ * - 44pt minimum touch targets per iPad-first design
+ */
+export function ClipCard({ clip, onDelete, onSourceTap }: ClipCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // Swipe tracking
+  const touchStartX = useRef(0);
+  const [swipeOffset, setSwipeOffset] = useState(0);
+  const [swiped, setSwiped] = useState(false);
+
+  const isLong = clip.snippetText.length > TRUNCATE_LIMIT;
+  const displayText =
+    isLong && !expanded ? clip.snippetText.slice(0, TRUNCATE_LIMIT) : clip.snippetText;
+
+  const hasSource = clip.sourceId !== null;
+
+  // Format date relative
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+    if (diffDays === 0) return "Today";
+    if (diffDays === 1) return "Yesterday";
+    if (diffDays < 7) return `${diffDays}d ago`;
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  };
+
+  // Compact chapter label: "Chapter N: Title" -> "Ch. N"
+  const chapterLabel = (() => {
+    if (!clip.chapterTitle) return null;
+    const match = clip.chapterTitle.match(/^Chapter\s+(\d+)/i);
+    if (match) return `Ch. ${match[1]}`;
+    return clip.chapterTitle.length > 20
+      ? clip.chapterTitle.slice(0, 20) + "..."
+      : clip.chapterTitle;
+  })();
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const diff = touchStartX.current - e.touches[0].clientX;
+    if (diff > 0) {
+      setSwipeOffset(Math.min(diff, 80));
+    } else {
+      setSwipeOffset(0);
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (swipeOffset > 60) {
+      setSwiped(true);
+    } else {
+      setSwipeOffset(0);
+      setSwiped(false);
+    }
+  };
+
+  const handleDeleteConfirm = () => {
+    onDelete(clip.id);
+  };
+
+  return (
+    <div className="relative overflow-hidden">
+      {/* Delete action behind the card (revealed by swipe) */}
+      {swiped && (
+        <div className="absolute inset-y-0 right-0 flex items-center">
+          <button
+            onClick={handleDeleteConfirm}
+            className="h-full px-4 bg-red-500 text-white font-medium text-sm flex items-center"
+            style={{ minHeight: 44 }}
+            aria-label="Delete clip"
+          >
+            Delete
+          </button>
+        </div>
+      )}
+
+      <div
+        className="bg-white border border-gray-200 rounded-lg p-3 transition-transform"
+        style={{ transform: swiped ? `translateX(-80px)` : `translateX(-${swipeOffset}px)` }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* Header: source + chapter tag + menu */}
+        <div className="flex items-start justify-between gap-2 mb-2">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            {hasSource ? (
+              <button
+                onClick={() => onSourceTap?.(clip.sourceId!)}
+                className="text-sm text-blue-600 hover:text-blue-700 hover:underline truncate font-medium"
+                style={{ minHeight: 44, display: "flex", alignItems: "center" }}
+              >
+                {clip.sourceTitle}
+              </button>
+            ) : (
+              <span
+                className="text-sm text-gray-400 italic"
+                style={{ minHeight: 44, display: "flex", alignItems: "center" }}
+              >
+                [Source removed]
+              </span>
+            )}
+
+            {chapterLabel && (
+              <span className="shrink-0 px-1.5 py-0.5 text-xs font-medium bg-blue-50 text-blue-700 rounded">
+                {chapterLabel}
+              </span>
+            )}
+          </div>
+
+          {/* Overflow menu */}
+          <div className="relative shrink-0">
+            <button
+              onClick={() => setMenuOpen(!menuOpen)}
+              className="p-2 text-gray-400 hover:text-gray-600 rounded"
+              style={{
+                minHeight: 44,
+                minWidth: 44,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+              aria-label="Clip actions"
+              aria-expanded={menuOpen}
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 16 16" aria-hidden="true">
+                <circle cx="8" cy="3" r="1.5" />
+                <circle cx="8" cy="8" r="1.5" />
+                <circle cx="8" cy="13" r="1.5" />
+              </svg>
+            </button>
+
+            {menuOpen && (
+              <>
+                {/* Backdrop to close menu */}
+                <div className="fixed inset-0 z-10" onClick={() => setMenuOpen(false)} />
+                <div className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-20 min-w-[120px]">
+                  <button
+                    onClick={() => {
+                      setMenuOpen(false);
+                      handleDeleteConfirm();
+                    }}
+                    className="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg"
+                    style={{ minHeight: 44, display: "flex", alignItems: "center" }}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Snippet text */}
+        <p className="text-sm text-gray-700 leading-relaxed whitespace-pre-wrap">
+          {displayText}
+          {isLong && !expanded && "..."}
+        </p>
+
+        {/* Show more/less toggle */}
+        {isLong && (
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="text-sm text-blue-600 hover:text-blue-700 mt-1 font-medium"
+            style={{ minHeight: 44, display: "flex", alignItems: "center" }}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        )}
+
+        {/* Footer: date */}
+        <div className="mt-2 text-xs text-gray-400">{formatDate(clip.createdAt)}</div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/research/clips-tab.tsx
+++ b/web/src/components/research/clips-tab.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState, useEffect, useMemo, useCallback } from "react";
+import type { ResearchClip } from "@/hooks/use-research-clips";
+import { ClipCard } from "./clip-card";
+
+interface Chapter {
+  id: string;
+  title: string;
+}
+
+interface ClipsTabProps {
+  clips: ResearchClip[];
+  isLoading: boolean;
+  error: string | null;
+  chapters: Chapter[];
+  onFetchClips: (chapterId?: string) => Promise<void>;
+  onDeleteClip: (clipId: string) => Promise<void>;
+  onSourceTap?: (sourceId: string) => void;
+}
+
+/**
+ * ClipsTab -- displays saved clips with chapter filter, search, and management.
+ *
+ * Features:
+ * - Chapter filter dropdown: "All Chapters" + per-chapter options (only chapters with clips)
+ * - Search field: client-side filtering by snippet text and source title
+ * - ClipCard list, most recent first
+ * - Empty state messaging
+ * - Loading and error states
+ */
+export function ClipsTab({
+  clips,
+  isLoading,
+  error,
+  chapters,
+  onFetchClips,
+  onDeleteClip,
+  onSourceTap,
+}: ClipsTabProps) {
+  const [selectedChapterId, setSelectedChapterId] = useState<string>("");
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Fetch clips on mount
+  useEffect(() => {
+    onFetchClips();
+  }, [onFetchClips]);
+
+  // Re-fetch when chapter filter changes
+  const handleChapterChange = useCallback(
+    (chapterId: string) => {
+      setSelectedChapterId(chapterId);
+      // Empty string means "all chapters"
+      onFetchClips(chapterId || undefined);
+    },
+    [onFetchClips],
+  );
+
+  // Chapters that have at least one clip tagged to them
+  const chaptersWithClips = useMemo(() => {
+    const chapterIds = new Set(clips.filter((c) => c.chapterId).map((c) => c.chapterId!));
+    return chapters.filter((ch) => chapterIds.has(ch.id));
+  }, [clips, chapters]);
+
+  // Client-side search filtering
+  const filteredClips = useMemo(() => {
+    if (!searchQuery.trim()) return clips;
+    const q = searchQuery.toLowerCase();
+    return clips.filter(
+      (clip) =>
+        clip.snippetText.toLowerCase().includes(q) || clip.sourceTitle.toLowerCase().includes(q),
+    );
+  }, [clips, searchQuery]);
+
+  // Loading state
+  if (isLoading && clips.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-sm text-gray-500">Loading clips...</div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (error && clips.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="text-center">
+          <p className="text-sm text-red-600 mb-2">{error}</p>
+          <button
+            onClick={() => onFetchClips()}
+            className="text-sm text-blue-600 hover:text-blue-700 font-medium"
+            style={{
+              minHeight: 44,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // Empty state
+  if (clips.length === 0 && !isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12 px-4">
+        <p className="text-sm text-gray-500 text-center leading-relaxed max-w-[280px]">
+          No clips yet. Save passages from AI results or select text in source documents to build
+          your research board.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Filter bar */}
+      <div className="px-3 py-2 border-b border-gray-200 space-y-2 shrink-0">
+        {/* Chapter filter */}
+        <select
+          value={selectedChapterId}
+          onChange={(e) => handleChapterChange(e.target.value)}
+          className="w-full text-sm border border-gray-200 rounded-lg px-3 bg-white text-gray-700"
+          style={{ minHeight: 44 }}
+          aria-label="Filter by chapter"
+        >
+          <option value="">All Chapters</option>
+          {chaptersWithClips.map((ch) => (
+            <option key={ch.id} value={ch.id}>
+              {ch.title}
+            </option>
+          ))}
+        </select>
+
+        {/* Search field */}
+        <div className="relative">
+          <svg
+            className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+          <input
+            type="text"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search clips..."
+            className="w-full text-sm border border-gray-200 rounded-lg pl-9 pr-3 bg-white text-gray-700 placeholder:text-gray-400"
+            style={{ minHeight: 44 }}
+            aria-label="Search clips"
+          />
+          {searchQuery && (
+            <button
+              onClick={() => setSearchQuery("")}
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+              aria-label="Clear search"
+            >
+              <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Clip list */}
+      <div className="flex-1 overflow-y-auto px-3 py-2 space-y-2">
+        {filteredClips.length === 0 && searchQuery ? (
+          <div className="flex items-center justify-center py-8">
+            <p className="text-sm text-gray-500">No clips match &ldquo;{searchQuery}&rdquo;</p>
+          </div>
+        ) : (
+          filteredClips.map((clip) => (
+            <ClipCard key={clip.id} clip={clip} onDelete={onDeleteClip} onSourceTap={onSourceTap} />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-research-clips.ts
+++ b/web/src/hooks/use-research-clips.ts
@@ -1,0 +1,133 @@
+"use client";
+
+import { useAuth } from "@clerk/nextjs";
+import { useState, useCallback } from "react";
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
+
+/** Clip model matching API response */
+export interface ResearchClip {
+  id: string;
+  projectId: string;
+  sourceId: string | null;
+  chapterId: string | null;
+  sourceTitle: string;
+  snippetText: string;
+  chapterTitle: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Hook for managing research clips -- fetch, create, and delete.
+ *
+ * Provides client-side state management for clips with optimistic
+ * delete and deduplication-aware save.
+ */
+export function useResearchClips(projectId: string) {
+  const { getToken } = useAuth();
+  const [clips, setClips] = useState<ResearchClip[]>([]);
+  const [clipCount, setClipCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  /** Fetch all clips for the project, optionally filtered by chapter */
+  const fetchClips = useCallback(
+    async (chapterId?: string) => {
+      try {
+        setIsLoading(true);
+        setError(null);
+        const token = await getToken();
+        const url = chapterId
+          ? `${API_URL}/projects/${projectId}/research/clips?chapterId=${chapterId}`
+          : `${API_URL}/projects/${projectId}/research/clips`;
+        const response = await fetch(url, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!response.ok) throw new Error("Failed to fetch clips");
+        const data = (await response.json()) as { clips: ResearchClip[]; count: number };
+        setClips(data.clips);
+        setClipCount(data.count);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load clips");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [getToken, projectId],
+  );
+
+  /** Save a new clip */
+  const saveClip = useCallback(
+    async (input: {
+      sourceId?: string | null;
+      sourceTitle: string;
+      snippetText: string;
+      chapterId?: string | null;
+    }): Promise<{ isNew: boolean } | null> => {
+      try {
+        setError(null);
+        const token = await getToken();
+        const response = await fetch(`${API_URL}/projects/${projectId}/research/clips`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify(input),
+        });
+        if (!response.ok) {
+          const data = await response.json().catch(() => null);
+          throw new Error((data as { error?: string } | null)?.error || "Failed to save clip");
+        }
+        const data = (await response.json()) as { clip: ResearchClip };
+        const isNew = response.status === 201;
+        if (isNew) {
+          setClips((prev) => [data.clip, ...prev]);
+          setClipCount((prev) => prev + 1);
+        }
+        return { isNew };
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to save clip");
+        return null;
+      }
+    },
+    [getToken, projectId],
+  );
+
+  /** Delete a clip (optimistic removal) */
+  const deleteClip = useCallback(
+    async (clipId: string) => {
+      try {
+        setError(null);
+        // Optimistic removal
+        setClips((prev) => prev.filter((c) => c.id !== clipId));
+        setClipCount((prev) => Math.max(0, prev - 1));
+
+        const token = await getToken();
+        const response = await fetch(`${API_URL}/research/clips/${clipId}`, {
+          method: "DELETE",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!response.ok) {
+          // Revert on failure -- re-fetch to get accurate state
+          await fetchClips();
+          throw new Error("Failed to delete clip");
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to delete clip");
+      }
+    },
+    [getToken, fetchClips],
+  );
+
+  return {
+    clips,
+    clipCount,
+    isLoading,
+    error,
+    fetchClips,
+    saveClip,
+    deleteClip,
+  };
+}

--- a/workers/dc-api/migrations/0014_create_research_clips.sql
+++ b/workers/dc-api/migrations/0014_create_research_clips.sql
@@ -1,0 +1,22 @@
+-- Research clips: saved text snippets from AI results or source text selection.
+-- Users can tag clips with a chapter for organization.
+CREATE TABLE IF NOT EXISTS research_clips (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id),
+  user_id TEXT NOT NULL REFERENCES users(id),
+  source_id TEXT REFERENCES source_materials(id) ON DELETE SET NULL,
+  chapter_id TEXT REFERENCES chapters(id) ON DELETE SET NULL,
+  source_title TEXT NOT NULL,
+  snippet_text TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+
+CREATE INDEX idx_research_clips_project ON research_clips(project_id);
+CREATE INDEX idx_research_clips_user ON research_clips(user_id);
+CREATE INDEX idx_research_clips_chapter ON research_clips(chapter_id);
+CREATE INDEX idx_research_clips_created ON research_clips(created_at);
+-- Deduplication: same user cannot save the exact same text for the same project
+CREATE UNIQUE INDEX idx_research_clips_dedup
+  ON research_clips(project_id, user_id, content_hash);

--- a/workers/dc-api/src/index.ts
+++ b/workers/dc-api/src/index.ts
@@ -11,6 +11,7 @@ import { chapters } from "./routes/chapters.js";
 import { ai } from "./routes/ai.js";
 import { exportRoutes } from "./routes/export.js";
 import { sources } from "./routes/sources.js";
+import { research } from "./routes/research.js";
 import type { ErrorCode } from "./types/index.js";
 
 const app = new Hono<{ Bindings: Env }>();
@@ -88,6 +89,7 @@ app.route("/ai", ai);
 app.route("/", exportRoutes);
 app.route("/", chapters);
 app.route("/", sources);
+app.route("/", research);
 
 // 404 fallback
 app.notFound((c) => {

--- a/workers/dc-api/src/routes/research.ts
+++ b/workers/dc-api/src/routes/research.ts
@@ -1,0 +1,81 @@
+/**
+ * Research routes -- clips management for the research board.
+ *
+ * Routes:
+ * - POST /projects/:projectId/research/clips - Save a new clip
+ * - GET /projects/:projectId/research/clips - List clips (optional ?chapterId filter)
+ * - DELETE /research/clips/:clipId - Delete a clip
+ *
+ * All routes require authentication and enforce ownership via project JOIN.
+ */
+
+import { Hono } from "hono";
+import type { Env } from "../types/index.js";
+import { standardRateLimit } from "../middleware/rate-limit.js";
+import { validationError } from "../middleware/error-handler.js";
+import { ResearchClipService, type CreateClipInput } from "../services/research-clip.js";
+
+const research = new Hono<{ Bindings: Env }>();
+
+// Auth is enforced globally in index.ts
+research.use("*", standardRateLimit);
+
+/**
+ * POST /projects/:projectId/research/clips
+ * Save a text snippet as a clip.
+ */
+research.post("/projects/:projectId/research/clips", async (c) => {
+  const { userId } = c.get("auth");
+  const projectId = c.req.param("projectId");
+  const body = (await c.req.json().catch(() => ({}))) as Partial<CreateClipInput>;
+
+  if (!body.snippetText || typeof body.snippetText !== "string" || body.snippetText.trim() === "") {
+    validationError("snippetText is required");
+  }
+
+  if (!body.sourceTitle || typeof body.sourceTitle !== "string") {
+    validationError("sourceTitle is required");
+  }
+
+  const service = new ResearchClipService(c.env.DB);
+  const { clip, isNew } = await service.createClip(userId, projectId, {
+    sourceId: body.sourceId ?? null,
+    sourceTitle: body.sourceTitle,
+    snippetText: body.snippetText,
+    chapterId: body.chapterId ?? null,
+  });
+
+  return c.json({ clip }, isNew ? 201 : 200);
+});
+
+/**
+ * GET /projects/:projectId/research/clips
+ * List clips for a project, most recent first.
+ * Optional query: ?chapterId=xxx to filter by chapter.
+ */
+research.get("/projects/:projectId/research/clips", async (c) => {
+  const { userId } = c.get("auth");
+  const projectId = c.req.param("projectId");
+  const chapterId = c.req.query("chapterId") || undefined;
+
+  const service = new ResearchClipService(c.env.DB);
+  const result = await service.listClips(userId, projectId, chapterId);
+
+  return c.json(result);
+});
+
+/**
+ * DELETE /research/clips/:clipId
+ * Delete a saved clip.
+ */
+research.delete("/research/clips/:clipId", async (c) => {
+  const { userId } = c.get("auth");
+  const clipId = c.req.param("clipId");
+
+  const service = new ResearchClipService(c.env.DB);
+  await service.deleteClip(userId, clipId);
+
+  return c.json({ success: true });
+});
+
+export { research };

--- a/workers/dc-api/src/services/research-clip.ts
+++ b/workers/dc-api/src/services/research-clip.ts
@@ -1,0 +1,208 @@
+/**
+ * Research clip service -- CRUD operations for saved text snippets.
+ *
+ * Clips are text snippets saved from AI results or source document selections.
+ * They belong to a project and user, optionally tagged to a chapter.
+ */
+
+import { ulid } from "ulidx";
+import { notFound } from "../middleware/error-handler.js";
+
+/** Row shape from D1 query */
+interface ClipRow {
+  id: string;
+  project_id: string;
+  user_id: string;
+  source_id: string | null;
+  chapter_id: string | null;
+  source_title: string;
+  snippet_text: string;
+  content_hash: string;
+  created_at: string;
+  updated_at: string;
+  chapter_title?: string | null;
+}
+
+/** Public clip model */
+export interface ResearchClip {
+  id: string;
+  projectId: string;
+  sourceId: string | null;
+  chapterId: string | null;
+  sourceTitle: string;
+  snippetText: string;
+  chapterTitle: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Input for creating a clip */
+export interface CreateClipInput {
+  sourceId?: string | null;
+  sourceTitle: string;
+  snippetText: string;
+  chapterId?: string | null;
+}
+
+function rowToClip(row: ClipRow): ResearchClip {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    sourceId: row.source_id,
+    chapterId: row.chapter_id,
+    sourceTitle: row.source_title,
+    snippetText: row.snippet_text,
+    chapterTitle: row.chapter_title ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** Generate a content hash for deduplication (simple but effective) */
+async function hashContent(text: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(text);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export class ResearchClipService {
+  constructor(private readonly db: D1Database) {}
+
+  /**
+   * Create a new clip. Returns 201 for new, 200 for existing (dedup).
+   */
+  async createClip(
+    userId: string,
+    projectId: string,
+    input: CreateClipInput,
+  ): Promise<{ clip: ResearchClip; isNew: boolean }> {
+    // Verify project ownership
+    const project = await this.db
+      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ?`)
+      .bind(projectId, userId)
+      .first<{ id: string }>();
+
+    if (!project) {
+      notFound("Project not found");
+    }
+
+    const contentHash = await hashContent(input.snippetText);
+    const now = new Date().toISOString();
+
+    // Check for existing clip with same hash (dedup)
+    const existing = await this.db
+      .prepare(
+        `SELECT rc.*, ch.title as chapter_title
+         FROM research_clips rc
+         LEFT JOIN chapters ch ON rc.chapter_id = ch.id
+         WHERE rc.project_id = ? AND rc.user_id = ? AND rc.content_hash = ?`,
+      )
+      .bind(projectId, userId, contentHash)
+      .first<ClipRow>();
+
+    if (existing) {
+      return { clip: rowToClip(existing), isNew: false };
+    }
+
+    const id = ulid();
+
+    await this.db
+      .prepare(
+        `INSERT INTO research_clips (id, project_id, user_id, source_id, chapter_id, source_title, snippet_text, content_hash, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        id,
+        projectId,
+        userId,
+        input.sourceId ?? null,
+        input.chapterId ?? null,
+        input.sourceTitle,
+        input.snippetText,
+        contentHash,
+        now,
+        now,
+      )
+      .run();
+
+    const clip: ResearchClip = {
+      id,
+      projectId,
+      sourceId: input.sourceId ?? null,
+      chapterId: input.chapterId ?? null,
+      sourceTitle: input.sourceTitle,
+      snippetText: input.snippetText,
+      chapterTitle: null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    return { clip, isNew: true };
+  }
+
+  /**
+   * List clips for a project, most recent first.
+   * Optionally filter by chapterId.
+   */
+  async listClips(
+    userId: string,
+    projectId: string,
+    chapterId?: string,
+  ): Promise<{ clips: ResearchClip[]; count: number }> {
+    // Verify project ownership
+    const project = await this.db
+      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ?`)
+      .bind(projectId, userId)
+      .first<{ id: string }>();
+
+    if (!project) {
+      notFound("Project not found");
+    }
+
+    let sql = `
+      SELECT rc.*, ch.title as chapter_title
+      FROM research_clips rc
+      LEFT JOIN chapters ch ON rc.chapter_id = ch.id
+      WHERE rc.project_id = ? AND rc.user_id = ?
+    `;
+    const params: string[] = [projectId, userId];
+
+    if (chapterId) {
+      sql += ` AND rc.chapter_id = ?`;
+      params.push(chapterId);
+    }
+
+    sql += ` ORDER BY rc.created_at DESC`;
+
+    const result = await this.db
+      .prepare(sql)
+      .bind(...params)
+      .all<ClipRow>();
+
+    const clips = (result.results ?? []).map(rowToClip);
+
+    return { clips, count: clips.length };
+  }
+
+  /**
+   * Delete a clip. Verifies ownership.
+   */
+  async deleteClip(userId: string, clipId: string): Promise<void> {
+    const clip = await this.db
+      .prepare(
+        `SELECT rc.id FROM research_clips rc
+         JOIN projects p ON rc.project_id = p.id
+         WHERE rc.id = ? AND p.user_id = ?`,
+      )
+      .bind(clipId, userId)
+      .first<{ id: string }>();
+
+    if (!clip) {
+      notFound("Clip not found");
+    }
+
+    await this.db.prepare(`DELETE FROM research_clips WHERE id = ?`).bind(clipId).run();
+  }
+}

--- a/workers/dc-api/test/helpers/seed.ts
+++ b/workers/dc-api/test/helpers/seed.ts
@@ -113,11 +113,50 @@ export async function seedSource(
   return { id, projectId, driveFileId, title };
 }
 
+export async function seedClip(
+  projectId: string,
+  userId: string,
+  overrides?: {
+    id?: string;
+    sourceId?: string | null;
+    chapterId?: string | null;
+    sourceTitle?: string;
+    snippetText?: string;
+    contentHash?: string;
+    createdAt?: string;
+  },
+) {
+  const id = overrides?.id ?? ulid();
+  const sourceTitle = overrides?.sourceTitle ?? "Test Source";
+  const snippetText = overrides?.snippetText ?? "Test clip text";
+  const contentHash = overrides?.contentHash ?? `hash-${id}`;
+  const ts = overrides?.createdAt ?? now();
+  await env.DB.prepare(
+    `INSERT INTO research_clips (id, project_id, user_id, source_id, chapter_id, source_title, snippet_text, content_hash, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      id,
+      projectId,
+      userId,
+      overrides?.sourceId ?? null,
+      overrides?.chapterId ?? null,
+      sourceTitle,
+      snippetText,
+      contentHash,
+      ts,
+      ts,
+    )
+    .run();
+  return { id, projectId, userId, sourceTitle, snippetText };
+}
+
 /**
  * Remove all rows from test tables in reverse FK order.
  */
 export async function cleanAll() {
   await env.DB.batch([
+    env.DB.prepare("DELETE FROM research_clips"),
     env.DB.prepare("DELETE FROM ai_interactions"),
     env.DB.prepare("DELETE FROM export_jobs"),
     env.DB.prepare("DELETE FROM source_materials"),

--- a/workers/dc-api/test/research-clip.test.ts
+++ b/workers/dc-api/test/research-clip.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { env } from "cloudflare:test";
+import { ResearchClipService } from "../src/services/research-clip.js";
+import {
+  seedUser,
+  seedProject,
+  seedChapter,
+  seedSource,
+  seedClip,
+  cleanAll,
+} from "./helpers/seed.js";
+
+describe("ResearchClipService", () => {
+  let service: ResearchClipService;
+  let userId: string;
+  let projectId: string;
+
+  beforeEach(async () => {
+    await cleanAll();
+    service = new ResearchClipService(env.DB);
+    const user = await seedUser();
+    userId = user.id;
+    const project = await seedProject(userId);
+    projectId = project.id;
+  });
+
+  describe("createClip", () => {
+    it("creates a new clip", async () => {
+      const { clip, isNew } = await service.createClip(userId, projectId, {
+        sourceTitle: "Interview Notes",
+        snippetText: "This is a test snippet from the interview.",
+      });
+
+      expect(isNew).toBe(true);
+      expect(clip.projectId).toBe(projectId);
+      expect(clip.sourceTitle).toBe("Interview Notes");
+      expect(clip.snippetText).toBe("This is a test snippet from the interview.");
+      expect(clip.sourceId).toBeNull();
+      expect(clip.chapterId).toBeNull();
+      expect(clip.id).toBeTruthy();
+    });
+
+    it("creates a clip with sourceId and chapterId", async () => {
+      const source = await seedSource(projectId);
+      const chapter = await seedChapter(projectId);
+
+      const { clip, isNew } = await service.createClip(userId, projectId, {
+        sourceId: source.id,
+        sourceTitle: source.title,
+        snippetText: "Snippet with source and chapter",
+        chapterId: chapter.id,
+      });
+
+      expect(isNew).toBe(true);
+      expect(clip.sourceId).toBe(source.id);
+      expect(clip.chapterId).toBe(chapter.id);
+    });
+
+    it("deduplicates on same snippet text", async () => {
+      const text = "Exact same text for dedup test.";
+
+      const first = await service.createClip(userId, projectId, {
+        sourceTitle: "Source A",
+        snippetText: text,
+      });
+      expect(first.isNew).toBe(true);
+
+      const second = await service.createClip(userId, projectId, {
+        sourceTitle: "Source B",
+        snippetText: text,
+      });
+      expect(second.isNew).toBe(false);
+      expect(second.clip.id).toBe(first.clip.id);
+    });
+
+    it("throws NOT_FOUND for non-existent project", async () => {
+      await expect(
+        service.createClip(userId, "fake-project-id", {
+          sourceTitle: "Test",
+          snippetText: "Test",
+        }),
+      ).rejects.toThrow("Project not found");
+    });
+
+    it("throws NOT_FOUND for project owned by different user", async () => {
+      const otherUser = await seedUser({ id: "other-user" });
+      const otherProject = await seedProject(otherUser.id);
+
+      await expect(
+        service.createClip(userId, otherProject.id, {
+          sourceTitle: "Test",
+          snippetText: "Test",
+        }),
+      ).rejects.toThrow("Project not found");
+    });
+  });
+
+  describe("listClips", () => {
+    it("returns clips ordered by created_at DESC (most recent first)", async () => {
+      await seedClip(projectId, userId, {
+        snippetText: "First clip",
+        createdAt: "2026-01-01T00:00:00Z",
+      });
+      await seedClip(projectId, userId, {
+        snippetText: "Second clip",
+        createdAt: "2026-01-02T00:00:00Z",
+      });
+      await seedClip(projectId, userId, {
+        snippetText: "Third clip",
+        createdAt: "2026-01-03T00:00:00Z",
+      });
+
+      const { clips, count } = await service.listClips(userId, projectId);
+
+      expect(count).toBe(3);
+      expect(clips[0].snippetText).toBe("Third clip");
+      expect(clips[1].snippetText).toBe("Second clip");
+      expect(clips[2].snippetText).toBe("First clip");
+    });
+
+    it("filters by chapterId", async () => {
+      const chapter = await seedChapter(projectId, { title: "Chapter 1" });
+      await seedClip(projectId, userId, { snippetText: "Tagged clip", chapterId: chapter.id });
+      await seedClip(projectId, userId, { snippetText: "Untagged clip" });
+
+      const { clips } = await service.listClips(userId, projectId, chapter.id);
+
+      expect(clips).toHaveLength(1);
+      expect(clips[0].snippetText).toBe("Tagged clip");
+    });
+
+    it("includes chapter title via JOIN", async () => {
+      const chapter = await seedChapter(projectId, { title: "Chapter 3: Discussion" });
+      await seedClip(projectId, userId, { chapterId: chapter.id });
+
+      const { clips } = await service.listClips(userId, projectId);
+
+      expect(clips[0].chapterTitle).toBe("Chapter 3: Discussion");
+    });
+
+    it("returns empty array for project with no clips", async () => {
+      const { clips, count } = await service.listClips(userId, projectId);
+
+      expect(clips).toHaveLength(0);
+      expect(count).toBe(0);
+    });
+
+    it("throws NOT_FOUND for non-existent project", async () => {
+      await expect(service.listClips(userId, "fake-project")).rejects.toThrow("Project not found");
+    });
+
+    it("does not leak clips from other users", async () => {
+      await seedClip(projectId, userId, { snippetText: "My clip" });
+
+      const otherUser = await seedUser({ id: "other-user-list" });
+      const otherProject = await seedProject(otherUser.id);
+      await seedClip(otherProject.id, otherUser.id, { snippetText: "Other user clip" });
+
+      const { clips } = await service.listClips(userId, projectId);
+      expect(clips).toHaveLength(1);
+      expect(clips[0].snippetText).toBe("My clip");
+    });
+  });
+
+  describe("deleteClip", () => {
+    it("deletes a clip", async () => {
+      const clip = await seedClip(projectId, userId);
+
+      await service.deleteClip(userId, clip.id);
+
+      const { clips } = await service.listClips(userId, projectId);
+      expect(clips).toHaveLength(0);
+    });
+
+    it("throws NOT_FOUND for non-existent clip", async () => {
+      await expect(service.deleteClip(userId, "fake-clip-id")).rejects.toThrow("Clip not found");
+    });
+
+    it("prevents deleting another user's clip", async () => {
+      const otherUser = await seedUser({ id: "other-user-delete" });
+      const otherProject = await seedProject(otherUser.id);
+      const otherClip = await seedClip(otherProject.id, otherUser.id);
+
+      await expect(service.deleteClip(userId, otherClip.id)).rejects.toThrow("Clip not found");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements the full Clips tab feature for the research board: API backend (D1 migration, service, routes), frontend hook, and UI components with chapter filtering, search, and clip management.

## Changes
- **Migration** `0014_create_research_clips.sql`: research_clips table with project/user/source/chapter FKs, content hash dedup index, and created_at ordering index
- **ResearchClipService**: create (with SHA-256 dedup), list (with optional chapterId filter, chapter title JOIN), delete (with ownership verification)
- **Research routes**: POST create, GET list with ?chapterId query, DELETE by clipId -- mounted at `/projects/:projectId/research/clips` and `/research/clips/:clipId`
- **useResearchClips hook**: fetch, save (dedup-aware), delete (optimistic removal with revert on failure), clip count tracking
- **ClipCard component**: 300-char truncation with Show more/less toggle, tappable source title (or "[Source removed]" in gray), compact chapter tag badge ("Ch. N"), swipe-left-to-delete gesture, overflow menu delete, 44pt touch targets, relative date formatting
- **ClipsTab component**: chapter filter dropdown (shows only chapters with clips), client-side search by snippet text and source title, empty/loading/error states with retry
- **Tests**: 14 API service tests (create, dedup, list ordering, chapter filter, delete, ownership), 12 ClipCard tests (rendering, truncation, source states, actions, touch targets), 11 ClipsTab tests (states, filtering, search, chapter dropdown)
- **Seed helper**: added `seedClip()` and `research_clips` to `cleanAll()`

## Test Plan
- [ ] API: POST /projects/:projectId/research/clips creates a clip (201) and deduplicates (200)
- [ ] API: GET /projects/:projectId/research/clips returns clips most-recent-first
- [ ] API: GET /projects/:projectId/research/clips?chapterId=xxx filters by chapter
- [ ] API: DELETE /research/clips/:clipId removes clip, rejects for wrong user
- [ ] UI: ClipsTab shows empty state when no clips
- [ ] UI: ClipsTab shows clip cards with snippet, source title, chapter tag, date
- [ ] UI: Chapter filter dropdown shows only chapters that have clips
- [ ] UI: Search filters clips by text content and source title
- [ ] UI: ClipCard truncates at 300 chars with Show more/less toggle
- [ ] UI: ClipCard shows "[Source removed]" for clips with deleted sources
- [ ] UI: Delete via overflow menu removes clip without confirmation dialog
- [ ] UI: All touch targets meet 44pt minimum height

Closes #199

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>