### PR TITLE
feat: insert clips into editor with automatic footnote creation

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -30,6 +30,7 @@ import { useSources } from "@/hooks/use-sources";
 import { isNudgeDismissed } from "@/components/research/first-use-nudge";
 import { useEditorProject } from "@/hooks/use-editor-project";
 import { useChapterContent } from "@/hooks/use-chapter-content";
+import { useClipInsert } from "@/hooks/use-clip-insert";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
@@ -133,6 +134,12 @@ function EditorPageInner() {
       setContent,
       currentContent,
     });
+
+  // --- Clip insertion (#200) ---
+  const { canInsert, insertClip, trackSelection } = useClipInsert({
+    editorRef,
+    activeChapterId,
+  });
 
   // --- Sidebar UI state ---
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
@@ -391,11 +398,12 @@ function EditorPageInner() {
           onTitleEditCancel={() => setEditingTitle(false)}
           currentWordCount={currentWordCount}
           selectionWordCount={selectionWordCount}
+          onSelectionUpdate={trackSelection}
         />
       </div>
 
       {/* Research Panel (#182) - side-by-side in landscape, overlay in portrait */}
-      <ResearchPanel />
+      <ResearchPanel onInsertClip={insertClip} canInsert={canInsert} />
 
       <EditorDialogs
         projectData={projectData}

--- a/web/src/components/editor/chapter-editor.tsx
+++ b/web/src/components/editor/chapter-editor.tsx
@@ -34,6 +34,8 @@ interface ChapterEditorProps {
   onEditorReady?: (editor: Editor) => void;
   /** Callback when selection word count changes (0 when no selection) */
   onSelectionWordCountChange?: (selectionWordCount: number) => void;
+  /** Callback when cursor/selection changes — used to track last cursor position for clip insertion */
+  onSelectionUpdate?: () => void;
 }
 
 /**
@@ -63,6 +65,7 @@ export const ChapterEditor = forwardRef<ChapterEditorHandle, ChapterEditorProps>
       editable = true,
       onEditorReady,
       onSelectionWordCountChange,
+      onSelectionUpdate,
     },
     ref,
   ) {
@@ -99,6 +102,9 @@ export const ChapterEditor = forwardRef<ChapterEditorHandle, ChapterEditorProps>
       },
       onUpdate: ({ editor: ed }) => {
         onUpdate?.(ed.getHTML());
+      },
+      onSelectionUpdate: () => {
+        onSelectionUpdate?.();
       },
     });
 

--- a/web/src/components/editor/editor-writing-area.tsx
+++ b/web/src/components/editor/editor-writing-area.tsx
@@ -22,6 +22,9 @@ interface EditorWritingAreaProps {
   // Word count display
   currentWordCount: number;
   selectionWordCount: number;
+
+  /** Callback when cursor/selection changes in the editor */
+  onSelectionUpdate?: () => void;
 }
 
 /**
@@ -47,6 +50,7 @@ export function EditorWritingArea({
   onTitleEditCancel,
   currentWordCount,
   selectionWordCount,
+  onSelectionUpdate,
 }: EditorWritingAreaProps) {
   return (
     <div className="flex-1 overflow-auto">
@@ -93,6 +97,7 @@ export function EditorWritingArea({
           content={currentContent}
           onUpdate={onContentChange}
           onSelectionWordCountChange={onSelectionWordCountChange}
+          onSelectionUpdate={onSelectionUpdate}
         />
 
         <div className="mt-4 flex items-center justify-end">

--- a/web/src/components/research/research-panel.tsx
+++ b/web/src/components/research/research-panel.tsx
@@ -7,6 +7,7 @@ import { SourcesTab } from "./sources-tab";
 import { AskTab } from "./ask-tab";
 import { ClipsTab } from "./clips-tab";
 import { useResearchClips } from "@/hooks/use-research-clips";
+import type { InsertResult } from "@/hooks/use-clip-insert";
 
 // === Tab Definitions ===
 
@@ -204,7 +205,15 @@ function TabBar({
 
 // === Tab Content Component ===
 
-function TabContent({ activeTab }: { activeTab: ResearchTab }) {
+function TabContent({
+  activeTab,
+  onInsertClip,
+  canInsert,
+}: {
+  activeTab: ResearchTab;
+  onInsertClip: (text: string, sourceTitle: string) => InsertResult;
+  canInsert: boolean;
+}) {
   // Render all tabs but only show the active one.
   // This preserves state when switching tabs (acceptance criteria).
   return (
@@ -216,7 +225,7 @@ function TabContent({ activeTab }: { activeTab: ResearchTab }) {
         <AskTab />
       </TabPanel>
       <TabPanel id="clips" activeTab={activeTab}>
-        <ClipsTab />
+        <ClipsTab onInsertClip={onInsertClip} canInsert={canInsert} />
       </TabPanel>
     </div>
   );
@@ -247,7 +256,12 @@ function TabPanel({
 
 // === Main Research Panel Component ===
 
-export function ResearchPanel() {
+export interface ResearchPanelProps {
+  onInsertClip?: (text: string, sourceTitle: string) => InsertResult;
+  canInsert?: boolean;
+}
+
+export function ResearchPanel({ onInsertClip, canInsert = false }: ResearchPanelProps) {
   const { isOpen, activeTab, setActiveTab, closePanel, openPanel } = useResearchPanel();
   const params = useParams();
   const projectId = params.projectId as string;
@@ -261,6 +275,14 @@ export function ResearchPanel() {
       fetchClips();
     }
   }, [isOpen, projectId, fetchClips]);
+
+  const handleInsertClip = useCallback(
+    (text: string, sourceTitle: string): InsertResult => {
+      if (onInsertClip) return onInsertClip(text, sourceTitle);
+      return "no-editor";
+    },
+    [onInsertClip],
+  );
 
   const layoutMode = useLayoutMode();
   const panelRef = useRef<HTMLDivElement>(null);
@@ -307,7 +329,7 @@ export function ResearchPanel() {
       >
         <PanelHeader onClose={closePanel} />
         <TabBar activeTab={activeTab} onTabChange={setActiveTab} clipCount={clipCount} />
-        <TabContent activeTab={activeTab} />
+        <TabContent activeTab={activeTab} onInsertClip={handleInsertClip} canInsert={canInsert} />
       </div>
     );
   }
@@ -333,7 +355,7 @@ export function ResearchPanel() {
       >
         <PanelHeader onClose={closePanel} />
         <TabBar activeTab={activeTab} onTabChange={setActiveTab} clipCount={clipCount} />
-        <TabContent activeTab={activeTab} />
+        <TabContent activeTab={activeTab} onInsertClip={handleInsertClip} canInsert={canInsert} />
       </div>
     </>
   );

--- a/web/src/extensions/index.ts
+++ b/web/src/extensions/index.ts
@@ -12,4 +12,4 @@ export { FootnoteRef } from "./footnote-ref";
 export { FootnoteContent } from "./footnote-content";
 export { FootnoteSection } from "./footnote-section";
 export { FootnotePlugin } from "./footnote-plugin";
-export { insertFootnote } from "./footnote-commands";
+export { insertFootnote, insertClipWithFootnote } from "./footnote-commands";

--- a/web/src/hooks/use-clip-insert.ts
+++ b/web/src/hooks/use-clip-insert.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useRef, useCallback, useEffect, useMemo } from "react";
+import type { ChapterEditorHandle } from "@/components/editor/chapter-editor";
+import { insertClipWithFootnote } from "@/extensions/footnote-commands";
+
+/**
+ * Result from calling insertClip().
+ * - "inserted": blockquote + footnote inserted at stored cursor position
+ * - "appended": no cursor stored, appended at end of chapter with fallback message
+ * - "no-editor": no active editor (no chapter selected)
+ */
+export type InsertResult = "inserted" | "appended" | "no-editor";
+
+export interface UseClipInsertOptions {
+  /** Ref to the ChapterEditor's imperative handle */
+  editorRef: React.RefObject<ChapterEditorHandle | null>;
+  /** Active chapter ID (null = no chapter selected) */
+  activeChapterId: string | null | undefined;
+}
+
+export interface UseClipInsertReturn {
+  /** Whether insert is available (editor exists and chapter is selected) */
+  canInsert: boolean;
+  /**
+   * Insert a clip into the editor as a blockquote with an auto-created footnote.
+   * Uses the last stored cursor position, or appends to end if none stored.
+   *
+   * @param text - The clip/snippet text to insert as a blockquote
+   * @param sourceTitle - The source title for the footnote reference
+   * @returns InsertResult indicating what happened
+   */
+  insertClip: (text: string, sourceTitle: string) => InsertResult;
+  /**
+   * Call this to track the editor's selection whenever it changes.
+   * Should be called from the editor's onSelectionUpdate or onTransaction callback.
+   */
+  trackSelection: () => void;
+}
+
+/**
+ * Hook that manages clip insertion into the Tiptap editor.
+ *
+ * Tracks the editor's cursor position via lastSelectionRef so that when the
+ * Research Panel has focus, we know where to insert. Uses requestAnimationFrame
+ * on editor.commands.focus() to prevent iPad viewport jumping.
+ *
+ * The insertion is a single ProseMirror transaction: blockquote + footnoteRef
+ * in the text, footnoteContent appended to the footnote section. This ensures
+ * Cmd+Z undoes the entire operation atomically.
+ *
+ * Per design-spec.md Flow 6 (Insert a Snippet) and Decision 9 (blockquote + footnote).
+ */
+export function useClipInsert({
+  editorRef,
+  activeChapterId,
+}: UseClipInsertOptions): UseClipInsertReturn {
+  // Track last known cursor position (ProseMirror document position).
+  // This is updated whenever the editor selection changes, even when the
+  // Research Panel subsequently takes focus.
+  const lastSelectionRef = useRef<number | null>(null);
+
+  const canInsert = !!activeChapterId;
+
+  // Reset stored position when chapter changes
+  useEffect(() => {
+    lastSelectionRef.current = null;
+  }, [activeChapterId]);
+
+  const trackSelection = useCallback(() => {
+    const editor = editorRef.current?.getEditor();
+    if (!editor) return;
+    const { from } = editor.state.selection;
+    lastSelectionRef.current = from;
+  }, [editorRef]);
+
+  const insertClip = useCallback(
+    (text: string, sourceTitle: string): InsertResult => {
+      const editor = editorRef.current?.getEditor();
+      if (!editor || !activeChapterId) return "no-editor";
+
+      const storedPos = lastSelectionRef.current;
+
+      // Use requestAnimationFrame to prevent iPad viewport jumping (#200 AC)
+      // Focus the editor first, then perform the insertion
+      requestAnimationFrame(() => {
+        if (storedPos !== null) {
+          // Restore cursor to stored position
+          editor.commands.focus(null, { scrollIntoView: false });
+          const maxPos = editor.state.doc.content.size;
+          const safePos = Math.min(storedPos, maxPos);
+          editor.commands.setTextSelection(safePos);
+        } else {
+          // No stored position -- move to end of document content.
+          // We need to find the end of the "body" content (before any
+          // footnoteSection / HR).
+          editor.commands.focus("end", { scrollIntoView: false });
+        }
+
+        // Perform the insertion as a single transaction
+        insertClipWithFootnote(editor, text, sourceTitle);
+
+        // Scroll into view after insertion
+        requestAnimationFrame(() => {
+          editor.commands.scrollIntoView();
+        });
+      });
+
+      return storedPos !== null ? "inserted" : "appended";
+    },
+    [editorRef, activeChapterId],
+  );
+
+  return useMemo(
+    () => ({ canInsert, insertClip, trackSelection }),
+    [canInsert, insertClip, trackSelection],
+  );
+}

--- a/web/test/components/clips-tab-search.test.tsx
+++ b/web/test/components/clips-tab-search.test.tsx
@@ -35,6 +35,10 @@ vi.mock("@/components/research/research-panel-provider", () => ({
   }),
 }));
 
+vi.mock("@/components/toast", () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+
 // Mock useResearchClips to control clips data
 let mockClips: ReturnType<typeof makeClip>[] = [];
 vi.mock("@/hooks/use-research-clips", () => ({
@@ -99,14 +103,14 @@ describe("ClipsTab search", () => {
 
   it("shows search input when clips exist", () => {
     mockClips = [makeClip({ id: "c1", content: "First clip" })];
-    render(<ClipsTab />);
+    render(<ClipsTab onInsertClip={vi.fn().mockReturnValue("no-editor")} canInsert={false} />);
 
     expect(screen.getByLabelText("Search clips")).toBeInTheDocument();
   });
 
   it("does not show search input when no clips", () => {
     mockClips = [];
-    render(<ClipsTab />);
+    render(<ClipsTab onInsertClip={vi.fn().mockReturnValue("no-editor")} canInsert={false} />);
 
     expect(screen.queryByLabelText("Search clips")).not.toBeInTheDocument();
   });
@@ -116,7 +120,7 @@ describe("ClipsTab search", () => {
       makeClip({ id: "c1", content: "Alpha beta gamma" }),
       makeClip({ id: "c2", content: "Delta epsilon zeta" }),
     ];
-    render(<ClipsTab />);
+    render(<ClipsTab onInsertClip={vi.fn().mockReturnValue("no-editor")} canInsert={false} />);
 
     const search = screen.getByLabelText("Search clips");
     fireEvent.change(search, { target: { value: "alpha" } });
@@ -130,7 +134,7 @@ describe("ClipsTab search", () => {
       makeClip({ id: "c1", content: "Clip A", sourceTitle: "Interview Notes" }),
       makeClip({ id: "c2", content: "Clip B", sourceTitle: "Research Paper" }),
     ];
-    render(<ClipsTab />);
+    render(<ClipsTab onInsertClip={vi.fn().mockReturnValue("no-editor")} canInsert={false} />);
 
     const search = screen.getByLabelText("Search clips");
     fireEvent.change(search, { target: { value: "interview" } });
@@ -141,7 +145,7 @@ describe("ClipsTab search", () => {
 
   it("shows 'no results' message when search matches nothing", () => {
     mockClips = [makeClip({ id: "c1", content: "Alpha" })];
-    render(<ClipsTab />);
+    render(<ClipsTab onInsertClip={vi.fn().mockReturnValue("no-editor")} canInsert={false} />);
 
     const search = screen.getByLabelText("Search clips");
     fireEvent.change(search, { target: { value: "zzzzz" } });
@@ -151,7 +155,7 @@ describe("ClipsTab search", () => {
 
   it("clears search with clear button", () => {
     mockClips = [makeClip({ id: "c1", content: "Alpha" }), makeClip({ id: "c2", content: "Beta" })];
-    render(<ClipsTab />);
+    render(<ClipsTab onInsertClip={vi.fn().mockReturnValue("no-editor")} canInsert={false} />);
 
     const search = screen.getByLabelText("Search clips");
     fireEvent.change(search, { target: { value: "alpha" } });
@@ -164,7 +168,7 @@ describe("ClipsTab search", () => {
 
   it("search is case-insensitive", () => {
     mockClips = [makeClip({ id: "c1", content: "UPPERCASE content" })];
-    render(<ClipsTab />);
+    render(<ClipsTab onInsertClip={vi.fn().mockReturnValue("no-editor")} canInsert={false} />);
 
     const search = screen.getByLabelText("Search clips");
     fireEvent.change(search, { target: { value: "uppercase" } });
@@ -174,7 +178,7 @@ describe("ClipsTab search", () => {
 
   it("shows empty state with correct wording", () => {
     mockClips = [];
-    render(<ClipsTab />);
+    render(<ClipsTab onInsertClip={vi.fn().mockReturnValue("no-editor")} canInsert={false} />);
 
     expect(screen.getByText("No clips yet")).toBeInTheDocument();
     expect(

--- a/web/test/extensions/clip-insert.test.ts
+++ b/web/test/extensions/clip-insert.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import {
+  FootnoteRef,
+  FootnoteContent,
+  FootnoteSection,
+  FootnotePlugin,
+  insertClipWithFootnote,
+} from "@/extensions";
+
+/**
+ * Tests for insertClipWithFootnote (#200).
+ *
+ * This function inserts a blockquote + footnote as a single ProseMirror transaction,
+ * ensuring Cmd+Z undoes the entire operation atomically.
+ *
+ * Uses StarterKit (which includes Document, Paragraph, Text, HorizontalRule,
+ * Blockquote, History, etc.) for a realistic editor environment.
+ */
+
+/** Create a Tiptap editor with StarterKit + footnote extensions */
+function createEditor(content?: string): Editor {
+  return new Editor({
+    extensions: [
+      StarterKit.configure({
+        heading: { levels: [2, 3] },
+      }),
+      FootnoteRef,
+      FootnoteContent,
+      FootnoteSection,
+      FootnotePlugin,
+    ],
+    content: content || "<p>Hello world</p>",
+  });
+}
+
+describe("insertClipWithFootnote", () => {
+  it("inserts a blockquote containing the clip text", () => {
+    const editor = createEditor("<p>Hello world</p>");
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    const result = insertClipWithFootnote(editor, "Test clip text", "Source Title");
+    expect(result).toBe(true);
+
+    const html = editor.getHTML();
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("Test clip text");
+    editor.destroy();
+  });
+
+  it("creates a footnoteRef after the blockquote", () => {
+    const editor = createEditor("<p>Hello world</p>");
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    insertClipWithFootnote(editor, "Quote from source", "My Research Paper");
+
+    const html = editor.getHTML();
+    expect(html).toContain("footnote-ref");
+    expect(html).toContain("data-footnote-id");
+    editor.destroy();
+  });
+
+  it("creates a footnoteContent with source title", () => {
+    const editor = createEditor("<p>Hello world</p>");
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    insertClipWithFootnote(editor, "Quote text", "My Research Paper");
+
+    const html = editor.getHTML();
+    expect(html).toContain("footnote-content");
+    expect(html).toContain("My Research Paper");
+    editor.destroy();
+  });
+
+  it("creates a footnoteSection with HR when none exists", () => {
+    const editor = createEditor("<p>Hello world</p>");
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    insertClipWithFootnote(editor, "Quote text", "Source A");
+
+    const html = editor.getHTML();
+    expect(html).toContain("<hr>");
+    expect(html).toContain('<div class="footnotes">');
+    editor.destroy();
+  });
+
+  it("appends to existing footnote section on second insert", () => {
+    const editor = createEditor("<p>Hello world</p>");
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    insertClipWithFootnote(editor, "First quote", "Source A");
+    // Move cursor back to the paragraph
+    editor.commands.setTextSelection(6);
+    insertClipWithFootnote(editor, "Second quote", "Source B");
+
+    const html = editor.getHTML();
+    expect(html).toContain("First quote");
+    expect(html).toContain("Second quote");
+    expect(html).toContain("Source A");
+    expect(html).toContain("Source B");
+
+    // Only one footnotes section
+    const footnoteSections = (html.match(/class="footnotes"/g) || []).length;
+    expect(footnoteSections).toBe(1);
+
+    editor.destroy();
+  });
+
+  it("assigns sequential labels via FootnotePlugin", () => {
+    const editor = createEditor("<p>Hello world</p>");
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    insertClipWithFootnote(editor, "Quote A", "Source A");
+    editor.commands.setTextSelection(6);
+    insertClipWithFootnote(editor, "Quote B", "Source B");
+
+    const html = editor.getHTML();
+    expect(html).toContain("[1]");
+    expect(html).toContain("[2]");
+
+    editor.destroy();
+  });
+
+  it("returns false when editor is null-ish", () => {
+    const result = insertClipWithFootnote(null as unknown as Editor, "text", "source");
+    expect(result).toBe(false);
+  });
+
+  it("undo removes both blockquote and footnote together", () => {
+    const editor = createEditor("<p>Hello world</p>");
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    insertClipWithFootnote(editor, "Quote text", "Source A");
+
+    // Verify content was inserted
+    let html = editor.getHTML();
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("footnote-ref");
+    expect(html).toContain("Source A");
+
+    // Undo should remove everything (blockquote + footnote section + hr)
+    editor.commands.undo();
+
+    html = editor.getHTML();
+    expect(html).not.toContain("<blockquote>");
+    expect(html).not.toContain("footnote-ref");
+    // The footnote content is cleaned up by the FootnotePlugin after ref removal
+    expect(html).not.toContain("footnote-content");
+
+    editor.destroy();
+  });
+
+  it("produces clean HTML for Drive export", () => {
+    const editor = createEditor("<p>Hello world</p>");
+    editor.commands.setTextSelection(editor.state.doc.content.size - 1);
+
+    insertClipWithFootnote(editor, "Important finding", "Research Paper Title");
+
+    const html = editor.getHTML();
+
+    // Clean HTML structure
+    expect(html).toContain("<blockquote>");
+    expect(html).toContain("<sup");
+    expect(html).toContain("<hr>");
+    expect(html).toContain('<div class="footnotes">');
+    expect(html).toContain('class="footnote-content"');
+
+    // No ProseMirror-specific garbage
+    expect(html).not.toContain("ProseMirror");
+    expect(html).not.toContain("contenteditable");
+
+    editor.destroy();
+  });
+
+  it("survives HTML round-trip", () => {
+    const editor1 = createEditor("<p>Hello world</p>");
+    editor1.commands.setTextSelection(editor1.state.doc.content.size - 1);
+    insertClipWithFootnote(editor1, "Quote text", "My Source");
+
+    const savedHtml = editor1.getHTML();
+    editor1.destroy();
+
+    // Restore into a new editor
+    const editor2 = createEditor(savedHtml);
+    const restoredHtml = editor2.getHTML();
+
+    expect(restoredHtml).toContain("<blockquote>");
+    expect(restoredHtml).toContain("Quote text");
+    expect(restoredHtml).toContain("footnote-ref");
+    expect(restoredHtml).toContain("footnote-content");
+    expect(restoredHtml).toContain("My Source");
+    expect(restoredHtml).toContain('data-footnote-label="1"');
+
+    editor2.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
Capstone feature (#200): inserting research clips from the Research Panel into the Tiptap editor as blockquotes with auto-numbered footnotes. A single ProseMirror transaction ensures Cmd+Z undoes the entire operation atomically.

Integrated from mbp27 PR #233, adapted to current main (which has search, swipe-to-delete, and chapter filtering from #195/#199/#230).

## Changes
- **`insertClipWithFootnote()`** in `footnote-commands.ts`: Inserts blockquote + footnoteRef at cursor, appends footnoteContent to footnote section, creates section with HR if needed — all in one transaction
- **`useClipInsert` hook**: Tracks editor cursor via `lastSelectionRef` (persists when Research Panel has focus), provides `canInsert` state, uses `requestAnimationFrame` for iPad viewport stability
- **Editor wiring**: `ChapterEditor` gains `onSelectionUpdate`, threaded through `EditorWritingArea` → editor page
- **`ResearchPanel`** accepts `onInsertClip` + `canInsert` props, threads to `TabContent` → `ClipsTab`
- **`ClipsTab`** wired to real insert: `onInsert` triggers `insertClipWithFootnote` with toast feedback ("Inserted with footnote" / "Inserted at end of chapter")
- **10 new insertion tests**: blockquote creation, footnote creation, HR/section management, sequential labels, null guard, undo atomicity, Drive export HTML, round-trip
- Updated search tests for new `ClipsTabProps`

## Test Plan
- [x] 436 web tests pass (30 files)
- [x] Typecheck clean
- [x] Prettier clean
- [ ] Insert from Clips tab — blockquote + footnote at cursor
- [ ] Insert from Ask tab result card — same behavior
- [ ] Cmd+Z after insert — blockquote + footnote removed atomically
- [ ] Insert with no cursor — appended at end with toast
- [ ] Insert button disabled when no chapter selected
- [ ] On iPad Safari: no viewport jumping during insertion

Closes #200
Supersedes #233 (mbp27 PR with stale base — clean functionality cherry-picked here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)