### PR TITLE
feat: grouped source list with provider management

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -384,7 +384,9 @@ function EditorPageInner() {
       <ResearchPanel
         onInsertClip={insertClip}
         canInsert={canInsert}
-        projectDriveConnectionId={projectData?.driveConnectionId}
+        protectedConnectionIds={
+          projectData?.driveConnectionId ? [projectData.driveConnectionId] : []
+        }
       />
 
       <EditorDialogs

--- a/web/src/components/research/inline-drive-browser.tsx
+++ b/web/src/components/research/inline-drive-browser.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import type { DriveBrowseItem } from "@/hooks/use-drive-browser";
+
+// === Inline Drive Browser ===
+
+export interface InlineDriveBrowserProps {
+  folders: DriveBrowseItem[];
+  docs: DriveBrowseItem[];
+  isLoading: boolean;
+  error: string | null;
+  canGoBack: boolean;
+  selectedIds: Set<string>;
+  existingDriveFileIds: Set<string>;
+  selectableSelectedCount: number;
+  isAdding: boolean;
+  /** Email shown in the header to identify which account is being browsed */
+  providerEmail?: string;
+  onBack: () => void;
+  onOpenFolder: (folderId: string) => void;
+  onToggleSelect: (fileId: string) => void;
+  onAddSelected: () => void;
+  onRefresh: () => void;
+}
+
+/**
+ * Inline folder browser rendered within the Sources tab (no sheet/modal).
+ *
+ * Per design spec Section 5, Flow 1:
+ * - Shows folders (navigable via tap) and Google Docs (selectable via checkbox)
+ * - Files already in project show "Already added" with disabled checkbox
+ * - "Add N Selected" sticky footer: 48pt height, full width
+ * - All touch targets minimum 44pt
+ * - Checkboxes: 44x44pt tap area (visually 24x24px)
+ * - [< Sources] back button for navigation
+ */
+export function InlineDriveBrowser({
+  folders,
+  docs,
+  isLoading,
+  error,
+  canGoBack,
+  selectedIds,
+  existingDriveFileIds,
+  selectableSelectedCount,
+  isAdding,
+  providerEmail,
+  onBack,
+  onOpenFolder,
+  onToggleSelect,
+  onAddSelected,
+  onRefresh,
+}: InlineDriveBrowserProps) {
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center gap-2 h-12 px-4 shrink-0 border-b border-border">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-700
+                     min-h-[44px] px-1 transition-colors"
+          aria-label={canGoBack ? "Back to parent folder" : "Back to sources"}
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          {canGoBack ? "Back" : "Sources"}
+        </button>
+        <span className="text-sm font-semibold text-foreground ml-auto truncate max-w-[180px]">
+          {providerEmail ?? "Google Drive"}
+        </span>
+      </div>
+
+      {/* Content area */}
+      <div className="flex-1 overflow-auto min-h-0">
+        {/* Loading state */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-12">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                />
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                />
+              </svg>
+              Loading...
+            </div>
+          </div>
+        )}
+
+        {/* Error state */}
+        {error && (
+          <div className="px-4 py-3 m-4 bg-red-50 border border-red-200 rounded-lg">
+            <p className="text-sm text-red-700">Could not access Google Drive. Please try again.</p>
+            <button onClick={onRefresh} className="text-xs text-red-600 underline mt-1">
+              Retry
+            </button>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!isLoading && !error && folders.length === 0 && docs.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
+            <p className="text-sm text-muted-foreground">
+              No Google Docs or folders found in this location.
+            </p>
+          </div>
+        )}
+
+        {/* File/folder list */}
+        {!isLoading && !error && (folders.length > 0 || docs.length > 0) && (
+          <ul className="divide-y divide-border" role="list" aria-label="Drive files and folders">
+            {/* Folders */}
+            {folders.map((folder) => (
+              <li key={folder.id}>
+                <button
+                  onClick={() => onOpenFolder(folder.id)}
+                  className="w-full flex items-center gap-3 px-4 py-3 hover:bg-gray-50
+                             transition-colors min-h-[44px] text-left"
+                >
+                  <svg
+                    className="w-5 h-5 text-amber-500 shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
+                    />
+                  </svg>
+                  <span className="text-sm font-medium text-foreground truncate flex-1">
+                    {folder.name}
+                  </span>
+                  <svg
+                    className="w-4 h-4 text-gray-400 shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 5l7 7-7 7"
+                    />
+                  </svg>
+                </button>
+              </li>
+            ))}
+
+            {/* Docs */}
+            {docs.map((doc) => {
+              const isAlreadyAdded = existingDriveFileIds.has(doc.id);
+              const isSelected = selectedIds.has(doc.id);
+
+              return (
+                <li key={doc.id}>
+                  <DriveDocRow
+                    doc={doc}
+                    isAlreadyAdded={isAlreadyAdded}
+                    isSelected={isSelected}
+                    onToggle={() => onToggleSelect(doc.id)}
+                  />
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      {/* Sticky footer: "Add N Selected" */}
+      {docs.length > 0 && (
+        <div
+          className="shrink-0 border-t border-border px-4 flex items-center justify-between"
+          style={{ height: "48px" }}
+        >
+          <span className="text-xs text-muted-foreground">
+            {selectableSelectedCount > 0
+              ? `${selectableSelectedCount} selected`
+              : "Select files to add"}
+          </span>
+          <button
+            onClick={onAddSelected}
+            disabled={selectableSelectedCount === 0 || isAdding}
+            className="h-9 px-4 bg-blue-600 text-white text-sm font-medium rounded-lg
+                       hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isAdding
+              ? "Adding..."
+              : selectableSelectedCount > 0
+                ? `Add ${selectableSelectedCount} Selected`
+                : "Add Selected"}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// === Drive Doc Row ===
+
+interface DriveDocRowProps {
+  doc: DriveBrowseItem;
+  isAlreadyAdded: boolean;
+  isSelected: boolean;
+  onToggle: () => void;
+}
+
+/**
+ * A single Google Doc row in the inline folder browser.
+ *
+ * Checkbox: 44x44pt tap area, visually 24x24px.
+ * "Already added" files show a disabled checkbox with label.
+ */
+export function DriveDocRow({ doc, isAlreadyAdded, isSelected, onToggle }: DriveDocRowProps) {
+  return (
+    <label
+      className={`w-full flex items-center gap-3 px-4 py-3 min-h-[44px] text-left
+        ${isAlreadyAdded ? "opacity-60 cursor-default" : "hover:bg-gray-50 cursor-pointer"}`}
+    >
+      {/* Checkbox: 44x44pt tap area wrapping a 24x24px visual checkbox */}
+      <span className="flex items-center justify-center w-11 h-11 shrink-0">
+        <input
+          type="checkbox"
+          checked={isAlreadyAdded || isSelected}
+          disabled={isAlreadyAdded}
+          onChange={isAlreadyAdded ? undefined : onToggle}
+          className="h-6 w-6 rounded border-gray-300 text-blue-600 focus:ring-blue-500
+                     disabled:opacity-50 disabled:cursor-not-allowed"
+          aria-label={isAlreadyAdded ? `${doc.name} - already added` : `Select ${doc.name}`}
+        />
+      </span>
+
+      {/* Doc icon */}
+      <svg
+        className="w-5 h-5 text-blue-500 shrink-0"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6zM14 3.5L18.5 8H14V3.5zM8 13h8v1.5H8V13zm0 3h8v1.5H8V16zm0-6h3v1.5H8V10z" />
+      </svg>
+
+      {/* Doc info */}
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-foreground truncate">{doc.name}</div>
+        {isAlreadyAdded ? (
+          <div className="text-xs text-muted-foreground">Already added</div>
+        ) : (
+          <div className="text-xs text-muted-foreground">Google Doc</div>
+        )}
+      </div>
+    </label>
+  );
+}

--- a/web/src/components/research/research-panel.tsx
+++ b/web/src/components/research/research-panel.tsx
@@ -209,19 +209,19 @@ function TabContent({
   activeTab,
   onInsertClip,
   canInsert,
-  projectDriveConnectionId,
+  protectedConnectionIds,
 }: {
   activeTab: ResearchTab;
   onInsertClip: (text: string, sourceTitle: string) => InsertResult;
   canInsert: boolean;
-  projectDriveConnectionId?: string | null;
+  protectedConnectionIds?: string[];
 }) {
   // Render all tabs but only show the active one.
   // This preserves state when switching tabs (acceptance criteria).
   return (
     <div className="flex-1 min-h-0 relative">
       <TabPanel id="sources" activeTab={activeTab}>
-        <SourcesTab projectDriveConnectionId={projectDriveConnectionId} />
+        <SourcesTab protectedConnectionIds={protectedConnectionIds} />
       </TabPanel>
       <TabPanel id="ask" activeTab={activeTab}>
         <AskTab />
@@ -261,14 +261,14 @@ function TabPanel({
 export interface ResearchPanelProps {
   onInsertClip?: (text: string, sourceTitle: string) => InsertResult;
   canInsert?: boolean;
-  /** The project's bound Drive connection ID (filters which accounts the source add flow shows). */
-  projectDriveConnectionId?: string | null;
+  /** Connection IDs that cannot be disconnected from within the Sources tab (e.g. backup accounts) */
+  protectedConnectionIds?: string[];
 }
 
 export function ResearchPanel({
   onInsertClip,
   canInsert = false,
-  projectDriveConnectionId,
+  protectedConnectionIds,
 }: ResearchPanelProps) {
   const { isOpen, activeTab, setActiveTab, closePanel, openPanel } = useResearchPanel();
   const params = useParams();
@@ -341,7 +341,7 @@ export function ResearchPanel({
           activeTab={activeTab}
           onInsertClip={handleInsertClip}
           canInsert={canInsert}
-          projectDriveConnectionId={projectDriveConnectionId}
+          protectedConnectionIds={protectedConnectionIds}
         />
       </div>
     );
@@ -372,7 +372,7 @@ export function ResearchPanel({
           activeTab={activeTab}
           onInsertClip={handleInsertClip}
           canInsert={canInsert}
-          projectDriveConnectionId={projectDriveConnectionId}
+          protectedConnectionIds={protectedConnectionIds}
         />
       </div>
     </>

--- a/web/src/components/research/source-provider-detail.tsx
+++ b/web/src/components/research/source-provider-detail.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useState } from "react";
+import type { SourceMaterial } from "@/hooks/use-sources";
+
+interface SourceProviderDetailProps {
+  connectionId: string | null;
+  email: string | null;
+  sources: SourceMaterial[];
+  isProtected: boolean;
+  onViewSource: (sourceId: string) => void;
+  onRemoveSource: (sourceId: string) => void;
+  onAddMore: () => void;
+  onDisconnect: (connectionId: string) => Promise<void>;
+  onBack: () => void;
+}
+
+/**
+ * Provider detail view — documents from a single source provider with management actions.
+ *
+ * Shows:
+ * - Provider header (email, type, connection date)
+ * - List of documents from this provider
+ * - "Add More" action button
+ * - "Disconnect Account" (hidden for protected/backup accounts and device uploads)
+ */
+export function SourceProviderDetail({
+  connectionId,
+  email,
+  sources,
+  isProtected,
+  onViewSource,
+  onRemoveSource,
+  onAddMore,
+  onDisconnect,
+  onBack,
+}: SourceProviderDetailProps) {
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
+
+  const isDeviceProvider = connectionId === null;
+  const providerLabel = isDeviceProvider ? "From This Device" : (email ?? "Google Drive");
+
+  const handleDisconnect = async () => {
+    if (!connectionId) return;
+    setIsDisconnecting(true);
+    try {
+      await onDisconnect(connectionId);
+      onBack();
+    } finally {
+      setIsDisconnecting(false);
+      setShowDisconnectConfirm(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center gap-2 h-12 px-4 shrink-0 border-b border-border">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-700
+                     min-h-[44px] px-1 transition-colors"
+          aria-label="Back to sources"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+          Sources
+        </button>
+      </div>
+
+      {/* Provider info */}
+      <div className="px-4 py-4 border-b border-border">
+        <div className="flex items-center gap-3">
+          {isDeviceProvider ? (
+            <div className="h-10 w-10 flex items-center justify-center rounded-full bg-gray-100 shrink-0">
+              <svg
+                className="w-5 h-5 text-gray-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+                />
+              </svg>
+            </div>
+          ) : (
+            <div className="h-10 w-10 flex items-center justify-center rounded-full bg-blue-50 shrink-0">
+              <svg
+                className="w-5 h-5 text-gray-500"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z" />
+              </svg>
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-foreground truncate">{providerLabel}</p>
+            <p className="text-xs text-muted-foreground">
+              {isDeviceProvider ? "Uploaded files" : "Google Drive"}
+              {isProtected && !isDeviceProvider && (
+                <span className="ml-1.5 text-xs text-amber-600 font-medium">Backup account</span>
+              )}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Document list */}
+      <div className="flex-1 overflow-auto min-h-0">
+        {sources.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
+            <p className="text-sm text-muted-foreground mb-3">No documents from this source yet.</p>
+            <button
+              onClick={onAddMore}
+              className="h-10 px-4 bg-blue-600 text-white text-sm font-medium rounded-lg
+                         hover:bg-blue-700 transition-colors"
+            >
+              {isDeviceProvider ? "Upload File" : "Browse Drive"}
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="px-4 pt-3 pb-1">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                Documents ({sources.length})
+              </p>
+            </div>
+            <ul className="divide-y divide-border" role="list" aria-label="Provider documents">
+              {sources.map((source) => (
+                <ProviderDocRow
+                  key={source.id}
+                  source={source}
+                  onTap={() => onViewSource(source.id)}
+                  onRemove={() => onRemoveSource(source.id)}
+                />
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+
+      {/* Footer actions */}
+      <div className="shrink-0 border-t border-border px-4 py-3 space-y-2">
+        {/* Add More */}
+        {sources.length > 0 && (
+          <button
+            onClick={onAddMore}
+            className="w-full h-10 flex items-center justify-center gap-2 rounded-lg
+                       border border-border text-sm font-medium text-foreground
+                       hover:bg-gray-50 transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            {isDeviceProvider ? "Upload Another File" : "Add More from This Drive"}
+          </button>
+        )}
+
+        {/* Disconnect (only for Drive accounts that are not protected) */}
+        {!isDeviceProvider && !isProtected && connectionId && (
+          <>
+            {showDisconnectConfirm ? (
+              <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
+                <p className="text-sm text-red-700 mb-2">
+                  Disconnect {email}? {sources.length} research document
+                  {sources.length !== 1 ? "s" : ""} from this account will be archived. Your Google
+                  Drive files won&apos;t be affected.
+                </p>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={handleDisconnect}
+                    disabled={isDisconnecting}
+                    className="h-8 px-3 text-sm font-medium text-white bg-red-600 rounded-md
+                               hover:bg-red-700 transition-colors disabled:opacity-50"
+                  >
+                    {isDisconnecting ? "Disconnecting..." : "Disconnect"}
+                  </button>
+                  <button
+                    onClick={() => setShowDisconnectConfirm(false)}
+                    disabled={isDisconnecting}
+                    className="h-8 px-3 text-sm font-medium text-gray-700 rounded-md
+                               hover:bg-gray-100 transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                onClick={() => setShowDisconnectConfirm(true)}
+                className="w-full h-10 flex items-center justify-center text-sm font-medium
+                           text-red-600 rounded-lg hover:bg-red-50 transition-colors"
+              >
+                Disconnect Account
+              </button>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// === Provider Document Row ===
+
+function ProviderDocRow({
+  source,
+  onTap,
+  onRemove,
+}: {
+  source: SourceMaterial;
+  onTap: () => void;
+  onRemove: () => void;
+}) {
+  const isError = source.status === "error";
+  const isArchived = source.status === "archived";
+
+  return (
+    <li className={`min-h-[56px] ${isArchived ? "opacity-60" : ""}`}>
+      <button
+        onClick={isError || isArchived ? undefined : onTap}
+        className={`w-full text-left px-4 py-3 flex items-start gap-3 transition-colors
+          ${isError || isArchived ? "" : "hover:bg-gray-50"}`}
+        disabled={isError || isArchived}
+      >
+        {/* Doc icon */}
+        <div
+          className={`h-9 w-9 flex items-center justify-center rounded-lg shrink-0 ${
+            isError ? "bg-red-50" : isArchived ? "bg-gray-100" : "bg-blue-50"
+          }`}
+        >
+          <svg
+            className={`w-4 h-4 ${isError ? "text-red-400" : isArchived ? "text-gray-400" : "text-blue-500"}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
+          </svg>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-foreground truncate">{source.title}</p>
+          <div className="flex items-center gap-2 mt-0.5">
+            {isError ? (
+              <span className="text-xs text-red-500">Could not extract text</span>
+            ) : isArchived ? (
+              <span className="text-xs text-amber-600">Account disconnected</span>
+            ) : source.cachedAt ? (
+              <span className="text-xs text-muted-foreground tabular-nums">
+                {source.wordCount.toLocaleString()} words
+              </span>
+            ) : (
+              <span className="text-xs text-muted-foreground flex items-center gap-1">
+                <svg
+                  className="animate-spin h-3 w-3"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Processing...
+              </span>
+            )}
+          </div>
+        </div>
+      </button>
+
+      {/* Error/archived actions */}
+      {(isError || isArchived) && (
+        <div className="flex items-center gap-2 px-4 pb-2 ml-12">
+          <button
+            onClick={onRemove}
+            className="h-8 px-2.5 text-xs font-medium text-red-500 rounded-md hover:bg-red-50 transition-colors"
+          >
+            Remove
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}


### PR DESCRIPTION
## Summary

- Separates source management (connecting/disconnecting providers) from content management (browsing/selecting documents)
- Research input is no longer restricted by backup output — all Drive accounts visible in every project
- Grouped source list with provider section headers (iOS Settings/Mail pattern)
- New provider detail view with document list, "Add More", and "Disconnect Account"
- `isBoundProject` guard removed — "Connect another Google account" always available
- `protectedConnectionIds` replaces `projectDriveConnectionId` for cleaner separation

## Changes

| File | Change |
|------|--------|
| `research-panel-provider.tsx` | Added `provider-detail` state, renamed `driveConnectionId` → `activeConnectionId`, new `VIEW_PROVIDER_DETAIL` action |
| `inline-drive-browser.tsx` | **New** — extracted from `source-add-flow.tsx` with `providerEmail` prop |
| `source-provider-detail.tsx` | **New** — provider documents + management actions (disconnect with confirmation) |
| `sources-tab.tsx` | Grouped list with provider headers, view router for 4 states, removed account filtering |
| `source-add-flow.tsx` | Removed `isBoundProject`, added `preSelectedConnectionId` + backup labels, imports extracted browser |
| `research-panel.tsx` | `projectDriveConnectionId` → `protectedConnectionIds` |
| `page.tsx` | Threads `protectedConnectionIds` array |
| `research-panel-provider.test.tsx` | 8 new tests (56 total) |

## Test plan

- [ ] TypeScript clean, lint 0 errors, 861 tests pass
- [ ] iPad Safari: grouped list renders with provider headers and document rows
- [ ] Connect first Google account → provider header appears
- [ ] "+ Add" shows all accounts, "Connect another account" always visible
- [ ] Tap provider header → detail view with docs, "Add More", "Disconnect"
- [ ] "Disconnect" on non-backup account → confirmation dialog, archives sources
- [ ] Backup account → "Disconnect" button hidden
- [ ] Cross-tab citation navigation unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)