### PR TITLE
fix: disable preview deployments to reduce Vercel costs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" != \"main\" ]"
+}


### PR DESCRIPTION
## Summary

- Adds `vercel.json` with `ignoreCommand` that skips builds on all branches except `main`
- Preview deployments (triggered on every push to non-main branches) were the primary cost driver - every agent push triggered a full Vercel build with no one looking at the preview URLs
- Production deployments on merge to `main` are unaffected

## Impact

Should reduce Vercel build minutes significantly. With no external users, preview URLs serve no purpose right now. When beta users need preview URLs for review, we can revisit (e.g., allowlist specific branches like `staging`).

## Test plan

- [ ] Verify this PR itself does NOT trigger a Vercel preview build (it should skip due to the ignoreCommand)
- [ ] Merge to main and confirm production deployment still triggers normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)