### PR TITLE
fix: correct email display, redirect timing, and collapsible sources

### DIFF
--- a/workers/dc-api/src/routes/drive.ts
+++ b/workers/dc-api/src/routes/drive.ts
@@ -159,6 +159,7 @@ driveCallback.get("/callback", async (c) => {
     const redirectUrl = new URL(c.env.FRONTEND_URL);
     redirectUrl.pathname = "/drive/success";
     redirectUrl.searchParams.set("cid", actualConnectionId);
+    redirectUrl.searchParams.set("email", email);
     validateFrontendUrl(redirectUrl, c.env.FRONTEND_URL);
     return c.redirect(redirectUrl.toString());
   } catch (err) {


### PR DESCRIPTION
## Summary

- **Success page shows wrong email**: After OAuth, the success page showed the first Drive connection's email (via `useDriveStatus` → `connections[0].email`) instead of the just-connected account. Now the email is passed as a URL param from the OAuth callback, displaying immediately without an API round-trip race. `useDriveStatus` replaced with `useDriveAccounts`.
- **Auto-redirect fires too early**: The 3-second redirect timer could fire before the source-link POST completed, landing users in the editor without the link created. Now tracks `linkComplete`/`folderId`/`folderError` state and only starts the timer after async flows finish.
- **Collapsible SOURCES section**: The SOURCES section in the research panel is now collapsible with a chevron toggle, connection count in the header, and `localStorage` persistence per project. "+ Link" stays visible when collapsed.

## Test plan

- [ ] OAuth flow with 2+ Drive accounts: success page shows correct email immediately (from URL param, not API)
- [ ] Source-link flow: redirect waits for link API call to complete before navigating
- [ ] Backup folder flow: redirect waits for folder creation before navigating
- [ ] Sources tab: SOURCES section collapses/expands with chevron click
- [ ] Collapse state persists across page navigations (localStorage)
- [ ] "+ Link" and connection count visible in collapsed header
- [ ] `cd workers/dc-api && npx tsc --noEmit` — zero errors
- [ ] `cd workers/dc-api && npm test` — 453 tests pass
- [ ] `cd web && npm run typecheck` — zero errors
- [ ] `cd web && npm run lint` — zero errors
- [ ] `cd web && npm test` — 403 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)