### PR TITLE
feat: Sources tab sanctuary redesign

### DIFF
--- a/web/src/components/toast.tsx
+++ b/web/src/components/toast.tsx
@@ -12,16 +12,23 @@ import {
 
 // === Toast Types ===
 
+interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
 interface Toast {
   id: string;
   message: string;
   /** Auto-dismiss duration in ms. Default: 2500 */
   duration: number;
+  /** Optional action button (e.g. "Undo") */
+  action?: ToastAction;
 }
 
 interface ToastContextValue {
   /** Show a toast notification. Returns the toast id. */
-  showToast: (message: string, duration?: number) => string;
+  showToast: (message: string, duration?: number, action?: ToastAction) => string;
 }
 
 // === Context ===
@@ -44,9 +51,9 @@ export function ToastProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const showToast = useCallback(
-    (message: string, duration = 2500): string => {
+    (message: string, duration = 2500, action?: ToastAction): string => {
       const id = crypto.randomUUID();
-      const toast: Toast = { id, message, duration };
+      const toast: Toast = { id, message, duration, action };
 
       setToasts((prev) => [...prev, toast]);
 
@@ -77,10 +84,21 @@ export function ToastProvider({ children }: { children: ReactNode }) {
             <div
               key={toast.id}
               className="pointer-events-auto px-4 py-2.5 bg-gray-900 text-white text-sm font-medium
-                         rounded-lg shadow-lg toast-fade-in"
+                         rounded-lg shadow-lg toast-fade-in flex items-center gap-3"
               role="status"
             >
               {toast.message}
+              {toast.action && (
+                <button
+                  onClick={() => {
+                    toast.action!.onClick();
+                    removeToast(toast.id);
+                  }}
+                  className="text-blue-300 hover:text-blue-200 font-semibold text-sm underline underline-offset-2 shrink-0"
+                >
+                  {toast.action.label}
+                </button>
+              )}
             </div>
           ))}
         </div>

--- a/web/src/hooks/use-sources.ts
+++ b/web/src/hooks/use-sources.ts
@@ -172,6 +172,26 @@ export function useSources(projectId: string) {
     [getToken],
   );
 
+  const restoreSource = useCallback(
+    async (sourceId: string): Promise<boolean> => {
+      try {
+        setError(null);
+        const token = await getToken();
+        const response = await fetch(`${API_URL}/sources/${sourceId}/restore`, {
+          method: "PATCH",
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!response.ok) throw new Error("Failed to restore source");
+        await fetchSources();
+        return true;
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to restore source");
+        return false;
+      }
+    },
+    [getToken, fetchSources],
+  );
+
   const importAsChapter = useCallback(
     async (sourceId: string): Promise<{ chapterId: string; title: string } | null> => {
       try {
@@ -199,6 +219,7 @@ export function useSources(projectId: string) {
     addSources,
     uploadLocalFile,
     removeSource,
+    restoreSource,
     importAsChapter,
   };
 }

--- a/workers/dc-api/src/routes/sources.ts
+++ b/workers/dc-api/src/routes/sources.ts
@@ -147,6 +147,20 @@ sources.delete("/sources/:sourceId", async (c) => {
 });
 
 /**
+ * PATCH /sources/:sourceId/restore
+ * Restore a previously removed (archived) source. Used for undo-remove.
+ */
+sources.patch("/sources/:sourceId/restore", async (c) => {
+  const { userId } = c.get("auth");
+  const sourceId = c.req.param("sourceId");
+
+  const service = new SourceMaterialService(c.env.DB, c.env.EXPORTS_BUCKET);
+  const source = await service.restoreSource(userId, sourceId);
+
+  return c.json({ source });
+});
+
+/**
  * POST /sources/:sourceId/import-as-chapter
  * Import source content as a new chapter.
  * Creates chapter in D1/R2, then fire-and-forget Drive file creation.


### PR DESCRIPTION
## Summary
- Replaces the confusing two-section (LINKED FOLDERS + DOCUMENTS) layout with a flat document list, pinned FTS5 search bar, and collapsible folders footer
- Adds universal remove action to all documents (three-dot menu + inline confirm + undo toast) — previously only error/archived sources had a Remove button
- Empty-state CTA ("Build Your Library") guides first-use discovery without cluttering the power-user experience
- Fixes `handleImportAsChapter` to use `useSources` hook instead of `window.Clerk` hack
- Backend: adds `PATCH /sources/:sourceId/restore` for undo, deduplicates Drive browse results

## Test plan
- [ ] Zero sources: empty-state CTA shows Link/Browse/Upload actions
- [ ] Search: type 2+ chars, FTS5 results with snippets replace list; clear restores list
- [ ] iPad keyboard: search focus hides [+] button; blur restores it
- [ ] Remove: tap three-dot on active doc, inline confirm, "Yes" removes, toast with "Undo" appears
- [ ] Undo: tap "Undo" in toast, document restored to list
- [ ] Folders footer: hidden when 0 folders; collapsed summary when 1+; expands to show rows + "+ Link a folder"
- [ ] [+] button opens add-documents flow (no folder linking option)
- [ ] Drive browser: no duplicate folders
- [ ] Error/archived sources still show inline "Remove" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)