### PR TITLE
feat: Source Manager & Content Manager split

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 import type { ChapterData } from "@/components/layout/sidebar";
@@ -17,6 +17,7 @@ import {
 } from "@/components/research/research-panel-provider";
 import { ResearchPanel } from "@/components/research/research-panel";
 import { ToastProvider } from "@/components/toast";
+import { SourceManagerSheet } from "@/components/project/source-manager-sheet";
 import { useDriveAccounts } from "@/hooks/use-drive-accounts";
 import { useAutoSave } from "@/hooks/use-auto-save";
 import { useSignOut } from "@/hooks/use-sign-out";
@@ -249,6 +250,20 @@ function EditorPageInner() {
     }
   }, [fetchProjectSources, projectId]);
 
+  // --- Source Manager sheet state ---
+  const [isSourceManagerOpen, setIsSourceManagerOpen] = useState(false);
+
+  const handleOpenSourceManager = useCallback(() => {
+    closeResearchPanel();
+    setIsSourceManagerOpen(true);
+  }, [closeResearchPanel]);
+
+  const handleCloseSourceManager = useCallback(() => {
+    setIsSourceManagerOpen(false);
+    // Refetch sources so Content Manager shows latest data
+    fetchProjectSources();
+  }, [fetchProjectSources]);
+
   // --- Computed values ---
   const totalWordCount = projectData?.chapters.reduce((sum, ch) => sum + ch.wordCount, 0) ?? 0;
 
@@ -353,6 +368,7 @@ function EditorPageInner() {
               }
             }}
             onManageAccounts={() => setIsAccountsSheetOpen(true)}
+            onManageSources={handleOpenSourceManager}
             onRenameBook={openRenameDialog}
             onDuplicateBook={openDuplicateDialog}
             isDuplicating={isDuplicating}
@@ -385,6 +401,7 @@ function EditorPageInner() {
         onInsertClip={insertClip}
         canInsert={canInsert}
         activeChapterTitle={activeChapter?.title}
+        onOpenSourceManager={handleOpenSourceManager}
       />
 
       <EditorDialogs
@@ -429,6 +446,13 @@ function EditorPageInner() {
         // Research panel (minimal props)
         isResearchPanelOpen={isResearchPanelOpen}
         onCloseResearchPanel={closeResearchPanel}
+      />
+
+      {/* Source Manager sheet — management surface for sources */}
+      <SourceManagerSheet
+        isOpen={isSourceManagerOpen}
+        projectId={projectId}
+        onClose={handleCloseSourceManager}
       />
     </div>
   );

--- a/web/src/components/editor/editor-toolbar.tsx
+++ b/web/src/components/editor/editor-toolbar.tsx
@@ -39,6 +39,9 @@ interface EditorToolbarProps {
   // First-use nudge (#185)
   hasAnySources: boolean;
 
+  // Source Manager
+  onManageSources: () => void;
+
   // Settings
   hasDriveFolder: boolean;
   driveFolderId?: string | null;
@@ -78,6 +81,7 @@ export function EditorToolbar({
   isResearchPanelOpen,
   onToggleResearchPanel,
   hasAnySources,
+  onManageSources,
   hasDriveFolder,
   driveFolderId,
   onSetupDrive,
@@ -202,6 +206,7 @@ export function EditorToolbar({
           onSetupDrive={onSetupDrive}
           onUnlinkDrive={onUnlinkDrive}
           onManageAccounts={onManageAccounts}
+          onManageSources={onManageSources}
           onRenameBook={onRenameBook}
           onDuplicateBook={onDuplicateBook}
           isDuplicating={isDuplicating}

--- a/web/src/components/project/settings-menu.tsx
+++ b/web/src/components/project/settings-menu.tsx
@@ -13,6 +13,8 @@ interface SettingsMenuProps {
   onUnlinkDrive?: () => void;
   /** Open Google Accounts management sheet */
   onManageAccounts?: () => void;
+  /** Open Source Manager sheet */
+  onManageSources?: () => void;
   /** Open rename book dialog */
   onRenameBook: () => void;
   /** Open duplicate book dialog */
@@ -42,6 +44,7 @@ export function SettingsMenu({
   onSetupDrive,
   onUnlinkDrive,
   onManageAccounts,
+  onManageSources,
   onRenameBook,
   onDuplicateBook,
   isDuplicating,
@@ -217,6 +220,31 @@ export function SettingsMenu({
                 />
               </svg>
               Google Accounts
+            </button>
+          )}
+
+          {/* Source Manager */}
+          {onManageSources && (
+            <button
+              onClick={() => handleMenuItem(onManageSources)}
+              className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                         transition-colors min-h-[44px] flex items-center gap-2"
+              role="menuitem"
+            >
+              <svg
+                className="w-4 h-4 shrink-0"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+                />
+              </svg>
+              Manage Sources
             </button>
           )}
 

--- a/web/src/components/project/source-manager-sheet.tsx
+++ b/web/src/components/project/source-manager-sheet.tsx
@@ -1,0 +1,690 @@
+"use client";
+
+import { useEffect, useCallback, useMemo, useState } from "react";
+import { useSources, type SourceMaterial } from "@/hooks/use-sources";
+import { useLinkedFolders, type LinkFolderInput } from "@/hooks/use-linked-folders";
+import { useProjectSourceConnections } from "@/hooks/use-project-source-connections";
+import { useToast } from "@/components/toast";
+import { SourceCard } from "@/components/research/source-card";
+import { SourceAddFlow } from "@/components/research/source-add-flow";
+import {
+  getSourceBadge,
+  abbreviateEmail,
+  relativeTime,
+} from "@/components/research/source-helpers";
+
+// === Types ===
+
+type SheetView = "list" | "add-documents" | "link-folder";
+
+interface SourceManagerSheetProps {
+  isOpen: boolean;
+  projectId: string;
+  onClose: () => void;
+}
+
+// === Linked Folder Row ===
+
+function LinkedFolderRow({
+  folder,
+  onUnlink,
+}: {
+  folder: {
+    id: string;
+    folderName: string;
+    email: string;
+    documentCount: number;
+    lastSyncedAt: string | null;
+  };
+  onUnlink: () => void;
+}) {
+  const [confirmUnlink, setConfirmUnlink] = useState(false);
+  const [isUnlinking, setIsUnlinking] = useState(false);
+
+  const handleUnlink = async () => {
+    setIsUnlinking(true);
+    try {
+      onUnlink();
+    } finally {
+      setIsUnlinking(false);
+      setConfirmUnlink(false);
+    }
+  };
+
+  return (
+    <li className="px-4 py-2.5 min-h-[48px]">
+      <div className="flex items-center gap-3">
+        {/* Folder icon */}
+        <div className="h-8 w-8 flex items-center justify-center rounded-lg bg-amber-50 shrink-0">
+          <svg
+            className="w-4 h-4 text-amber-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
+            />
+          </svg>
+        </div>
+
+        {/* Info */}
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-foreground truncate">{folder.folderName}</p>
+          <div className="flex items-center gap-1.5 mt-0.5">
+            <span className="text-xs text-muted-foreground">
+              {folder.documentCount} doc{folder.documentCount !== 1 ? "s" : ""}
+            </span>
+            <span className="text-xs text-gray-300" aria-hidden="true">
+              &middot;
+            </span>
+            <span className="text-xs text-muted-foreground truncate max-w-[100px]">
+              {abbreviateEmail(folder.email, false)}
+            </span>
+            <span className="text-xs text-gray-300" aria-hidden="true">
+              &middot;
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {relativeTime(folder.lastSyncedAt)}
+            </span>
+          </div>
+        </div>
+
+        {/* Unlink button */}
+        {!confirmUnlink && (
+          <button
+            onClick={() => setConfirmUnlink(true)}
+            className="text-xs font-medium text-red-500 hover:text-red-600
+                       min-h-[32px] px-2 flex items-center transition-colors shrink-0"
+          >
+            Unlink
+          </button>
+        )}
+      </div>
+
+      {/* Inline unlink confirmation */}
+      {confirmUnlink && (
+        <div className="flex items-center gap-2 mt-1.5 py-1 px-2 bg-amber-50 rounded ml-11">
+          <span className="text-xs text-amber-700">Unlink folder? Documents will remain.</span>
+          <button
+            onClick={handleUnlink}
+            disabled={isUnlinking}
+            className="text-xs font-medium text-amber-600 hover:text-amber-700
+                       min-h-[32px] flex items-center transition-colors disabled:opacity-50"
+          >
+            {isUnlinking ? "..." : "Yes"}
+          </button>
+          <button
+            onClick={() => setConfirmUnlink(false)}
+            disabled={isUnlinking}
+            className="text-xs font-medium text-gray-600 hover:text-gray-700
+                       min-h-[32px] flex items-center transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </li>
+  );
+}
+
+// === Empty State CTA ===
+
+function EmptyStateCTA({
+  onLinkFolder,
+  onBrowseDrive,
+  onUpload,
+}: {
+  onLinkFolder: () => void;
+  onBrowseDrive: () => void;
+  onUpload: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center px-6 py-8">
+      <div className="text-center mb-6">
+        <h3 className="text-base font-semibold text-foreground mb-1">Build Your Library</h3>
+        <p className="text-sm text-muted-foreground">
+          Add your research documents to search and reference them while writing.
+        </p>
+      </div>
+
+      <div className="w-full max-w-[280px] space-y-2">
+        <button
+          onClick={onLinkFolder}
+          className="w-full flex items-center gap-3 px-4 py-3 rounded-lg border border-border
+                     hover:bg-gray-50 transition-colors text-left min-h-[52px]"
+        >
+          <svg
+            className="w-5 h-5 text-amber-500 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
+            />
+          </svg>
+          <div>
+            <p className="text-sm font-medium text-foreground">Link a Drive Folder</p>
+            <p className="text-xs text-muted-foreground">Auto-sync Google Docs</p>
+          </div>
+        </button>
+
+        <button
+          onClick={onBrowseDrive}
+          className="w-full flex items-center gap-3 px-4 py-3 rounded-lg border border-border
+                     hover:bg-gray-50 transition-colors text-left min-h-[52px]"
+        >
+          <svg
+            className="w-5 h-5 text-blue-500 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          <p className="text-sm font-medium text-foreground">Browse Drive</p>
+        </button>
+
+        <button
+          onClick={onUpload}
+          className="w-full flex items-center gap-3 px-4 py-3 rounded-lg border border-border
+                     hover:bg-gray-50 transition-colors text-left min-h-[52px]"
+        >
+          <svg
+            className="w-5 h-5 text-gray-500 shrink-0"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
+            />
+          </svg>
+          <p className="text-sm font-medium text-foreground">Upload from Device</p>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// === Three-Dot Menu Button ===
+
+function ThreeDotMenuButton({
+  source,
+  onStartRemove,
+}: {
+  source: SourceMaterial;
+  onStartRemove: () => void;
+}) {
+  const isError = source.status === "error";
+  const isArchived = source.status === "archived";
+
+  if (isError || isArchived) return null;
+
+  return (
+    <button
+      onClick={onStartRemove}
+      className="flex items-center justify-center w-11 h-11 shrink-0 mr-1 mt-1.5
+                 text-gray-400 hover:text-gray-600 transition-colors"
+      aria-label={`Options for ${source.title}`}
+    >
+      <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <circle cx="12" cy="5" r="1.5" />
+        <circle cx="12" cy="12" r="1.5" />
+        <circle cx="12" cy="19" r="1.5" />
+      </svg>
+    </button>
+  );
+}
+
+// === Remove Confirmation Row ===
+
+function RemoveConfirmation({
+  source,
+  onRemove,
+}: {
+  source: SourceMaterial;
+  onRemove: () => void;
+}) {
+  const isError = source.status === "error";
+  const isArchived = source.status === "archived";
+
+  // Error/archived sources: inline remove button (no confirmation)
+  if (isError || isArchived) {
+    return (
+      <div className="flex items-center gap-2 px-4 pb-2 ml-12">
+        <button
+          onClick={onRemove}
+          className="h-8 px-2.5 text-xs font-medium text-red-500 rounded-md hover:bg-red-50 transition-colors"
+        >
+          Remove
+        </button>
+      </div>
+    );
+  }
+
+  return null;
+}
+
+// === Source Manager Sheet ===
+
+/**
+ * SourceManagerSheet — Right-slide management surface for source library.
+ *
+ * Set-and-forget management: add, remove, link folders, unlink folders.
+ * Accessed from Settings gear menu → "Manage Sources".
+ * Uses the same slide-over pattern as AccountsSheet.
+ */
+export function SourceManagerSheet({ isOpen, projectId, onClose }: SourceManagerSheetProps) {
+  const { showToast } = useToast();
+
+  // Sheet-local view state — reset by handleClose (not by effect) to avoid lint warning
+  const [view, setView] = useState<SheetView>("list");
+  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
+
+  // Reset state when sheet closes via onClose callback
+  const handleClose = useCallback(() => {
+    setView("list");
+    setConfirmRemoveId(null);
+    onClose();
+  }, [onClose]);
+
+  // --- Hooks ---
+
+  const {
+    sources,
+    isLoading,
+    error,
+    fetchSources,
+    addSources,
+    uploadLocalFile,
+    removeSource,
+    restoreSource,
+  } = useSources(projectId);
+
+  const { connections: projectConnections, isLoading: connectionsLoading } =
+    useProjectSourceConnections(projectId);
+
+  const {
+    linkedFolders,
+    isLoading: foldersLoading,
+    isSyncing,
+    linkFolder,
+    unlinkFolder,
+  } = useLinkedFolders(projectId);
+
+  // Fetch sources when sheet opens
+  useEffect(() => {
+    if (isOpen) {
+      fetchSources();
+    }
+  }, [isOpen, fetchSources]);
+
+  // --- Derived data ---
+
+  const emailByConnectionId = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const conn of projectConnections) {
+      map.set(conn.driveConnectionId, conn.email);
+    }
+    return map;
+  }, [projectConnections]);
+
+  const sortedSources = useMemo(
+    () =>
+      [...sources].sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+      ),
+    [sources],
+  );
+
+  const existingDriveFileIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const source of sources) {
+      if (source.driveFileId) {
+        ids.add(source.driveFileId);
+      }
+    }
+    return ids;
+  }, [sources]);
+
+  const linkedDriveAccounts = useMemo(
+    () =>
+      projectConnections.map((c) => ({
+        id: c.driveConnectionId,
+        email: c.email,
+        connectedAt: c.connectedAt,
+      })),
+    [projectConnections],
+  );
+
+  // --- Handlers ---
+
+  const handleRemoveSource = useCallback(
+    async (sourceId: string) => {
+      setConfirmRemoveId(null);
+      await removeSource(sourceId);
+      showToast("Source removed", 5000, {
+        label: "Undo",
+        onClick: () => {
+          restoreSource(sourceId);
+        },
+      });
+    },
+    [removeSource, restoreSource, showToast],
+  );
+
+  const handleUnlinkFolder = useCallback(
+    async (linkedFolderId: string) => {
+      await unlinkFolder(linkedFolderId);
+    },
+    [unlinkFolder],
+  );
+
+  const handleUploadLocal = useCallback(
+    async (file: File) => {
+      await uploadLocalFile(file);
+      setView("list");
+    },
+    [uploadLocalFile],
+  );
+
+  const handleAddDriveFiles = useCallback(
+    async (
+      files: Array<{ driveFileId: string; title: string; mimeType: string }>,
+      connectionId: string,
+    ) => {
+      const pickerFiles = files.map((f) => ({
+        driveFileId: f.driveFileId,
+        title: f.title,
+        mimeType: f.mimeType,
+      }));
+      const result = await addSources(pickerFiles, connectionId);
+      if (result?.expandedCounts) {
+        const { docsInserted, selectedFolders } = result.expandedCounts;
+        showToast(
+          `Added ${docsInserted} doc${docsInserted !== 1 ? "s" : ""} from ${selectedFolders} folder${selectedFolders !== 1 ? "s" : ""}`,
+        );
+      }
+      setView("list");
+    },
+    [addSources, showToast],
+  );
+
+  const handleLinkFolder = useCallback(
+    async (folderId: string, folderName: string, connectionId: string) => {
+      const input: LinkFolderInput = {
+        driveConnectionId: connectionId,
+        driveFolderId: folderId,
+        folderName,
+      };
+      const result = await linkFolder(input);
+      if (result) {
+        const newDocs = result.sync?.newDocs ?? 0;
+        showToast(`Linked "${folderName}" — ${newDocs} doc${newDocs !== 1 ? "s" : ""} added`);
+        fetchSources();
+      }
+      setView("list");
+    },
+    [linkFolder, showToast, fetchSources],
+  );
+
+  // Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") handleClose();
+    }
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, handleClose]);
+
+  if (!isOpen) return null;
+
+  // --- Add Flow Views ---
+
+  if (view === "add-documents" || view === "link-folder") {
+    return (
+      <>
+        {/* Backdrop */}
+        <div className="fixed inset-0 bg-black/20 z-50" onClick={handleClose} aria-hidden="true" />
+
+        {/* Panel */}
+        <div
+          className="fixed top-0 right-0 h-full w-full max-w-sm bg-white shadow-xl z-50 flex flex-col"
+          role="dialog"
+          aria-label="Source Manager"
+        >
+          <SourceAddFlow
+            mode={view === "link-folder" ? "link-folder" : "add-documents"}
+            driveAccounts={linkedDriveAccounts}
+            existingDriveFileIds={existingDriveFileIds}
+            onBack={() => setView("list")}
+            onAddDriveFiles={handleAddDriveFiles}
+            onUploadLocal={handleUploadLocal}
+            onLinkFolder={handleLinkFolder}
+          />
+        </div>
+      </>
+    );
+  }
+
+  // --- List View ---
+
+  const dataReady = !error && !(isLoading && sources.length === 0);
+  const showEmptyState =
+    dataReady && sources.length === 0 && linkedFolders.length === 0 && !isLoading;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/20 z-50" onClick={handleClose} aria-hidden="true" />
+
+      {/* Panel */}
+      <div
+        className="fixed top-0 right-0 h-full w-full max-w-sm bg-white shadow-xl z-50 flex flex-col"
+        role="dialog"
+        aria-label="Source Manager"
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-4 h-14 border-b border-gray-200 shrink-0">
+          <h2 className="text-lg font-semibold text-gray-900">Source Manager</h2>
+          <button
+            onClick={handleClose}
+            className="w-9 h-9 flex items-center justify-center rounded-lg hover:bg-gray-100 min-h-[44px] min-w-[44px]"
+            aria-label="Close"
+          >
+            <svg
+              className="w-5 h-5 text-gray-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto min-h-0">
+          {/* Loading state */}
+          {(isLoading || connectionsLoading || foldersLoading) && sources.length === 0 && (
+            <div className="flex items-center justify-center py-12">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Loading sources...
+              </div>
+            </div>
+          )}
+
+          {/* Error state */}
+          {error && (
+            <div className="px-4 py-3 m-4 bg-red-50 border border-red-200 rounded-lg">
+              <p className="text-sm text-red-700">{error}</p>
+              <button onClick={fetchSources} className="text-xs text-red-600 underline mt-1">
+                Retry
+              </button>
+            </div>
+          )}
+
+          {/* Empty state CTA */}
+          {showEmptyState && (
+            <EmptyStateCTA
+              onLinkFolder={() => setView("link-folder")}
+              onBrowseDrive={() => setView("add-documents")}
+              onUpload={() => setView("add-documents")}
+            />
+          )}
+
+          {/* Linked folders section */}
+          {dataReady && linkedFolders.length > 0 && (
+            <div className="border-b border-gray-200">
+              <div className="flex items-center gap-2 px-4 py-2.5">
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Linked Folders
+                </span>
+                {isSyncing && (
+                  <span
+                    className="inline-block w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse"
+                    title="Syncing folders..."
+                    aria-label="Syncing folders"
+                  />
+                )}
+              </div>
+              <ul className="divide-y divide-border" role="list" aria-label="Linked folders">
+                {linkedFolders.map((folder) => (
+                  <LinkedFolderRow
+                    key={folder.id}
+                    folder={folder}
+                    onUnlink={() => handleUnlinkFolder(folder.id)}
+                  />
+                ))}
+              </ul>
+              <button
+                onClick={() => setView("link-folder")}
+                className="w-full flex items-center gap-2 px-4 py-2.5 text-left
+                           hover:bg-gray-50 transition-colors min-h-[44px]"
+              >
+                <span className="text-xs font-medium text-blue-600">+ Link a folder</span>
+              </button>
+            </div>
+          )}
+
+          {/* Documents section */}
+          {dataReady && sortedSources.length > 0 && (
+            <div>
+              <div className="px-4 py-2.5">
+                <span className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                  Documents
+                </span>
+              </div>
+              <ul className="divide-y divide-border" role="list" aria-label="Source documents">
+                {sortedSources.map((source) => (
+                  <div key={source.id}>
+                    <SourceCard
+                      source={source}
+                      sourceBadge={getSourceBadge(source, emailByConnectionId)}
+                      onTap={() => {
+                        /* no-op in management view — no detail navigation */
+                      }}
+                      actionSlot={
+                        <ThreeDotMenuButton
+                          source={source}
+                          onStartRemove={() =>
+                            setConfirmRemoveId(confirmRemoveId === source.id ? null : source.id)
+                          }
+                        />
+                      }
+                    />
+                    {/* Inline remove confirmation */}
+                    {confirmRemoveId === source.id &&
+                      source.status !== "error" &&
+                      source.status !== "archived" && (
+                        <div className="flex items-center gap-2 py-1.5 px-4 bg-red-50 ml-4 mr-4 mb-2 rounded">
+                          <span className="text-xs text-red-700">Remove from project?</span>
+                          <button
+                            onClick={() => handleRemoveSource(source.id)}
+                            className="text-xs font-medium text-red-600 hover:text-red-700
+                                       min-h-[32px] flex items-center transition-colors"
+                          >
+                            Yes
+                          </button>
+                          <button
+                            onClick={() => setConfirmRemoveId(null)}
+                            className="text-xs font-medium text-gray-600 hover:text-gray-700
+                                       min-h-[32px] flex items-center transition-colors"
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      )}
+                    {/* Error/archived quick remove */}
+                    <RemoveConfirmation
+                      source={source}
+                      onRemove={() => handleRemoveSource(source.id)}
+                    />
+                  </div>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+
+        {/* Footer: Add Documents button (always visible when not empty) */}
+        {dataReady && !showEmptyState && (
+          <div className="px-4 py-3 border-t border-gray-200 shrink-0">
+            <button
+              onClick={() => setView("add-documents")}
+              className="w-full flex items-center justify-center gap-2 px-4 py-2.5
+                         text-sm font-medium text-blue-600 bg-blue-50 hover:bg-blue-100
+                         rounded-lg transition-colors min-h-[44px]"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+                />
+              </svg>
+              Add Documents
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/research/research-panel.tsx
+++ b/web/src/components/research/research-panel.tsx
@@ -210,11 +210,13 @@ function TabContent({
   onInsertClip,
   canInsert,
   activeChapterTitle,
+  onOpenSourceManager,
 }: {
   activeTab: ResearchTab;
   onInsertClip: (text: string, sourceTitle: string) => InsertResult;
   canInsert: boolean;
   activeChapterTitle?: string;
+  onOpenSourceManager?: () => void;
 }) {
   // Render all tabs but only show the active one.
   // This preserves state when switching tabs (acceptance criteria).
@@ -225,6 +227,7 @@ function TabContent({
           onInsertContent={onInsertClip}
           canInsert={canInsert}
           activeChapterTitle={activeChapterTitle}
+          onOpenSourceManager={onOpenSourceManager}
         />
       </TabPanel>
       <TabPanel id="ask" activeTab={activeTab}>
@@ -266,12 +269,14 @@ export interface ResearchPanelProps {
   onInsertClip?: (text: string, sourceTitle: string) => InsertResult;
   canInsert?: boolean;
   activeChapterTitle?: string;
+  onOpenSourceManager?: () => void;
 }
 
 export function ResearchPanel({
   onInsertClip,
   canInsert = false,
   activeChapterTitle,
+  onOpenSourceManager,
 }: ResearchPanelProps) {
   const { isOpen, activeTab, setActiveTab, closePanel, openPanel } = useResearchPanel();
   const params = useParams();
@@ -345,6 +350,7 @@ export function ResearchPanel({
           onInsertClip={handleInsertClip}
           canInsert={canInsert}
           activeChapterTitle={activeChapterTitle}
+          onOpenSourceManager={onOpenSourceManager}
         />
       </div>
     );
@@ -376,6 +382,7 @@ export function ResearchPanel({
           onInsertClip={handleInsertClip}
           canInsert={canInsert}
           activeChapterTitle={activeChapterTitle}
+          onOpenSourceManager={onOpenSourceManager}
         />
       </div>
     </>

--- a/web/src/components/research/source-card.tsx
+++ b/web/src/components/research/source-card.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import type { ReactNode } from "react";
+import type { SourceMaterial } from "@/hooks/use-sources";
+
+/**
+ * SourceCard — shared between Source Manager (with actionSlot) and Content Manager (bare).
+ *
+ * Displays a source document row with icon, title, word count, and badge.
+ * The optional `actionSlot` prop allows the Source Manager to inject a three-dot
+ * menu without the Content Manager needing to know about management actions.
+ */
+export function SourceCard({
+  source,
+  sourceBadge,
+  onTap,
+  actionSlot,
+}: {
+  source: SourceMaterial;
+  sourceBadge: string;
+  onTap: () => void;
+  actionSlot?: ReactNode;
+}) {
+  const isError = source.status === "error";
+  const isArchived = source.status === "archived";
+
+  return (
+    <li className={`min-h-[56px] ${isArchived ? "opacity-60" : ""}`}>
+      <div className="flex items-start">
+        <button
+          onClick={isError || isArchived ? undefined : onTap}
+          className={`flex-1 text-left px-4 py-3 flex items-start gap-3 transition-colors min-w-0
+            ${isError || isArchived ? "" : "hover:bg-gray-50"}`}
+          disabled={isError || isArchived}
+        >
+          {/* Doc icon */}
+          <div
+            className={`h-9 w-9 flex items-center justify-center rounded-lg shrink-0 ${
+              isError ? "bg-red-50" : isArchived ? "bg-gray-100" : "bg-blue-50"
+            }`}
+          >
+            <svg
+              className={`w-4 h-4 ${isError ? "text-red-400" : isArchived ? "text-gray-400" : "text-blue-500"}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              />
+            </svg>
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-foreground truncate">{source.title}</p>
+            <div className="flex items-center gap-2 mt-0.5">
+              {isError ? (
+                <span className="text-xs text-red-500">Could not extract text</span>
+              ) : isArchived ? (
+                <span className="text-xs text-amber-600">Account disconnected</span>
+              ) : source.cachedAt ? (
+                <>
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    {source.wordCount.toLocaleString()} words
+                  </span>
+                  <span className="text-xs text-gray-300" aria-hidden="true">
+                    &middot;
+                  </span>
+                  <span className="text-xs text-muted-foreground truncate max-w-[120px]">
+                    {sourceBadge}
+                  </span>
+                </>
+              ) : (
+                <span className="text-xs text-muted-foreground truncate max-w-[120px]">
+                  {sourceBadge}
+                </span>
+              )}
+            </div>
+          </div>
+        </button>
+
+        {/* Action slot — Source Manager injects the three-dot menu here */}
+        {actionSlot}
+      </div>
+    </li>
+  );
+}

--- a/web/src/components/research/source-helpers.ts
+++ b/web/src/components/research/source-helpers.ts
@@ -1,0 +1,37 @@
+import type { SourceMaterial } from "@/hooks/use-sources";
+
+/**
+ * Shared helper functions for source badge display, email abbreviation,
+ * and relative time formatting. Used by both Source Manager and Content Manager.
+ */
+
+export function getSourceBadge(
+  source: SourceMaterial,
+  emailByConnectionId: Map<string, string>,
+): string {
+  if (source.sourceType === "local") return "Device";
+  if (!source.driveConnectionId) return "Account disconnected";
+  const email = emailByConnectionId.get(source.driveConnectionId);
+  if (!email) return "Account disconnected";
+  const singleAccount = emailByConnectionId.size <= 1;
+  return abbreviateEmail(email, singleAccount);
+}
+
+export function abbreviateEmail(email: string, singleAccount: boolean): string {
+  if (singleAccount) return "Drive";
+  const [local] = email.split("@");
+  if (!local) return email;
+  return local.length > 14 ? local.slice(0, 12) + "..." : local;
+}
+
+export function relativeTime(dateStr: string | null): string {
+  if (!dateStr) return "Never synced";
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes} min ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/web/src/components/research/sources-tab.tsx
+++ b/web/src/components/research/sources-tab.tsx
@@ -1,183 +1,16 @@
 "use client";
 
-import { useEffect, useCallback, useMemo, useState, useRef } from "react";
+import { useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams } from "next/navigation";
 import { useResearchPanel } from "./research-panel-provider";
-import { SourceAddFlow } from "./source-add-flow";
 import { SourceDetailView } from "./source-detail-view";
+import { SourceCard } from "./source-card";
+import { getSourceBadge } from "./source-helpers";
 import { useSources, type SourceMaterial } from "@/hooks/use-sources";
 import { useSourceSearch, type SourceSearchResult } from "@/hooks/use-source-search";
 import { useToast } from "@/components/toast";
-import { useLinkedFolders, type LinkFolderInput } from "@/hooks/use-linked-folders";
 import { useProjectSourceConnections } from "@/hooks/use-project-source-connections";
 import type { InsertResult } from "@/hooks/use-clip-insert";
-
-// === Source Badge Helpers ===
-
-function getSourceBadge(source: SourceMaterial, emailByConnectionId: Map<string, string>): string {
-  if (source.sourceType === "local") return "Device";
-  if (!source.driveConnectionId) return "Account disconnected";
-  const email = emailByConnectionId.get(source.driveConnectionId);
-  if (!email) return "Account disconnected";
-  const singleAccount = emailByConnectionId.size <= 1;
-  return abbreviateEmail(email, singleAccount);
-}
-
-function abbreviateEmail(email: string, singleAccount: boolean): string {
-  if (singleAccount) return "Drive";
-  const [local] = email.split("@");
-  if (!local) return email;
-  return local.length > 14 ? local.slice(0, 12) + "..." : local;
-}
-
-// === Relative time helper ===
-
-function relativeTime(dateStr: string | null): string {
-  if (!dateStr) return "Never synced";
-  const diff = Date.now() - new Date(dateStr).getTime();
-  const minutes = Math.floor(diff / 60000);
-  if (minutes < 1) return "Just now";
-  if (minutes < 60) return `${minutes} min ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
-}
-
-// === Source Card ===
-
-function SourceCard({
-  source,
-  sourceBadge,
-  onTap,
-  onRemove,
-  confirmingRemove,
-  onStartRemove,
-  onCancelRemove,
-}: {
-  source: SourceMaterial;
-  sourceBadge: string;
-  onTap: () => void;
-  onRemove: () => void;
-  confirmingRemove: boolean;
-  onStartRemove: () => void;
-  onCancelRemove: () => void;
-}) {
-  const isError = source.status === "error";
-  const isArchived = source.status === "archived";
-
-  return (
-    <li className={`min-h-[56px] ${isArchived ? "opacity-60" : ""}`}>
-      <div className="flex items-start">
-        <button
-          onClick={isError || isArchived ? undefined : onTap}
-          className={`flex-1 text-left px-4 py-3 flex items-start gap-3 transition-colors min-w-0
-            ${isError || isArchived ? "" : "hover:bg-gray-50"}`}
-          disabled={isError || isArchived}
-        >
-          {/* Doc icon */}
-          <div
-            className={`h-9 w-9 flex items-center justify-center rounded-lg shrink-0 ${
-              isError ? "bg-red-50" : isArchived ? "bg-gray-100" : "bg-blue-50"
-            }`}
-          >
-            <svg
-              className={`w-4 h-4 ${isError ? "text-red-400" : isArchived ? "text-gray-400" : "text-blue-500"}`}
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-              />
-            </svg>
-          </div>
-
-          {/* Content */}
-          <div className="flex-1 min-w-0">
-            <p className="text-sm font-medium text-foreground truncate">{source.title}</p>
-            <div className="flex items-center gap-2 mt-0.5">
-              {isError ? (
-                <span className="text-xs text-red-500">Could not extract text</span>
-              ) : isArchived ? (
-                <span className="text-xs text-amber-600">Account disconnected</span>
-              ) : source.cachedAt ? (
-                <>
-                  <span className="text-xs text-muted-foreground tabular-nums">
-                    {source.wordCount.toLocaleString()} words
-                  </span>
-                  <span className="text-xs text-gray-300" aria-hidden="true">
-                    &middot;
-                  </span>
-                  <span className="text-xs text-muted-foreground truncate max-w-[120px]">
-                    {sourceBadge}
-                  </span>
-                </>
-              ) : (
-                <span className="text-xs text-muted-foreground truncate max-w-[120px]">
-                  {sourceBadge}
-                </span>
-              )}
-            </div>
-          </div>
-        </button>
-
-        {/* Three-dot menu for active documents */}
-        {!isError && !isArchived && (
-          <button
-            onClick={onStartRemove}
-            className="flex items-center justify-center w-11 h-11 shrink-0 mr-1 mt-1.5
-                       text-gray-400 hover:text-gray-600 transition-colors"
-            aria-label={`Options for ${source.title}`}
-          >
-            <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-              <circle cx="12" cy="5" r="1.5" />
-              <circle cx="12" cy="12" r="1.5" />
-              <circle cx="12" cy="19" r="1.5" />
-            </svg>
-          </button>
-        )}
-      </div>
-
-      {/* Inline remove confirmation for active documents */}
-      {confirmingRemove && !isError && !isArchived && (
-        <div className="flex items-center gap-2 py-1.5 px-4 bg-red-50 ml-4 mr-4 mb-2 rounded">
-          <span className="text-xs text-red-700">Remove from project?</span>
-          <button
-            onClick={onRemove}
-            className="text-xs font-medium text-red-600 hover:text-red-700
-                       min-h-[32px] flex items-center transition-colors"
-          >
-            Yes
-          </button>
-          <button
-            onClick={onCancelRemove}
-            className="text-xs font-medium text-gray-600 hover:text-gray-700
-                       min-h-[32px] flex items-center transition-colors"
-          >
-            Cancel
-          </button>
-        </div>
-      )}
-
-      {/* Error/archived sources: inline remove button (no menu needed) */}
-      {(isError || isArchived) && (
-        <div className="flex items-center gap-2 px-4 pb-2 ml-12">
-          <button
-            onClick={onRemove}
-            className="h-8 px-2.5 text-xs font-medium text-red-500 rounded-md hover:bg-red-50 transition-colors"
-          >
-            Remove
-          </button>
-        </div>
-      )}
-    </li>
-  );
-}
 
 // === Search Result Row ===
 
@@ -218,341 +51,76 @@ function SearchResultRow({ result, onTap }: { result: SourceSearchResult; onTap:
   );
 }
 
-// === Linked Folder Row ===
+// === Content-Only Empty State ===
 
-function LinkedFolderRow({
-  folder,
-  onUnlink,
-}: {
-  folder: {
-    id: string;
-    folderName: string;
-    email: string;
-    documentCount: number;
-    lastSyncedAt: string | null;
-  };
-  onUnlink: () => void;
-}) {
-  const [confirmUnlink, setConfirmUnlink] = useState(false);
-  const [isUnlinking, setIsUnlinking] = useState(false);
-
-  const handleUnlink = async () => {
-    setIsUnlinking(true);
-    try {
-      onUnlink();
-    } finally {
-      setIsUnlinking(false);
-      setConfirmUnlink(false);
-    }
-  };
-
-  return (
-    <li className="px-4 py-2.5 min-h-[48px]">
-      <div className="flex items-center gap-3">
-        {/* Folder icon */}
-        <div className="h-8 w-8 flex items-center justify-center rounded-lg bg-amber-50 shrink-0">
-          <svg
-            className="w-4 h-4 text-amber-500"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
-            />
-          </svg>
-        </div>
-
-        {/* Info */}
-        <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium text-foreground truncate">{folder.folderName}</p>
-          <div className="flex items-center gap-1.5 mt-0.5">
-            <span className="text-xs text-muted-foreground">
-              {folder.documentCount} doc{folder.documentCount !== 1 ? "s" : ""}
-            </span>
-            <span className="text-xs text-gray-300" aria-hidden="true">
-              &middot;
-            </span>
-            <span className="text-xs text-muted-foreground truncate max-w-[100px]">
-              {abbreviateEmail(folder.email, false)}
-            </span>
-            <span className="text-xs text-gray-300" aria-hidden="true">
-              &middot;
-            </span>
-            <span className="text-xs text-muted-foreground">
-              {relativeTime(folder.lastSyncedAt)}
-            </span>
-          </div>
-        </div>
-
-        {/* Unlink button */}
-        {!confirmUnlink && (
-          <button
-            onClick={() => setConfirmUnlink(true)}
-            className="text-xs font-medium text-red-500 hover:text-red-600
-                       min-h-[32px] px-2 flex items-center transition-colors shrink-0"
-          >
-            Unlink
-          </button>
-        )}
-      </div>
-
-      {/* Inline unlink confirmation */}
-      {confirmUnlink && (
-        <div className="flex items-center gap-2 mt-1.5 py-1 px-2 bg-amber-50 rounded ml-11">
-          <span className="text-xs text-amber-700">Unlink folder? Documents will remain.</span>
-          <button
-            onClick={handleUnlink}
-            disabled={isUnlinking}
-            className="text-xs font-medium text-amber-600 hover:text-amber-700
-                       min-h-[32px] flex items-center transition-colors disabled:opacity-50"
-          >
-            {isUnlinking ? "..." : "Yes"}
-          </button>
-          <button
-            onClick={() => setConfirmUnlink(false)}
-            disabled={isUnlinking}
-            className="text-xs font-medium text-gray-600 hover:text-gray-700
-                       min-h-[32px] flex items-center transition-colors"
-          >
-            Cancel
-          </button>
-        </div>
-      )}
-    </li>
-  );
-}
-
-// === Empty State CTA ===
-
-function EmptyStateCTA({
-  onLinkFolder,
-  onBrowseDrive,
-  onUpload,
-}: {
-  onLinkFolder: () => void;
-  onBrowseDrive: () => void;
-  onUpload: () => void;
-}) {
+function ContentEmptyState({ onOpenSourceManager }: { onOpenSourceManager: () => void }) {
   return (
     <div className="flex flex-col items-center px-6 py-8">
       <div className="text-center mb-6">
-        <h3 className="text-base font-semibold text-foreground mb-1">Build Your Library</h3>
+        <h3 className="text-base font-semibold text-foreground mb-1">No sources yet</h3>
         <p className="text-sm text-muted-foreground">
-          Add your research documents to search and reference them while writing.
+          Add research documents to search and reference them while writing.
         </p>
       </div>
 
-      <div className="w-full max-w-[280px] space-y-2">
-        <button
-          onClick={onLinkFolder}
-          className="w-full flex items-center gap-3 px-4 py-3 rounded-lg border border-border
-                     hover:bg-gray-50 transition-colors text-left min-h-[52px]"
-        >
-          <svg
-            className="w-5 h-5 text-amber-500 shrink-0"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M3 7a2 2 0 012-2h5l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
-            />
-          </svg>
-          <div>
-            <p className="text-sm font-medium text-foreground">Link a Drive Folder</p>
-            <p className="text-xs text-muted-foreground">Auto-sync Google Docs</p>
-          </div>
-        </button>
-
-        <button
-          onClick={onBrowseDrive}
-          className="w-full flex items-center gap-3 px-4 py-3 rounded-lg border border-border
-                     hover:bg-gray-50 transition-colors text-left min-h-[52px]"
-        >
-          <svg
-            className="w-5 h-5 text-blue-500 shrink-0"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          <p className="text-sm font-medium text-foreground">Browse Drive</p>
-        </button>
-
-        <button
-          onClick={onUpload}
-          className="w-full flex items-center gap-3 px-4 py-3 rounded-lg border border-border
-                     hover:bg-gray-50 transition-colors text-left min-h-[52px]"
-        >
-          <svg
-            className="w-5 h-5 text-gray-500 shrink-0"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"
-            />
-          </svg>
-          <p className="text-sm font-medium text-foreground">Upload from Device</p>
-        </button>
-      </div>
-    </div>
-  );
-}
-
-// === Collapsible Folders Footer ===
-
-function FoldersFooter({
-  linkedFolders,
-  isSyncing,
-  onUnlink,
-  onLinkFolder,
-}: {
-  linkedFolders: Array<{
-    id: string;
-    folderName: string;
-    email: string;
-    documentCount: number;
-    lastSyncedAt: string | null;
-  }>;
-  isSyncing: boolean;
-  onUnlink: (folderId: string) => void;
-  onLinkFolder: () => void;
-}) {
-  const [expanded, setExpanded] = useState(false);
-
-  if (linkedFolders.length === 0) return null;
-
-  // Find the most recent sync time across all folders
-  const mostRecentSync = linkedFolders.reduce<string | null>((latest, f) => {
-    if (!f.lastSyncedAt) return latest;
-    if (!latest) return f.lastSyncedAt;
-    return f.lastSyncedAt > latest ? f.lastSyncedAt : latest;
-  }, null);
-
-  return (
-    <div className="border-t border-border mt-auto">
       <button
-        onClick={() => setExpanded(!expanded)}
-        className="w-full flex items-center gap-2 px-4 py-2.5 text-left hover:bg-gray-50 transition-colors min-h-[44px]"
-        aria-expanded={expanded}
+        onClick={onOpenSourceManager}
+        className="flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-blue-600
+                   bg-blue-50 hover:bg-blue-100 rounded-lg transition-colors min-h-[44px]"
       >
-        {isSyncing && (
-          <span
-            className="inline-block w-1.5 h-1.5 rounded-full bg-blue-500 animate-pulse shrink-0"
-            title="Syncing folders..."
-            aria-label="Syncing folders"
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 6v6m0 0v6m0-6h6m-6 0H6"
           />
-        )}
-        <span className="text-xs text-muted-foreground flex-1">
-          {linkedFolders.length} folder{linkedFolders.length !== 1 ? "s" : ""}
-          {mostRecentSync && <> &middot; Synced {relativeTime(mostRecentSync)}</>}
-        </span>
-        <svg
-          className={`w-3.5 h-3.5 text-gray-400 shrink-0 transition-transform ${expanded ? "rotate-180" : ""}`}
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
         </svg>
+        Add Sources
       </button>
-
-      {expanded && (
-        <div className="border-t border-border">
-          <ul className="divide-y divide-border" role="list" aria-label="Linked folders">
-            {linkedFolders.map((folder) => (
-              <LinkedFolderRow
-                key={folder.id}
-                folder={folder}
-                onUnlink={() => onUnlink(folder.id)}
-              />
-            ))}
-          </ul>
-          <button
-            onClick={onLinkFolder}
-            className="w-full flex items-center gap-2 px-4 py-2.5 text-left
-                       hover:bg-gray-50 transition-colors min-h-[44px] border-t border-border"
-          >
-            <span className="text-xs font-medium text-blue-600">+ Link a folder</span>
-          </button>
-        </div>
-      )}
     </div>
   );
 }
 
-// === Sources Tab ===
+// === Sources Tab (Content Manager) ===
 
 export interface SourcesTabProps {
   onInsertContent?: (text: string, sourceTitle: string) => InsertResult;
   canInsert?: boolean;
   activeChapterTitle?: string;
+  onOpenSourceManager?: () => void;
 }
 
+/**
+ * SourcesTab — Content-only surface for the Research panel.
+ *
+ * Search, browse, read, clip, and insert sources. No management actions.
+ * Management (add, remove, link folders) lives in the Source Manager sheet.
+ */
 export function SourcesTab({
   onInsertContent,
   canInsert = false,
   activeChapterTitle,
+  onOpenSourceManager,
 }: SourcesTabProps) {
   const params = useParams();
   const projectId = params.projectId as string;
   const {
     sourcesView,
     activeSourceId,
-    activeConnectionId,
-    addMode,
     returnTab,
     scrollToText,
-    startAddDocument,
-    startLinkFolder,
     viewSource,
     backToSourceList,
     returnToPreviousTab,
-    finishFlow,
   } = useResearchPanel();
 
   const { showToast } = useToast();
 
-  const {
-    sources,
-    isLoading,
-    error,
-    fetchSources,
-    addSources,
-    uploadLocalFile,
-    removeSource,
-    restoreSource,
-    importAsChapter,
-  } = useSources(projectId);
+  const { sources, isLoading, error, fetchSources, importAsChapter } = useSources(projectId);
 
   const { connections: projectConnections, isLoading: connectionsLoading } =
     useProjectSourceConnections(projectId);
-
-  const {
-    linkedFolders,
-    isLoading: foldersLoading,
-    isSyncing,
-    linkFolder,
-    unlinkFolder,
-  } = useLinkedFolders(projectId);
 
   // Search
   const {
@@ -564,13 +132,9 @@ export function SourcesTab({
     clearSearch,
   } = useSourceSearch(projectId);
 
-  const [searchFocused, setSearchFocused] = useState(false);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
-  // Remove confirmation state — one at a time via shared state
-  const [confirmRemoveId, setConfirmRemoveId] = useState<string | null>(null);
-
-  // Derive active source from sources list and activeSourceId (no state needed)
+  // Derive active source from sources list and activeSourceId
   const activeSource = useMemo<SourceMaterial | null>(() => {
     if (!activeSourceId || sources.length === 0) return null;
     return sources.find((s) => s.id === activeSourceId) ?? null;
@@ -581,18 +145,7 @@ export function SourcesTab({
     fetchSources();
   }, [fetchSources]);
 
-  // Build a set of Drive file IDs already in the project for "Already added" detection
-  const existingDriveFileIds = useMemo(() => {
-    const ids = new Set<string>();
-    for (const source of sources) {
-      if (source.driveFileId) {
-        ids.add(source.driveFileId);
-      }
-    }
-    return ids;
-  }, [sources]);
-
-  // Email lookup for source badges — from project connections only
+  // Email lookup for source badges
   const emailByConnectionId = useMemo(() => {
     const map = new Map<string, string>();
     for (const conn of projectConnections) {
@@ -601,79 +154,13 @@ export function SourcesTab({
     return map;
   }, [projectConnections]);
 
-  // Intentional client-side recency sort — overrides API's sort_order ASC
+  // Client-side recency sort
   const sortedSources = useMemo(
     () =>
       [...sources].sort(
         (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
       ),
     [sources],
-  );
-
-  // Drive accounts for add flow — only project-linked accounts
-  const linkedDriveAccounts = useMemo(
-    () =>
-      projectConnections.map((c) => ({
-        id: c.driveConnectionId,
-        email: c.email,
-        connectedAt: c.connectedAt,
-      })),
-    [projectConnections],
-  );
-
-  const handleUploadLocal = useCallback(
-    async (file: File) => {
-      await uploadLocalFile(file);
-      finishFlow();
-    },
-    [uploadLocalFile, finishFlow],
-  );
-
-  const handleAddDriveFiles = useCallback(
-    async (
-      files: Array<{ driveFileId: string; title: string; mimeType: string }>,
-      connectionId: string,
-    ) => {
-      const pickerFiles = files.map((f) => ({
-        driveFileId: f.driveFileId,
-        title: f.title,
-        mimeType: f.mimeType,
-      }));
-      const result = await addSources(pickerFiles, connectionId);
-      if (result?.expandedCounts) {
-        const { docsInserted, selectedFolders } = result.expandedCounts;
-        showToast(
-          `Added ${docsInserted} doc${docsInserted !== 1 ? "s" : ""} from ${selectedFolders} folder${selectedFolders !== 1 ? "s" : ""}`,
-        );
-      }
-      finishFlow();
-    },
-    [addSources, finishFlow, showToast],
-  );
-
-  const handleLinkFolder = useCallback(
-    async (folderId: string, folderName: string, connectionId: string) => {
-      const input: LinkFolderInput = {
-        driveConnectionId: connectionId,
-        driveFolderId: folderId,
-        folderName,
-      };
-      const result = await linkFolder(input);
-      if (result) {
-        const newDocs = result.sync?.newDocs ?? 0;
-        showToast(`Linked "${folderName}" — ${newDocs} doc${newDocs !== 1 ? "s" : ""} added`);
-        fetchSources();
-      }
-      finishFlow();
-    },
-    [linkFolder, finishFlow, showToast, fetchSources],
-  );
-
-  const handleUnlinkFolder = useCallback(
-    async (linkedFolderId: string) => {
-      await unlinkFolder(linkedFolderId);
-    },
-    [unlinkFolder],
   );
 
   const handleInsertIntoChapter = useCallback(
@@ -700,21 +187,7 @@ export function SourcesTab({
     [importAsChapter, showToast],
   );
 
-  const handleRemoveSource = useCallback(
-    async (sourceId: string) => {
-      setConfirmRemoveId(null);
-      await removeSource(sourceId);
-      showToast("Source removed", 5000, {
-        label: "Undo",
-        onClick: () => {
-          restoreSource(sourceId);
-        },
-      });
-    },
-    [removeSource, restoreSource, showToast],
-  );
-
-  // Compute back label for source detail view based on returnTab
+  // Back navigation from detail view
   const handleDetailBack = useCallback(() => {
     if (returnTab) {
       returnToPreviousTab();
@@ -727,21 +200,6 @@ export function SourcesTab({
     returnTab === "ask" ? "Back to Ask" : returnTab === "clips" ? "Back to Clips" : "Sources";
 
   // --- View Router ---
-
-  if (sourcesView === "add-document") {
-    return (
-      <SourceAddFlow
-        mode={addMode === "link-folder" ? "link-folder" : "add-documents"}
-        driveAccounts={linkedDriveAccounts}
-        existingDriveFileIds={existingDriveFileIds}
-        preSelectedConnectionId={activeConnectionId}
-        onBack={backToSourceList}
-        onAddDriveFiles={handleAddDriveFiles}
-        onUploadLocal={handleUploadLocal}
-        onLinkFolder={handleLinkFolder}
-      />
-    );
-  }
 
   if (sourcesView === "detail" && activeSourceId) {
     return (
@@ -767,7 +225,7 @@ export function SourcesTab({
 
   return (
     <div className="flex flex-col h-full">
-      {/* Search header — always visible when sources exist or loading is done */}
+      {/* Search header — visible when sources exist */}
       {dataReady && !showEmptyState && (
         <div className="shrink-0 border-b border-border px-3 py-2 flex items-center gap-2">
           <div className="flex-1 relative">
@@ -816,8 +274,6 @@ export function SourcesTab({
               role="searchbox"
               value={searchQuery}
               onChange={(e) => handleQueryChange(e.target.value)}
-              onFocus={() => setSearchFocused(true)}
-              onBlur={() => setSearchFocused(false)}
               placeholder="Search sources..."
               className="w-full h-8 pl-8 pr-2 text-sm bg-gray-100 rounded-md border-0
                          placeholder:text-muted-foreground/60 focus:outline-none focus:ring-1 focus:ring-blue-500"
@@ -842,32 +298,13 @@ export function SourcesTab({
               </button>
             )}
           </div>
-
-          {/* [+] button — hidden when search is focused (iPad keyboard) */}
-          {!searchFocused && (
-            <button
-              onClick={() => startAddDocument()}
-              className="h-8 w-8 flex items-center justify-center rounded-md bg-blue-600 text-white
-                         hover:bg-blue-700 transition-colors shrink-0"
-              aria-label="Add document"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 4v16m8-8H4"
-                />
-              </svg>
-            </button>
-          )}
         </div>
       )}
 
       {/* Scrollable content */}
       <div className="flex-1 overflow-auto min-h-0 flex flex-col">
         {/* Loading state */}
-        {(isLoading || connectionsLoading || foldersLoading) && sources.length === 0 && (
+        {(isLoading || connectionsLoading) && sources.length === 0 && (
           <div className="flex items-center justify-center py-12">
             <div className="flex items-center gap-2 text-sm text-muted-foreground">
               <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
@@ -900,13 +337,9 @@ export function SourcesTab({
           </div>
         )}
 
-        {/* Empty state CTA */}
-        {showEmptyState && (
-          <EmptyStateCTA
-            onLinkFolder={() => startLinkFolder()}
-            onBrowseDrive={() => startAddDocument()}
-            onUpload={() => startAddDocument()}
-          />
+        {/* Empty state — doorway to Source Manager */}
+        {showEmptyState && onOpenSourceManager && (
+          <ContentEmptyState onOpenSourceManager={onOpenSourceManager} />
         )}
 
         {/* Search results */}
@@ -942,25 +375,9 @@ export function SourcesTab({
                 source={source}
                 sourceBadge={getSourceBadge(source, emailByConnectionId)}
                 onTap={() => viewSource(source.id)}
-                onRemove={() => handleRemoveSource(source.id)}
-                confirmingRemove={confirmRemoveId === source.id}
-                onStartRemove={() =>
-                  setConfirmRemoveId(confirmRemoveId === source.id ? null : source.id)
-                }
-                onCancelRemove={() => setConfirmRemoveId(null)}
               />
             ))}
           </ul>
-        )}
-
-        {/* Collapsible folders footer — pushed to bottom */}
-        {dataReady && !searchIsActive && !showEmptyState && (
-          <FoldersFooter
-            linkedFolders={linkedFolders}
-            isSyncing={isSyncing}
-            onUnlink={handleUnlinkFolder}
-            onLinkFolder={() => startLinkFolder()}
-          />
         )}
       </div>
     </div>

--- a/web/test/components/editor-toolbar.test.tsx
+++ b/web/test/components/editor-toolbar.test.tsx
@@ -80,6 +80,7 @@ function makeProps(overrides?: Partial<React.ComponentProps<typeof EditorToolbar
     isResearchPanelOpen: false,
     onToggleResearchPanel: vi.fn(),
     hasAnySources: false,
+    onManageSources: vi.fn(),
     hasDriveFolder: false,
     onViewSources: vi.fn(),
     onManageAccounts: vi.fn(),

--- a/web/test/components/research-panel-provider.test.tsx
+++ b/web/test/components/research-panel-provider.test.tsx
@@ -19,10 +19,8 @@ describe("researchPanelReducer", () => {
     activeTab: "sources",
     sourcesView: "list",
     activeSourceId: null,
-    activeConnectionId: null,
     returnTab: null,
     scrollToText: null,
-    addMode: null,
   };
 
   const sourcesListState: ResearchPanelState = {
@@ -30,10 +28,8 @@ describe("researchPanelReducer", () => {
     activeTab: "sources",
     sourcesView: "list",
     activeSourceId: null,
-    activeConnectionId: null,
     returnTab: null,
     scrollToText: null,
-    addMode: null,
   };
 
   const sourcesDetailState: ResearchPanelState = {
@@ -41,21 +37,8 @@ describe("researchPanelReducer", () => {
     activeTab: "sources",
     sourcesView: "detail",
     activeSourceId: "src-1",
-    activeConnectionId: null,
     returnTab: null,
     scrollToText: null,
-    addMode: null,
-  };
-
-  const addDocumentState: ResearchPanelState = {
-    isOpen: true,
-    activeTab: "sources",
-    sourcesView: "add-document",
-    activeSourceId: null,
-    activeConnectionId: null,
-    returnTab: null,
-    scrollToText: null,
-    addMode: "add-documents",
   };
 
   const askState: ResearchPanelState = {
@@ -63,10 +46,8 @@ describe("researchPanelReducer", () => {
     activeTab: "ask",
     sourcesView: "list",
     activeSourceId: null,
-    activeConnectionId: null,
     returnTab: null,
     scrollToText: null,
-    addMode: null,
   };
 
   const clipsState: ResearchPanelState = {
@@ -74,10 +55,8 @@ describe("researchPanelReducer", () => {
     activeTab: "clips",
     sourcesView: "list",
     activeSourceId: null,
-    activeConnectionId: null,
     returnTab: null,
     scrollToText: null,
-    addMode: null,
   };
 
   // --- OPEN_PANEL ---
@@ -287,18 +266,6 @@ describe("researchPanelReducer", () => {
       expect(result.scrollToText).toBeNull();
     });
 
-    it("returns to list from add-document view", () => {
-      const addWithConnection: ResearchPanelState = {
-        ...addDocumentState,
-        activeConnectionId: "conn-1",
-      };
-      const result = researchPanelReducer(addWithConnection, {
-        type: "BACK_TO_LIST",
-      });
-      expect(result.sourcesView).toBe("list");
-      expect(result.activeConnectionId).toBeNull();
-    });
-
     it("is a no-op when already on list view", () => {
       const result = researchPanelReducer(sourcesListState, {
         type: "BACK_TO_LIST",
@@ -366,134 +333,23 @@ describe("researchPanelReducer", () => {
     });
   });
 
-  // --- START_ADD_DOCUMENT ---
-
-  describe("START_ADD_DOCUMENT", () => {
-    it("enters add-document flow from sources list", () => {
-      const result = researchPanelReducer(sourcesListState, {
-        type: "START_ADD_DOCUMENT",
-      });
-      expect(result.activeTab).toBe("sources");
-      expect(result.sourcesView).toBe("add-document");
-      expect(result.activeSourceId).toBeNull();
-    });
-
-    it("enters add-document flow from ask tab (switches to sources)", () => {
-      const result = researchPanelReducer(askState, {
-        type: "START_ADD_DOCUMENT",
-      });
-      expect(result.activeTab).toBe("sources");
-      expect(result.sourcesView).toBe("add-document");
-    });
-
-    it("stores connectionId when provided (from source row tap)", () => {
-      const result = researchPanelReducer(sourcesListState, {
-        type: "START_ADD_DOCUMENT",
-        connectionId: "conn-42",
-      });
-      expect(result.sourcesView).toBe("add-document");
-      expect(result.activeConnectionId).toBe("conn-42");
-    });
-
-    it("sets activeConnectionId to null when no connectionId provided", () => {
-      const result = researchPanelReducer(sourcesListState, {
-        type: "START_ADD_DOCUMENT",
-      });
-      expect(result.sourcesView).toBe("add-document");
-      expect(result.activeConnectionId).toBeNull();
-    });
-
-    it("is a no-op when panel is closed", () => {
-      const result = researchPanelReducer(closedState, {
-        type: "START_ADD_DOCUMENT",
-      });
-      expect(result).toEqual(closedState);
-    });
-  });
-
-  // --- SET_DRIVE_CONNECTION ---
-
-  describe("SET_DRIVE_CONNECTION", () => {
-    it("sets drive connection during add-document flow", () => {
-      const result = researchPanelReducer(addDocumentState, {
-        type: "SET_DRIVE_CONNECTION",
-        connectionId: "conn-123",
-      });
-      expect(result.activeConnectionId).toBe("conn-123");
-    });
-
-    it("is a no-op when not in add-document flow", () => {
-      const result = researchPanelReducer(sourcesListState, {
-        type: "SET_DRIVE_CONNECTION",
-        connectionId: "conn-123",
-      });
-      expect(result).toEqual(sourcesListState);
-    });
-
-    it("is a no-op when panel is closed", () => {
-      const result = researchPanelReducer(closedState, {
-        type: "SET_DRIVE_CONNECTION",
-        connectionId: "conn-123",
-      });
-      expect(result).toEqual(closedState);
-    });
-  });
-
-  // --- FINISH_FLOW ---
-
-  describe("FINISH_FLOW", () => {
-    it("returns to list from add-document flow", () => {
-      const addWithConnection: ResearchPanelState = {
-        ...addDocumentState,
-        activeConnectionId: "conn-123",
-      };
-      const result = researchPanelReducer(addWithConnection, {
-        type: "FINISH_FLOW",
-      });
-      expect(result.sourcesView).toBe("list");
-      expect(result.activeConnectionId).toBeNull();
-    });
-
-    it("is a no-op when not in a flow", () => {
-      const result = researchPanelReducer(sourcesListState, {
-        type: "FINISH_FLOW",
-      });
-      expect(result).toEqual(sourcesListState);
-    });
-
-    it("is a no-op when panel is closed", () => {
-      const result = researchPanelReducer(closedState, {
-        type: "FINISH_FLOW",
-      });
-      expect(result).toEqual(closedState);
-    });
-  });
-
   // --- State machine invariants ---
 
   describe("state machine invariants", () => {
-    it("always has exactly one of the 6 valid states", () => {
+    it("always has exactly one of the 5 valid states", () => {
       // Define all valid state combinations
       const isValidState = (s: ResearchPanelState): boolean => {
         if (!s.isOpen) return true; // State 1: Closed
         if (s.activeTab === "sources" && s.sourcesView === "list") return true; // State 2: Sources-List
         if (s.activeTab === "sources" && s.sourcesView === "detail" && s.activeSourceId !== null)
           return true; // State 3: Sources-Detail
-        if (s.activeTab === "sources" && s.sourcesView === "add-document") return true; // State 4: Sources-AddDocument
-        if (s.activeTab === "ask") return true; // State 5: Ask
-        if (s.activeTab === "clips") return true; // State 6: Clips
+        if (s.activeTab === "ask") return true; // State 4: Ask
+        if (s.activeTab === "clips") return true; // State 5: Clips
         return false;
       };
 
       // Run through all actions from all valid starting states
-      const states = [
-        closedState,
-        sourcesListState,
-        sourcesDetailState,
-        addDocumentState,
-        askState,
-        clipsState,
-      ];
+      const states = [closedState, sourcesListState, sourcesDetailState, askState, clipsState];
 
       const actions: ResearchPanelAction[] = [
         { type: "OPEN_PANEL" },
@@ -510,10 +366,6 @@ describe("researchPanelReducer", () => {
         { type: "VIEW_SOURCE", sourceId: "src-1", returnTo: "ask", scrollToText: "test text" },
         { type: "BACK_TO_LIST" },
         { type: "RETURN_TO_TAB" },
-        { type: "START_ADD_DOCUMENT" },
-        { type: "START_ADD_DOCUMENT", connectionId: "conn-1" },
-        { type: "SET_DRIVE_CONNECTION", connectionId: "conn-1" },
-        { type: "FINISH_FLOW" },
       ];
 
       for (const state of states) {
@@ -655,50 +507,6 @@ describe("ResearchPanelProvider + useResearchPanel", () => {
       result.current.returnToPreviousTab();
     });
     expect(result.current.scrollToText).toBeNull();
-  });
-
-  it("starts add-document flow with pre-selected connectionId from source row", () => {
-    const { result } = renderHook(() => useResearchPanel(), { wrapper });
-
-    act(() => {
-      result.current.openPanel();
-    });
-
-    act(() => {
-      result.current.startAddDocument("conn-42");
-    });
-    expect(result.current.sourcesView).toBe("add-document");
-    expect(result.current.activeConnectionId).toBe("conn-42");
-
-    act(() => {
-      result.current.finishFlow();
-    });
-    expect(result.current.sourcesView).toBe("list");
-    expect(result.current.activeConnectionId).toBeNull();
-  });
-
-  it("manages add-document flow lifecycle", () => {
-    const { result } = renderHook(() => useResearchPanel(), { wrapper });
-
-    act(() => {
-      result.current.openPanel();
-    });
-
-    act(() => {
-      result.current.startAddDocument();
-    });
-    expect(result.current.sourcesView).toBe("add-document");
-
-    act(() => {
-      result.current.setDriveConnection("conn-123");
-    });
-    expect(result.current.activeConnectionId).toBe("conn-123");
-
-    act(() => {
-      result.current.finishFlow();
-    });
-    expect(result.current.sourcesView).toBe("list");
-    expect(result.current.activeConnectionId).toBeNull();
   });
 
   it("throws when used outside provider", () => {


### PR DESCRIPTION
## Summary

- **Source Manager sheet** — new right-slide overlay (Settings → "Manage Sources") for set-and-forget management: add documents, remove documents, link/unlink folders, empty-state CTA
- **Content Manager (Sources tab)** — stripped to content-only: search, document list, detail view with clip/insert. No management actions.
- **Shared components** — extracted `SourceCard` (with `actionSlot`), `source-helpers.ts` (badge/email/time helpers)
- **State machine cleanup** — removed `START_ADD_DOCUMENT`, `START_LINK_FOLDER`, `addMode` from research-panel-provider (5 states instead of 6)
- **Panel overlap prevention** — opening Source Manager closes Research panel first

## Test plan

- [ ] Settings menu → "Manage Sources" opens Source Manager sheet
- [ ] Source Manager: documents list, linked folders, add/remove/unlink all work
- [ ] Source Manager: [+ Add Documents] → Drive browser → add → returns to list
- [ ] Source Manager: "+ Link a folder" → folder browser → link → returns to list
- [ ] Source Manager: close + reopen → no stale confirmation state
- [ ] Opening Source Manager closes Research panel (no overlap)
- [ ] Sources tab (Research panel): search-only header (no [+] button, no ⋮ menus)
- [ ] Sources tab: empty state shows "Add Sources" button → opens Source Manager
- [ ] Sources tab: search, detail view, insert-into-chapter, import-as-chapter work
- [ ] Close Source Manager after adding docs → Sources tab shows new docs
- [ ] iPad Safari: 44pt touch targets, sheet overlay, backdrop dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)