### PR TITLE
fix: Sources panel account picker and error handling

### DIFF
--- a/web/src/components/project/accounts-sheet.tsx
+++ b/web/src/components/project/accounts-sheet.tsx
@@ -86,6 +86,12 @@ export function AccountsSheet({
 
         {/* Content */}
         <div className="flex-1 overflow-auto px-4 py-4">
+          {/* Explanation */}
+          <p className="text-xs text-gray-500 mb-4">
+            Connected accounts let you browse Google Drive for source materials and back up your
+            manuscript. You can connect multiple accounts.
+          </p>
+
           {accounts.length === 0 ? (
             <div className="text-center py-8">
               <p className="text-sm text-gray-500 mb-4">No Google accounts connected</p>


### PR DESCRIPTION
## Summary

Fixes #261 — Sources > Library tab was broken for multi-account users:

- **Account picker**: When multiple Drive accounts are connected, shows a dropdown to select which account to browse. Single-account users see the account email as context.
- **Error handling**: DriveBrowser now shows real error messages (expired tokens, permission errors) with Retry and Reconnect buttons, instead of silent "No files found" for all failure modes.
- **MIME filter fix**: Added `.docx` to frontend `SUPPORTED_MIMES` to match backend's `browseFolder` response — Word docs were being returned by the API but filtered out client-side.
- **Accounts sheet context**: Added explanatory text so users understand what connected accounts are used for.

4 files changed, 89 insertions, 8 deletions. All 673 tests passing, lint/typecheck/format clean.

## Test plan

- [ ] With 2 Google accounts connected, open Sources > Library — verify account picker dropdown appears
- [ ] Switch accounts in the picker — verify Drive browser reloads with the other account's files
- [ ] With 1 account connected, verify email shown as static text (no dropdown)
- [ ] Disconnect all accounts, verify "Connect Drive" empty state appears
- [ ] With an expired token, verify error message appears with Retry and Reconnect buttons
- [ ] Navigate into a folder with only .docx files — verify they appear (previously hidden)
- [ ] Open Settings > Google Accounts — verify explanatory text appears above account list
- [ ] Test on iPad Safari in both landscape and portrait

🤖 Generated with [Claude Code](https://claude.com/claude-code)