### PR TITLE
feat: Sources panel redesign with three-mode Library tab

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -107,17 +107,8 @@ function EditorPageInner() {
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileOverlayOpen, setMobileOverlayOpen] = useState(false);
 
-  // --- Accounts management sheet state ---
-  const [isAccountsSheetOpen, setIsAccountsSheetOpen] = useState(false);
-
   // --- Drive connection (multi-account) ---
-  const {
-    accounts: driveAccounts,
-    connected: driveConnected,
-    connect: connectDrive,
-    disconnect: disconnectDriveAccount,
-    refetch: refetchDriveAccounts,
-  } = useDriveAccounts();
+  const { connected: driveConnected, connect: connectDrive } = useDriveAccounts();
 
   // --- Chapter management ---
   const {
@@ -296,7 +287,6 @@ function EditorPageInner() {
                   disconnectProjectFromDrive();
                 }
               }}
-              onManageAccounts={() => setIsAccountsSheetOpen(true)}
               onRenameBook={openRenameDialog}
               onDuplicateBook={openDuplicateDialog}
               isDuplicating={isDuplicating}
@@ -357,13 +347,6 @@ function EditorPageInner() {
           onAIRetry={handleAIRetry}
           onAIDiscard={handleAIDiscard}
           onGoDeeper={handleGoDeeper}
-          // Accounts sheet
-          isAccountsSheetOpen={isAccountsSheetOpen}
-          onCloseAccountsSheet={() => setIsAccountsSheetOpen(false)}
-          onConnectAccount={() => connectDrive()}
-          onDisconnectDriveAccount={disconnectDriveAccount}
-          onRefetchDriveAccounts={refetchDriveAccounts}
-          driveAccounts={driveAccounts}
         />
 
         <SourcesPanelOverlay />

--- a/web/src/components/editor/editor-dialogs.tsx
+++ b/web/src/components/editor/editor-dialogs.tsx
@@ -4,13 +4,11 @@ import { useRouter } from "next/navigation";
 import type { ProjectData } from "@/types/editor";
 import type { AIRewriteResult } from "./ai-rewrite-sheet";
 import type { SheetState } from "@/hooks/use-ai-rewrite";
-import type { DriveAccount } from "@/hooks/use-drive-accounts";
 import { DeleteProjectDialog } from "@/components/project/delete-project-dialog";
 import { RenameProjectDialog } from "@/components/project/rename-project-dialog";
 import { DuplicateProjectDialog } from "@/components/project/duplicate-project-dialog";
 import { DeleteChapterDialog } from "@/components/project/delete-chapter-dialog";
 import { AIRewriteSheet } from "./ai-rewrite-sheet";
-import { AccountsSheet } from "@/components/project/accounts-sheet";
 
 interface EditorDialogsProps {
   projectData: ProjectData | null;
@@ -46,14 +44,6 @@ interface EditorDialogsProps {
   onAIRetry: (result: AIRewriteResult, instruction: string) => Promise<void>;
   onAIDiscard: (result: AIRewriteResult) => Promise<void>;
   onGoDeeper: (result: AIRewriteResult) => void;
-
-  // Accounts sheet
-  isAccountsSheetOpen: boolean;
-  onCloseAccountsSheet: () => void;
-  onConnectAccount: () => void;
-  onDisconnectDriveAccount: (connectionId: string) => Promise<void>;
-  onRefetchDriveAccounts: () => Promise<void>;
-  driveAccounts: DriveAccount[];
 }
 
 /**
@@ -62,8 +52,9 @@ interface EditorDialogsProps {
  * Extracted to keep the page orchestrator focused on layout and state wiring.
  * Each dialog/sheet is a controlled component receiving open/close state from the parent.
  *
- * Source management is handled by the ResearchPanel via the ResearchPanelProvider context (#180).
+ * Source management is handled by the SourcesPanel via the SourcesProvider context.
  * Drive backup config is handled by the SettingsMenu (2-state: setup vs open/unlink).
+ * Account management is handled by the SourcesSection within the Sources panel.
  */
 export function EditorDialogs({
   projectData,
@@ -89,12 +80,6 @@ export function EditorDialogs({
   onAIRetry,
   onAIDiscard,
   onGoDeeper,
-  isAccountsSheetOpen,
-  onCloseAccountsSheet,
-  onConnectAccount,
-  onDisconnectDriveAccount,
-  onRefetchDriveAccounts,
-  driveAccounts,
 }: EditorDialogsProps) {
   const router = useRouter();
 
@@ -154,18 +139,6 @@ export function EditorDialogs({
         onRetry={onAIRetry}
         onDiscard={onAIDiscard}
         onGoDeeper={onGoDeeper}
-      />
-
-      {/* Google Accounts management sheet */}
-      <AccountsSheet
-        isOpen={isAccountsSheetOpen}
-        accounts={driveAccounts}
-        onClose={onCloseAccountsSheet}
-        onConnectAccount={onConnectAccount}
-        onDisconnectAccount={async (connectionId) => {
-          await onDisconnectDriveAccount(connectionId);
-          await onRefetchDriveAccounts();
-        }}
       />
     </>
   );

--- a/web/src/components/editor/editor-toolbar.tsx
+++ b/web/src/components/editor/editor-toolbar.tsx
@@ -36,7 +36,6 @@ interface EditorToolbarProps {
   driveFolderId?: string | null;
   onSetupDrive?: () => void;
   onUnlinkDrive?: () => void;
-  onManageAccounts: () => void;
   onRenameBook: () => void;
   onDuplicateBook: () => void;
   isDuplicating: boolean;
@@ -66,7 +65,6 @@ export function EditorToolbar({
   driveFolderId,
   onSetupDrive,
   onUnlinkDrive,
-  onManageAccounts,
   onRenameBook,
   onDuplicateBook,
   isDuplicating,
@@ -161,7 +159,6 @@ export function EditorToolbar({
           driveFolderId={driveFolderId}
           onSetupDrive={onSetupDrive}
           onUnlinkDrive={onUnlinkDrive}
-          onManageAccounts={onManageAccounts}
           onRenameBook={onRenameBook}
           onDuplicateBook={onDuplicateBook}
           isDuplicating={isDuplicating}

--- a/web/src/components/project/settings-menu.tsx
+++ b/web/src/components/project/settings-menu.tsx
@@ -11,8 +11,6 @@ interface SettingsMenuProps {
   onSetupDrive?: () => void;
   /** Unlink project from Google Drive folder */
   onUnlinkDrive?: () => void;
-  /** Open Google Accounts management sheet */
-  onManageAccounts?: () => void;
   /** Open rename book dialog */
   onRenameBook: () => void;
   /** Open duplicate book dialog */
@@ -41,7 +39,6 @@ export function SettingsMenu({
   driveFolderId,
   onSetupDrive,
   onUnlinkDrive,
-  onManageAccounts,
   onRenameBook,
   onDuplicateBook,
   isDuplicating,
@@ -194,33 +191,6 @@ export function SettingsMenu({
               <div className="my-1 border-t border-gray-200" role="separator" />
             </>
           )}
-
-          {/* Google Accounts management */}
-          {onManageAccounts && (
-            <button
-              onClick={() => handleMenuItem(onManageAccounts)}
-              className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
-                         transition-colors min-h-[44px] flex items-center gap-2"
-              role="menuitem"
-            >
-              <svg
-                className="w-4 h-4 shrink-0"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-                />
-              </svg>
-              Google Accounts
-            </button>
-          )}
-
-          <div className="my-1 border-t border-gray-200" role="separator" />
 
           {/* Rename Book */}
           <button

--- a/web/src/components/sources/assist-tab.tsx
+++ b/web/src/components/sources/assist-tab.tsx
@@ -111,7 +111,7 @@ export function AssistTab() {
           </svg>
         }
         message="Add sources to use AI analysis"
-        description="Import sources from your Drive or upload files first."
+        description="Add documents to get started."
       />
     );
   }

--- a/web/src/components/sources/empty-state.tsx
+++ b/web/src/components/sources/empty-state.tsx
@@ -10,26 +10,48 @@ interface EmptyStateProps {
     label: string;
     onClick: () => void;
   };
+  secondaryAction?: {
+    label: string;
+    onClick: () => void;
+  };
 }
 
 /**
  * Reusable empty state component for the Sources panel.
  * Used for: no sources, no connections, no search results, no source selected.
  */
-export function EmptyState({ icon, message, description, action }: EmptyStateProps) {
+export function EmptyState({
+  icon,
+  message,
+  description,
+  action,
+  secondaryAction,
+}: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center px-6 py-12 text-center">
       <div className="mb-4 text-gray-400">{icon}</div>
       <p className="text-sm font-medium text-gray-700 mb-1">{message}</p>
       {description && <p className="text-xs text-gray-500 mb-4 max-w-[240px]">{description}</p>}
-      {action && (
-        <button
-          onClick={action.onClick}
-          className="h-9 px-4 rounded-lg bg-blue-600 text-sm font-medium text-white
-                     hover:bg-blue-700 transition-colors min-h-[44px] min-w-[44px]"
-        >
-          {action.label}
-        </button>
+      {(action || secondaryAction) && (
+        <div className="flex flex-col items-center gap-2">
+          {action && (
+            <button
+              onClick={action.onClick}
+              className="h-9 px-4 rounded-lg bg-blue-600 text-sm font-medium text-white
+                       hover:bg-blue-700 transition-colors min-h-[44px] min-w-[44px]"
+            >
+              {action.label}
+            </button>
+          )}
+          {secondaryAction && (
+            <button
+              onClick={secondaryAction.onClick}
+              className="text-xs text-gray-500 hover:text-gray-700 transition-colors min-h-[44px]"
+            >
+              {secondaryAction.label}
+            </button>
+          )}
+        </div>
       )}
     </div>
   );

--- a/web/src/components/sources/library-tab.tsx
+++ b/web/src/components/sources/library-tab.tsx
@@ -4,18 +4,21 @@ import { useState, useCallback, useRef } from "react";
 import { useSourcesContext } from "@/contexts/sources-context";
 import { ProjectSourceList } from "./project-source-list";
 import { DriveBrowser } from "./drive-browser";
+import { SourcePicker } from "./source-picker";
+import { SourcesSection } from "./sources-section";
 import { EmptyState } from "./empty-state";
+import type { DriveAccount } from "@/hooks/use-drive-accounts";
+
+type ViewMode = "list" | "picker" | "browse";
 
 /**
- * Library tab — Project sources (default view) + on-demand Drive browser.
+ * Library tab — three-mode redesign.
  *
- * Three empty states:
- * 1. No Drive connection: "Connect Google Drive" + Connect button
- * 2. Drive connected, no sources: Drive browser expanded by default
- * 3. Sources exist: source list with "Add from Drive" button
+ * List mode (default): ProjectSourceList + "Add Documents" button + "Your Sources" section
+ * Picker mode: SourcePicker fills the panel ("Add documents from")
+ * Browse mode: Full-height DriveBrowser fills the panel content area
  *
- * Multi-account: when multiple Drive accounts are connected, shows an
- * account picker so the user can choose which account to browse.
+ * Vocabulary: Source = provider, Folder = directory, Document = file.
  */
 export function LibraryTab() {
   const {
@@ -27,15 +30,16 @@ export function LibraryTab() {
     uploadLocalFile,
   } = useSourcesContext();
 
-  const [showDriveBrowser, setShowDriveBrowser] = useState(false);
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [isUploading, setIsUploading] = useState(false);
   const [selectedAccountIndex, setSelectedAccountIndex] = useState(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Determine which connection to use for the Drive browser
   const safeIndex = Math.min(selectedAccountIndex, Math.max(driveAccounts.length - 1, 0));
-  const activeConnectionId = driveAccounts[safeIndex]?.id ?? null;
-  const activeAccountEmail = driveAccounts[safeIndex]?.email ?? null;
+  const activeAccount = driveAccounts[safeIndex] ?? null;
+  const activeConnectionId = activeAccount?.id ?? null;
+  const activeAccountEmail = activeAccount?.email ?? null;
 
   const handleUpload = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -49,152 +53,222 @@ export function LibraryTab() {
         console.error("Upload failed:", err);
       } finally {
         setIsUploading(false);
+        setViewMode("list");
         if (fileInputRef.current) fileInputRef.current.value = "";
       }
     },
     [uploadLocalFile],
   );
 
+  const handleAddDocuments = useCallback(() => {
+    // If exactly 1 source connected, skip picker and go straight to browse
+    if (driveAccounts.length === 1) {
+      setSelectedAccountIndex(0);
+      setViewMode("browse");
+    } else {
+      // 0 or 2+ sources: show picker
+      setViewMode("picker");
+    }
+  }, [driveAccounts.length]);
+
+  const handleSelectAccount = useCallback(
+    (account: DriveAccount) => {
+      const index = driveAccounts.findIndex((a) => a.id === account.id);
+      setSelectedAccountIndex(index >= 0 ? index : 0);
+      setViewMode("browse");
+    },
+    [driveAccounts],
+  );
+
+  const handleConnectDrive = useCallback(() => {
+    connectDrive();
+  }, [connectDrive]);
+
+  const handleUploadLocal = useCallback(() => {
+    fileInputRef.current?.click();
+  }, []);
+
   // Loading state
   if (isLoadingSources) {
     return (
       <div className="px-3 py-8 text-center">
-        <p className="text-sm text-gray-500">Loading sources...</p>
+        <p className="text-sm text-gray-500">Loading...</p>
       </div>
     );
   }
 
-  // Empty state 1: No Drive connection
-  if (!driveConnected && sources.length === 0) {
-    return (
-      <EmptyState
-        icon={
-          <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={1.5}
-              d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z"
-            />
-          </svg>
-        }
-        message="Connect Google Drive to import your research"
-        description="Add source materials from your Drive to reference while writing. Your files stay in your Drive."
-        action={{
-          label: "Connect Drive",
-          onClick: () => connectDrive(),
-        }}
-      />
-    );
-  }
+  // Hidden file input (always rendered for upload)
+  const fileInput = (
+    <input
+      ref={fileInputRef}
+      type="file"
+      accept=".txt,.md,.pdf,.docx"
+      onChange={handleUpload}
+      className="hidden"
+    />
+  );
 
-  // Account picker for multi-account users
-  const accountPicker =
-    driveAccounts.length > 1 ? (
-      <div className="flex items-center gap-2">
-        <label htmlFor="drive-account-picker" className="text-xs text-gray-500 shrink-0">
-          Account:
-        </label>
-        <select
-          id="drive-account-picker"
-          value={safeIndex}
-          onChange={(e) => setSelectedAccountIndex(Number(e.target.value))}
-          className="text-xs text-gray-700 bg-white border border-gray-200 rounded-md
-                     px-2 py-1.5 min-h-[36px] max-w-[200px] truncate"
-        >
-          {driveAccounts.map((account, i) => (
-            <option key={account.id} value={i}>
-              {account.email}
-            </option>
-          ))}
-        </select>
-      </div>
-    ) : activeAccountEmail ? (
-      <p className="text-xs text-gray-500 truncate">Browsing {activeAccountEmail}</p>
-    ) : null;
-
-  // Empty state 2: Drive connected, no sources
-  if (driveConnected && sources.length === 0 && activeConnectionId) {
+  // ── PICKER MODE ──
+  if (viewMode === "picker") {
     return (
-      <div className="flex flex-col gap-3 px-3 pt-2">
-        <p className="text-sm text-gray-600">Browse your Drive to add sources to this project.</p>
-        {accountPicker}
-        <DriveBrowser
-          connectionId={activeConnectionId}
-          onClose={() => {}}
-          onReconnect={() => connectDrive(activeAccountEmail ?? undefined)}
+      <div className="flex flex-col flex-1 min-h-0">
+        {fileInput}
+        <SourcePicker
+          driveAccounts={driveAccounts}
+          onSelectAccount={handleSelectAccount}
+          onConnectDrive={handleConnectDrive}
+          onUploadLocal={handleUploadLocal}
+          onCancel={() => setViewMode("list")}
         />
       </div>
     );
   }
 
-  // Normal state: Sources exist
-  return (
-    <div className="flex flex-col gap-2">
-      <ProjectSourceList />
+  // ── BROWSE MODE ──
+  if (viewMode === "browse" && activeConnectionId) {
+    return (
+      <div className="flex flex-col flex-1 min-h-0">
+        {fileInput}
 
-      {/* Add from Drive / Upload buttons */}
-      <div className="px-3 flex items-center gap-2 pb-2">
-        {driveConnected && activeConnectionId && (
-          <>
-            {showDriveBrowser ? (
-              <div className="w-full flex flex-col gap-2">
-                {accountPicker}
-                <DriveBrowser
-                  connectionId={activeConnectionId}
-                  onClose={() => setShowDriveBrowser(false)}
-                  onReconnect={() => connectDrive(activeAccountEmail ?? undefined)}
-                />
-              </div>
-            ) : (
-              <button
-                onClick={() => setShowDriveBrowser(true)}
-                className="h-9 px-3 text-xs text-blue-600 border border-blue-200 rounded-lg
-                           hover:bg-blue-50 transition-colors min-h-[44px] flex items-center gap-1.5"
+        {/* Back button + source picker for multi-account */}
+        <div className="px-3 py-2 border-b border-gray-100 flex items-center gap-2 shrink-0">
+          <button
+            onClick={() => setViewMode("list")}
+            className="text-xs text-gray-500 hover:text-gray-700 min-h-[32px] flex items-center gap-1"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            Back
+          </button>
+
+          {driveAccounts.length > 1 && (
+            <>
+              <div className="w-px h-4 bg-gray-200" />
+              <label htmlFor="browse-account-picker" className="sr-only">
+                Source
+              </label>
+              <select
+                id="browse-account-picker"
+                value={safeIndex}
+                onChange={(e) => setSelectedAccountIndex(Number(e.target.value))}
+                className="text-xs text-gray-700 bg-white border border-gray-200 rounded-md
+                           px-2 py-1.5 min-h-[32px] max-w-[180px] truncate"
               >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M12 4v16m8-8H4"
-                  />
-                </svg>
-                Add from Drive
-              </button>
-            )}
-          </>
-        )}
+                {driveAccounts.map((account, i) => (
+                  <option key={account.id} value={i}>
+                    {account.email}
+                  </option>
+                ))}
+              </select>
+            </>
+          )}
+        </div>
 
-        {!showDriveBrowser && (
-          <>
-            <button
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isUploading}
-              className="h-9 px-3 text-xs text-gray-600 border border-gray-200 rounded-lg
-                         hover:bg-gray-50 transition-colors min-h-[44px] flex items-center gap-1.5
-                         disabled:opacity-50"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
-                />
-              </svg>
-              {isUploading ? "Uploading..." : "Upload File"}
-            </button>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".txt,.md"
-              onChange={handleUpload}
-              className="hidden"
-            />
-          </>
-        )}
+        <DriveBrowser
+          connectionId={activeConnectionId}
+          onClose={() => setViewMode("list")}
+          onReconnect={() => connectDrive(activeAccountEmail ?? undefined)}
+          rootLabel={activeAccountEmail ?? undefined}
+        />
       </div>
+    );
+  }
+
+  // ── LIST MODE ──
+
+  // Empty state: no sources connected, no documents
+  if (!driveConnected && sources.length === 0) {
+    return (
+      <div className="flex flex-col flex-1 min-h-0">
+        {fileInput}
+        <EmptyState
+          icon={
+            <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+              />
+            </svg>
+          }
+          message="Add documents to your library"
+          description="Import from Google Drive or your device."
+          action={{
+            label: "Add Documents",
+            onClick: handleAddDocuments,
+          }}
+        />
+      </div>
+    );
+  }
+
+  // Empty state: sources connected but no documents yet
+  if (driveConnected && sources.length === 0) {
+    return (
+      <div className="flex flex-col flex-1 min-h-0">
+        {fileInput}
+        <EmptyState
+          icon={
+            <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+              />
+            </svg>
+          }
+          message="Add documents to your library"
+          description="Select documents to add to this project."
+          action={{
+            label: "Add Documents",
+            onClick: handleAddDocuments,
+          }}
+        />
+        <SourcesSection onAddSource={() => setViewMode("picker")} />
+      </div>
+    );
+  }
+
+  // Normal state: documents exist
+  return (
+    <div className="flex flex-col flex-1 min-h-0">
+      {fileInput}
+
+      <div className="flex-1 overflow-auto min-h-0">
+        <ProjectSourceList />
+
+        {/* Add Documents button */}
+        <div className="px-3 py-2">
+          <button
+            onClick={handleAddDocuments}
+            disabled={isUploading}
+            className="h-9 px-3 text-xs text-blue-600 border border-blue-200 rounded-lg
+                       hover:bg-blue-50 transition-colors min-h-[44px] flex items-center gap-1.5
+                       disabled:opacity-50"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            {isUploading ? "Uploading..." : "Add Documents"}
+          </button>
+        </div>
+      </div>
+
+      {/* Your Sources section at bottom */}
+      <SourcesSection onAddSource={() => setViewMode("picker")} />
     </div>
   );
 }

--- a/web/src/components/sources/source-picker.tsx
+++ b/web/src/components/sources/source-picker.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import type { DriveAccount } from "@/hooks/use-drive-accounts";
+
+interface SourcePickerProps {
+  /** Connected Drive accounts */
+  driveAccounts: DriveAccount[];
+  /** Called when user picks a connected Drive account to browse */
+  onSelectAccount: (account: DriveAccount) => void;
+  /** Called when user wants to connect a new Google Drive */
+  onConnectDrive: () => void;
+  /** Called when user wants to upload from this device */
+  onUploadLocal: () => void;
+  /** Called when user taps Cancel */
+  onCancel: () => void;
+}
+
+/**
+ * SourcePicker — inline panel for choosing where to add documents from.
+ *
+ * Shows connected sources as full-width rows, plus "This device" for local upload.
+ * If multiple sources exist, shows each individually. Includes "Connect another source"
+ * when at least one source is already connected.
+ *
+ * 44pt touch targets throughout. iPad-first.
+ */
+export function SourcePicker({
+  driveAccounts,
+  onSelectAccount,
+  onConnectDrive,
+  onUploadLocal,
+  onCancel,
+}: SourcePickerProps) {
+  return (
+    <div className="flex flex-col px-4 py-4 flex-1">
+      <h3 className="text-sm font-medium text-gray-900 mb-3">Add documents from</h3>
+
+      <div className="flex flex-col gap-1">
+        {/* Connected Drive accounts */}
+        {driveAccounts.map((account) => (
+          <button
+            key={account.id}
+            onClick={() => onSelectAccount(account)}
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+                       transition-colors min-h-[44px] w-full text-left"
+          >
+            <svg className="w-5 h-5 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+              <path
+                d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z"
+                className="text-blue-500"
+              />
+            </svg>
+            <span className="text-sm text-gray-900 truncate">{account.email}</span>
+          </button>
+        ))}
+
+        {/* Connect Google Drive (when no accounts connected) */}
+        {driveAccounts.length === 0 && (
+          <button
+            onClick={onConnectDrive}
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+                       transition-colors min-h-[44px] w-full text-left"
+          >
+            <svg className="w-5 h-5 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+              <path
+                d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z"
+                className="text-blue-500"
+              />
+            </svg>
+            <span className="text-sm text-gray-900">Google Drive</span>
+          </button>
+        )}
+
+        {/* This device */}
+        <button
+          onClick={onUploadLocal}
+          className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+                     transition-colors min-h-[44px] w-full text-left"
+        >
+          <svg
+            className="w-5 h-5 shrink-0 text-gray-500"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12"
+            />
+          </svg>
+          <span className="text-sm text-gray-900">This device</span>
+        </button>
+
+        {/* Connect another source (when accounts already exist) */}
+        {driveAccounts.length > 0 && (
+          <button
+            onClick={onConnectDrive}
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+                       transition-colors min-h-[44px] w-full text-left"
+          >
+            <svg
+              className="w-5 h-5 shrink-0 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            <span className="text-sm text-gray-500">Connect another source</span>
+          </button>
+        )}
+      </div>
+
+      {/* Cancel */}
+      <div className="mt-4">
+        <button
+          onClick={onCancel}
+          className="text-sm text-gray-500 hover:text-gray-700 transition-colors min-h-[44px] px-3"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/sources/sources-panel-overlay.tsx
+++ b/web/src/components/sources/sources-panel-overlay.tsx
@@ -76,7 +76,7 @@ export function SourcesPanelOverlay() {
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-auto">
+        <div className="flex-1 overflow-auto flex flex-col">
           {activeTab === "library" && <LibraryTab />}
           {activeTab === "review" && <ReviewTab />}
           {activeTab === "assist" && <AssistTab />}

--- a/web/src/components/sources/sources-panel.tsx
+++ b/web/src/components/sources/sources-panel.tsx
@@ -62,7 +62,7 @@ export function SourcesPanel() {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto">
+      <div className="flex-1 overflow-auto flex flex-col">
         {activeTab === "library" && <LibraryTab />}
         {activeTab === "review" && <ReviewTab />}
         {activeTab === "assist" && <AssistTab />}

--- a/web/src/components/sources/sources-section.tsx
+++ b/web/src/components/sources/sources-section.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useSourcesContext } from "@/contexts/sources-context";
+
+/**
+ * SourcesSection — collapsible "Your Sources" section at the bottom of Library tab.
+ *
+ * Shows connected providers with disconnect capability.
+ * Replaces AccountsSheet as the primary provider management path.
+ *
+ * - Collapsed by default when sources exist
+ * - Expanded when no providers connected (guides first-run)
+ * - "+ Add" opens source picker via callback
+ * - Inline disconnect confirmation (no window.confirm)
+ * - 44pt touch targets throughout
+ */
+interface SourcesSectionProps {
+  /** Called when user taps "+ Add" to open the source picker */
+  onAddSource: () => void;
+}
+
+export function SourcesSection({ onAddSource }: SourcesSectionProps) {
+  const { driveAccounts, disconnectDrive, refetchDriveAccounts } = useSourcesContext();
+
+  const [expanded, setExpanded] = useState(driveAccounts.length === 0);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [isDisconnecting, setIsDisconnecting] = useState(false);
+
+  const handleDisconnect = useCallback(
+    async (connectionId: string) => {
+      setIsDisconnecting(true);
+      try {
+        await disconnectDrive(connectionId);
+        await refetchDriveAccounts();
+        setConfirmingId(null);
+      } catch (err) {
+        console.error("Failed to disconnect:", err);
+      } finally {
+        setIsDisconnecting(false);
+      }
+    },
+    [disconnectDrive, refetchDriveAccounts],
+  );
+
+  return (
+    <div className="border-t border-gray-100 px-3 py-2">
+      {/* Header */}
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center justify-between w-full min-h-[44px] text-left"
+      >
+        <div className="flex items-center gap-1.5">
+          <svg
+            className={`w-3.5 h-3.5 text-gray-400 transition-transform ${expanded ? "rotate-90" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+          <span className="text-xs font-medium text-gray-500">Your Sources</span>
+        </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onAddSource();
+          }}
+          className="text-xs text-blue-600 hover:text-blue-700 min-h-[44px] min-w-[44px]
+                     flex items-center justify-center"
+          aria-label="Add source"
+        >
+          + Add
+        </button>
+      </button>
+
+      {/* Content */}
+      {expanded && (
+        <div className="flex flex-col gap-1 pb-2">
+          {driveAccounts.length === 0 ? (
+            <p className="text-xs text-gray-400 py-2 px-1">No sources connected.</p>
+          ) : (
+            driveAccounts.map((account) => (
+              <div key={account.id}>
+                <div className="flex items-center gap-2 px-1 min-h-[44px]">
+                  {/* Google Drive icon */}
+                  <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                    <path
+                      d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z"
+                      className="text-blue-500"
+                    />
+                  </svg>
+                  <span className="text-xs text-gray-700 truncate flex-1">{account.email}</span>
+
+                  {confirmingId === account.id ? null : (
+                    <button
+                      onClick={() => setConfirmingId(account.id)}
+                      className="text-xs text-gray-400 hover:text-red-600 transition-colors
+                                 min-h-[44px] flex items-center shrink-0"
+                    >
+                      Disconnect
+                    </button>
+                  )}
+                </div>
+
+                {/* Inline confirmation */}
+                {confirmingId === account.id && (
+                  <div className="px-1 py-2 bg-gray-50 rounded-lg mx-1 mb-1">
+                    <p className="text-xs text-gray-600 mb-2">
+                      Disconnect {account.email}? Documents from this source will be archived.
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleDisconnect(account.id)}
+                        disabled={isDisconnecting}
+                        className="text-xs font-medium text-red-600 hover:text-red-700
+                                   min-h-[36px] px-2 disabled:opacity-50"
+                      >
+                        {isDisconnecting ? "Disconnecting..." : "Confirm"}
+                      </button>
+                      <button
+                        onClick={() => setConfirmingId(null)}
+                        disabled={isDisconnecting}
+                        className="text-xs text-gray-500 hover:text-gray-700
+                                   min-h-[36px] px-2 disabled:opacity-50"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/contexts/sources-context.tsx
+++ b/web/src/contexts/sources-context.tsx
@@ -81,6 +81,8 @@ interface SourcesContextValue {
   driveAccounts: DriveAccount[];
   driveConnected: boolean;
   connectDrive: (loginHint?: string) => Promise<void>;
+  disconnectDrive: (connectionId: string) => Promise<void>;
+  refetchDriveAccounts: () => Promise<void>;
 
   // Editor ref (for content insertion)
   editorRef: React.RefObject<ChapterEditorHandle | null>;
@@ -169,6 +171,8 @@ export function SourcesProvider({ projectId, editorRef, children }: SourcesProvi
     driveAccounts: driveAccountsHook.accounts,
     driveConnected: driveAccountsHook.connected,
     connectDrive: driveAccountsHook.connect,
+    disconnectDrive: driveAccountsHook.disconnect,
+    refetchDriveAccounts: driveAccountsHook.refetch,
 
     // Refs
     editorRef,

--- a/web/test/components/editor-toolbar.test.tsx
+++ b/web/test/components/editor-toolbar.test.tsx
@@ -77,7 +77,6 @@ function makeProps(overrides?: Partial<React.ComponentProps<typeof EditorToolbar
     getToken: vi.fn().mockResolvedValue("token"),
     apiUrl: "https://api.test",
     hasDriveFolder: false,
-    onManageAccounts: vi.fn(),
     onRenameBook: vi.fn(),
     onDuplicateBook: vi.fn(),
     isDuplicating: false,


### PR DESCRIPTION
## Summary

- **Three-mode LibraryTab** (list/picker/browse) replaces the boolean Drive browser toggle, giving Diane a clear flow: tap "Add Documents" → pick a source → browse and select
- **New SourcePicker component** — inline panel for choosing where to add documents from (connected Drive accounts, this device, connect another source). Skips the picker and goes straight to browse when only one source is connected
- **New SourcesSection component** — collapsible "Your Sources" at the bottom of the Library tab with inline disconnect confirmation, replacing the AccountsSheet that was buried in Settings
- **DriveBrowser redesign** — full-height flex layout (no more 300px cap), context-aware empty states ("This folder is empty" vs "No supported documents in this folder"), and mutually exclusive action bar (Add N Documents when files selected, Link This Folder when in a subfolder with nothing selected)
- **Consistent vocabulary** enforced: Source = provider, Folder = directory, Document = file
- **AccountsSheet removed** from editor dialogs; "Google Accounts" menu item removed from Settings menu
- **EmptyState** gains `secondaryAction` prop for two-CTA layouts

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — passes
- [x] `npm run test` — 495 tests pass (28 files)
- [x] `npm run format:check` — passes
- [ ] Manual: No sources connected, no documents → empty state with "Add Documents" CTA
- [ ] Manual: Tap "Add Documents" → Source Picker shows Google Drive + This device
- [ ] Manual: One source connected → "Add Documents" skips picker, goes to browse
- [ ] Manual: Two sources connected → picker shows both + This device + Connect another
- [ ] Manual: Browse into empty folder → "This folder is empty"
- [ ] Manual: Browse folder with only spreadsheets → "No supported documents in this folder"
- [ ] Manual: Select documents → "Add N Documents" (no Link folder)
- [ ] Manual: No selection in subfolder → "Link This Folder" action
- [ ] Manual: "Your Sources" section: expand, disconnect → inline confirmation
- [ ] Manual: Settings menu → no "Google Accounts" item
- [ ] Manual: iPad Safari landscape + portrait layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)