### PR TITLE
fix: enforce project-scoped Drive connections in all UI

### DIFF
--- a/web/src/app/(protected)/drive/success/page.tsx
+++ b/web/src/app/(protected)/drive/success/page.tsx
@@ -57,9 +57,10 @@ export default function DriveSuccessPage() {
   const { getToken } = useAuth();
   const { accounts, isLoading: isLoadingDrive } = useDriveAccounts();
 
-  // Connection ID and email from OAuth callback redirect
+  // Connection ID, email, and optional projectId from OAuth callback redirect
   const connectionId = searchParams.get("cid");
   const connectedEmail = searchParams.get("email");
+  const pidFromUrl = searchParams.get("pid");
 
   // Derive connection state from accounts array
   const isConnected = accounts.length > 0;
@@ -68,12 +69,13 @@ export default function DriveSuccessPage() {
   const fallbackEmail = accounts.find((a) => a.id === connectionId)?.email ?? accounts[0]?.email;
   const displayEmail = connectedEmail || fallbackEmail;
 
-  // Source-link flow: project ID from sessionStorage
-  const sourceLinkProjectId = useSyncExternalStore(
+  // Source-link flow: project ID from sessionStorage, with URL pid fallback (iPad Safari)
+  const sessionProjectId = useSyncExternalStore(
     subscribeNoop,
     readPendingSourceLink,
     getServerSnapshot,
   );
+  const sourceLinkProjectId = sessionProjectId || pidFromUrl;
 
   const [linkComplete, setLinkComplete] = useState(false);
   const linkAttempted = useRef(false);

--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -12,7 +12,6 @@ import { EditorToolbar } from "@/components/editor/editor-toolbar";
 import { EditorWritingArea } from "@/components/editor/editor-writing-area";
 import { EditorDialogs } from "@/components/editor/editor-dialogs";
 import { ToastProvider } from "@/components/toast";
-import { useDriveAccounts } from "@/hooks/use-drive-accounts";
 import { useAutoSave } from "@/hooks/use-auto-save";
 import { useSignOut } from "@/hooks/use-sign-out";
 import { useChapterManagement } from "@/hooks/use-chapter-management";
@@ -98,9 +97,6 @@ function EditorPageInner() {
   // --- Sidebar UI state ---
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileOverlayOpen, setMobileOverlayOpen] = useState(false);
-
-  // --- Drive accounts (for export) ---
-  const { accounts: driveAccounts } = useDriveAccounts();
 
   // --- Chapter management ---
   const {
@@ -258,7 +254,6 @@ function EditorPageInner() {
               selectionWordCount={selectionWordCount}
               aiSheetState={aiSheetState}
               onOpenAiRewrite={handleOpenAiRewrite}
-              driveAccounts={driveAccounts}
               projectId={projectId}
               activeChapterId={activeChapterId}
               getToken={getToken as () => Promise<string | null>}

--- a/web/src/components/editor/editor-toolbar.tsx
+++ b/web/src/components/editor/editor-toolbar.tsx
@@ -4,7 +4,6 @@ import type { ProjectData } from "@/types/editor";
 import type { SaveStatus } from "@/hooks/use-auto-save";
 import type { SheetState } from "@/hooks/use-ai-rewrite";
 import type { ProjectSummary } from "@/hooks/use-project-actions";
-import type { DriveAccount } from "@/hooks/use-drive-accounts";
 import { ProjectSwitcher } from "@/components/project/project-switcher";
 import { SaveIndicator } from "./save-indicator";
 import { ExportMenu } from "@/components/project/export-menu";
@@ -26,7 +25,6 @@ interface EditorToolbarProps {
   onOpenAiRewrite: () => void;
 
   // Export
-  driveAccounts: DriveAccount[];
   projectId: string;
   activeChapterId: string | null;
   getToken: () => Promise<string | null>;
@@ -53,7 +51,6 @@ export function EditorToolbar({
   selectionWordCount,
   aiSheetState,
   onOpenAiRewrite,
-  driveAccounts,
   projectId,
   activeChapterId,
   getToken,
@@ -65,7 +62,7 @@ export function EditorToolbar({
   onSignOut,
   isSigningOut,
 }: EditorToolbarProps) {
-  const { isPanelOpen, togglePanel } = useSourcesContext();
+  const { isPanelOpen, togglePanel, connections } = useSourcesContext();
 
   return (
     <div className="flex items-center justify-between h-12 px-4 border-b border-border bg-background shrink-0">
@@ -144,7 +141,7 @@ export function EditorToolbar({
           activeChapterId={activeChapterId}
           getToken={getToken}
           apiUrl={apiUrl}
-          driveAccounts={driveAccounts}
+          connections={connections}
         />
 
         <SettingsMenu

--- a/web/src/components/editor/onboarding-tooltips.tsx
+++ b/web/src/components/editor/onboarding-tooltips.tsx
@@ -10,7 +10,7 @@ interface OnboardingStep {
   /** Main text shown to the user */
   text: string;
   /** Which region of the editor this step points to */
-  target: "editor" | "sidebar" | "text-selection";
+  target: "editor" | "sidebar" | "text-selection" | "sources";
 }
 
 /**
@@ -29,6 +29,11 @@ const STEPS: OnboardingStep[] = [
     key: "sidebar",
     text: "Use the sidebar to switch between chapters or add new ones.",
     target: "sidebar",
+  },
+  {
+    key: "sources",
+    text: "Import reference documents from Google Drive or your device.",
+    target: "sources",
   },
   {
     key: "ai",
@@ -173,6 +178,9 @@ function getPositionClasses(target: OnboardingStep["target"]): string {
     case "sidebar":
       // Near the left edge where the sidebar lives
       return "top-1/3 left-4 lg:left-[270px]";
+    case "sources":
+      // Near the top-right where the Sources button is in the toolbar
+      return "top-16 right-4 lg:right-[200px]";
     case "text-selection":
       // Center of the content area, slightly below middle
       return "top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2";

--- a/web/src/components/project/export-menu.tsx
+++ b/web/src/components/project/export-menu.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useBackup } from "@/hooks/use-backup";
-import type { DriveAccount } from "@/hooks/use-drive-accounts";
+import type { SourceConnection } from "@/hooks/use-sources";
 
 type ExportFormat = "pdf" | "epub";
 
@@ -23,8 +23,8 @@ interface ExportMenuProps {
   activeChapterId: string | null;
   getToken: () => Promise<string | null>;
   apiUrl: string;
-  /** Connected Drive accounts. When empty, "Save to Drive" is hidden. */
-  driveAccounts?: DriveAccount[];
+  /** Project-scoped Drive connections. When empty, "Save to Drive" is hidden. */
+  connections?: SourceConnection[];
 }
 
 /**
@@ -44,7 +44,7 @@ export function ExportMenu({
   activeChapterId,
   getToken,
   apiUrl,
-  driveAccounts = [],
+  connections = [],
 }: ExportMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [state, setState] = useState<ExportState>({ phase: "idle" });
@@ -52,7 +52,7 @@ export function ExportMenu({
   const menuRef = useRef<HTMLDivElement>(null);
   const { downloadBackup, isDownloading } = useBackup();
 
-  const driveConnected = driveAccounts.length > 0;
+  const driveConnected = connections.length > 0;
 
   // Close menu on outside click
   useEffect(() => {
@@ -448,9 +448,9 @@ export function ExportMenu({
                 {/* Save to Google Drive - account picker (US-021) */}
                 {driveConnected && driveState.phase === "idle" && (
                   <>
-                    {driveAccounts.length === 1 ? (
+                    {connections.length === 1 ? (
                       <button
-                        onClick={() => handleSaveToDrive(driveAccounts[0].id)}
+                        onClick={() => handleSaveToDrive(connections[0].driveConnectionId)}
                         className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium
                                    text-blue-700 bg-blue-100 hover:bg-blue-200 rounded-md
                                    transition-colors min-h-[44px]"
@@ -464,14 +464,14 @@ export function ExportMenu({
                     ) : (
                       <div className="w-full mt-1">
                         <p className="text-xs text-gray-500 mb-1">Save to Drive:</p>
-                        {driveAccounts.map((account) => (
+                        {connections.map((connection) => (
                           <button
-                            key={account.id}
-                            onClick={() => handleSaveToDrive(account.id)}
+                            key={connection.driveConnectionId}
+                            onClick={() => handleSaveToDrive(connection.driveConnectionId)}
                             className="w-full text-left inline-flex items-center gap-2 px-3 py-2 text-sm font-medium
                                        text-blue-700 bg-blue-50 hover:bg-blue-100 rounded-md
                                        transition-colors min-h-[44px] mb-1"
-                            aria-label={`Save to ${account.email}`}
+                            aria-label={`Save to ${connection.email}`}
                           >
                             <svg
                               className="w-4 h-4 shrink-0"
@@ -480,7 +480,7 @@ export function ExportMenu({
                             >
                               <path d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z" />
                             </svg>
-                            {account.email}
+                            {connection.email}
                           </button>
                         ))}
                       </div>

--- a/web/src/components/sources/connect-source-sheet.tsx
+++ b/web/src/components/sources/connect-source-sheet.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { useDriveAccounts, type DriveAccount } from "@/hooks/use-drive-accounts";
+import { useSourcesContext } from "@/contexts/sources-context";
+
+const SOURCE_LINK_KEY = "dc_pending_source_link";
+
+interface ConnectSourceSheetProps {
+  /** Called when sheet should close */
+  onClose: () => void;
+}
+
+/**
+ * ConnectSourceSheet — the ONLY place user-level Drive accounts are fetched
+ * and displayed, solely for linking to the current project.
+ *
+ * Shows:
+ * 1. User-level accounts not yet linked to this project → "Link" button
+ * 2. "Connect new account" → initiates OAuth with projectId in sessionStorage
+ * 3. "Manage accounts" section for full OAuth revocation
+ *
+ * Vocabulary: Source = provider, Document = file.
+ */
+export function ConnectSourceSheet({ onClose }: ConnectSourceSheetProps) {
+  const {
+    connections,
+    linkConnection,
+    connectDrive,
+    disconnectDrive,
+    refetchDriveAccounts,
+    projectId,
+  } = useSourcesContext();
+
+  // Fetch user-level accounts locally — NOT from context
+  const { accounts: userAccounts, isLoading, refetch: refetchAccounts } = useDriveAccounts();
+
+  const [isLinking, setIsLinking] = useState<string | null>(null);
+  const [showManage, setShowManage] = useState(false);
+  const [confirmRevokeId, setConfirmRevokeId] = useState<string | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  // Filter out accounts already linked to this project
+  const linkedDriveConnectionIds = useMemo(
+    () => new Set(connections.map((c) => c.driveConnectionId)),
+    [connections],
+  );
+
+  const availableAccounts = useMemo(
+    () => userAccounts.filter((a) => !linkedDriveConnectionIds.has(a.id)),
+    [userAccounts, linkedDriveConnectionIds],
+  );
+
+  const handleLink = useCallback(
+    async (account: DriveAccount) => {
+      setIsLinking(account.id);
+      try {
+        await linkConnection(account.id);
+        // If this was the last available account, close the sheet
+        if (availableAccounts.length <= 1) {
+          onClose();
+        }
+      } catch (err) {
+        console.error("Failed to link connection:", err);
+      } finally {
+        setIsLinking(null);
+      }
+    },
+    [linkConnection, availableAccounts.length, onClose],
+  );
+
+  const handleConnectNew = useCallback(() => {
+    // Store projectId for auto-link after OAuth return (sessionStorage)
+    try {
+      sessionStorage.setItem(SOURCE_LINK_KEY, projectId);
+    } catch {
+      // sessionStorage unavailable — pid fallback in OAuth state handles this
+    }
+    // Also pass projectId to backend for encoding in OAuth state (iPad Safari fallback)
+    connectDrive(undefined, projectId);
+  }, [connectDrive, projectId]);
+
+  const handleRevoke = useCallback(
+    async (connectionId: string) => {
+      setIsRevoking(true);
+      try {
+        await disconnectDrive(connectionId);
+        await refetchDriveAccounts();
+        await refetchAccounts();
+        setConfirmRevokeId(null);
+      } catch (err) {
+        console.error("Failed to revoke:", err);
+      } finally {
+        setIsRevoking(false);
+      }
+    },
+    [disconnectDrive, refetchDriveAccounts, refetchAccounts],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col px-4 py-6 flex-1">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-medium text-gray-900">Connect a source</h3>
+          <button
+            onClick={onClose}
+            className="text-sm text-gray-500 hover:text-gray-700 min-h-[44px] min-w-[44px]
+                       flex items-center justify-center"
+            aria-label="Close"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+        <p className="text-sm text-gray-500">Loading accounts...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col px-4 py-4 flex-1">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium text-gray-900">Connect a source</h3>
+        <button
+          onClick={onClose}
+          className="text-sm text-gray-500 hover:text-gray-700 min-h-[44px] min-w-[44px]
+                     flex items-center justify-center"
+          aria-label="Close"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+
+      {!showManage ? (
+        <>
+          {/* Available accounts to link */}
+          {availableAccounts.length > 0 && (
+            <div className="mb-3">
+              <p className="text-xs text-gray-500 mb-2">
+                Link a Google Drive account to this book:
+              </p>
+              <div className="flex flex-col gap-1">
+                {availableAccounts.map((account) => (
+                  <button
+                    key={account.id}
+                    onClick={() => handleLink(account)}
+                    disabled={isLinking === account.id}
+                    className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+                               transition-colors min-h-[44px] w-full text-left
+                               disabled:opacity-50"
+                  >
+                    <svg className="w-5 h-5 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                      <path
+                        d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z"
+                        className="text-blue-500"
+                      />
+                    </svg>
+                    <span className="text-sm text-gray-900 truncate flex-1">{account.email}</span>
+                    <span className="text-xs text-blue-600 font-medium shrink-0">
+                      {isLinking === account.id ? "Linking..." : "Link"}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Connect new account */}
+          <button
+            onClick={handleConnectNew}
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+                       transition-colors min-h-[44px] w-full text-left"
+          >
+            <svg
+              className="w-5 h-5 shrink-0 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            <span className="text-sm text-gray-700">Connect new Google Drive account</span>
+          </button>
+
+          {/* Manage accounts link */}
+          {userAccounts.length > 0 && (
+            <div className="mt-4 pt-3 border-t border-gray-100">
+              <button
+                onClick={() => setShowManage(true)}
+                className="text-xs text-gray-400 hover:text-gray-600 transition-colors
+                           min-h-[44px] px-1"
+              >
+                Manage accounts
+              </button>
+            </div>
+          )}
+        </>
+      ) : (
+        <>
+          {/* Manage accounts view — full OAuth revocation */}
+          <button
+            onClick={() => {
+              setShowManage(false);
+              setConfirmRevokeId(null);
+            }}
+            className="text-xs text-gray-500 hover:text-gray-700 min-h-[44px] flex items-center gap-1 mb-2"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            Back
+          </button>
+
+          <p className="text-xs text-gray-500 mb-2">
+            Revoking access removes the account from all books and deletes stored tokens.
+          </p>
+
+          <div className="flex flex-col gap-1">
+            {userAccounts.map((account) => (
+              <div key={account.id}>
+                <div className="flex items-center gap-2 px-1 min-h-[44px]">
+                  <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                    <path
+                      d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z"
+                      className="text-blue-500"
+                    />
+                  </svg>
+                  <span className="text-xs text-gray-700 truncate flex-1">{account.email}</span>
+
+                  {confirmRevokeId !== account.id && (
+                    <button
+                      onClick={() => setConfirmRevokeId(account.id)}
+                      className="text-xs text-gray-400 hover:text-red-600 transition-colors
+                                 min-h-[44px] flex items-center shrink-0"
+                    >
+                      Revoke access
+                    </button>
+                  )}
+                </div>
+
+                {/* Inline confirmation */}
+                {confirmRevokeId === account.id && (
+                  <div className="px-1 py-2 bg-gray-50 rounded-lg mx-1 mb-1">
+                    <p className="text-xs text-gray-600 mb-2">
+                      Revoke access for {account.email}? Documents from this source will be archived
+                      in all books.
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <button
+                        onClick={() => handleRevoke(account.id)}
+                        disabled={isRevoking}
+                        className="text-xs font-medium text-red-600 hover:text-red-700
+                                   min-h-[36px] px-2 disabled:opacity-50"
+                      >
+                        {isRevoking ? "Revoking..." : "Confirm"}
+                      </button>
+                      <button
+                        onClick={() => setConfirmRevokeId(null)}
+                        disabled={isRevoking}
+                        className="text-xs text-gray-500 hover:text-gray-700
+                                   min-h-[36px] px-2 disabled:opacity-50"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          {userAccounts.length === 0 && (
+            <p className="text-xs text-gray-400 py-2 px-1">No accounts connected.</p>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/sources/source-picker.tsx
+++ b/web/src/components/sources/source-picker.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import type { DriveAccount } from "@/hooks/use-drive-accounts";
+import type { SourceConnection } from "@/hooks/use-sources";
 
 interface SourcePickerProps {
-  /** Connected Drive accounts */
-  driveAccounts: DriveAccount[];
-  /** Called when user picks a connected Drive account to browse */
-  onSelectAccount: (account: DriveAccount) => void;
-  /** Called when user wants to connect a new Google Drive */
-  onConnectDrive: () => void;
+  /** Project-scoped Drive connections */
+  connections: SourceConnection[];
+  /** Called when user picks a project-linked connection to browse */
+  onSelectConnection: (connection: SourceConnection) => void;
+  /** Called when user wants to connect a source (opens ConnectSourceSheet) */
+  onConnectSource: () => void;
   /** Called when user wants to upload from this device */
   onUploadLocal: () => void;
   /** Called when user taps Cancel */
@@ -18,16 +18,17 @@ interface SourcePickerProps {
 /**
  * SourcePicker — inline panel for choosing where to add documents from.
  *
- * Shows connected sources as full-width rows, plus "This device" for local upload.
- * If multiple sources exist, shows each individually. Includes "Connect another source"
- * when at least one source is already connected.
+ * Shows project-linked Drive connections, "This device" for local upload,
+ * and "Connect a source" for linking new accounts.
  *
  * 44pt touch targets throughout. iPad-first.
+ *
+ * Vocabulary: Source = provider, Folder = directory, Document = file.
  */
 export function SourcePicker({
-  driveAccounts,
-  onSelectAccount,
-  onConnectDrive,
+  connections,
+  onSelectConnection,
+  onConnectSource,
   onUploadLocal,
   onCancel,
 }: SourcePickerProps) {
@@ -36,11 +37,11 @@ export function SourcePicker({
       <h3 className="text-sm font-medium text-gray-900 mb-3">Add documents from</h3>
 
       <div className="flex flex-col gap-1">
-        {/* Connected Drive accounts */}
-        {driveAccounts.map((account) => (
+        {/* Project-linked Drive connections */}
+        {connections.map((connection) => (
           <button
-            key={account.id}
-            onClick={() => onSelectAccount(account)}
+            key={connection.driveConnectionId}
+            onClick={() => onSelectConnection(connection)}
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
                        transition-colors min-h-[44px] w-full text-left"
           >
@@ -50,26 +51,9 @@ export function SourcePicker({
                 className="text-blue-500"
               />
             </svg>
-            <span className="text-sm text-gray-900 truncate">{account.email}</span>
+            <span className="text-sm text-gray-900 truncate">{connection.email}</span>
           </button>
         ))}
-
-        {/* Connect Google Drive (when no accounts connected) */}
-        {driveAccounts.length === 0 && (
-          <button
-            onClick={onConnectDrive}
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
-                       transition-colors min-h-[44px] w-full text-left"
-          >
-            <svg className="w-5 h-5 shrink-0" viewBox="0 0 24 24" fill="currentColor">
-              <path
-                d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z"
-                className="text-blue-500"
-              />
-            </svg>
-            <span className="text-sm text-gray-900">Google Drive</span>
-          </button>
-        )}
 
         {/* This device */}
         <button
@@ -93,29 +77,22 @@ export function SourcePicker({
           <span className="text-sm text-gray-900">This device</span>
         </button>
 
-        {/* Connect another source (when accounts already exist) */}
-        {driveAccounts.length > 0 && (
-          <button
-            onClick={onConnectDrive}
-            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
-                       transition-colors min-h-[44px] w-full text-left"
+        {/* Connect a source */}
+        <button
+          onClick={onConnectSource}
+          className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+                     transition-colors min-h-[44px] w-full text-left"
+        >
+          <svg
+            className="w-5 h-5 shrink-0 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <svg
-              className="w-5 h-5 shrink-0 text-gray-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 4v16m8-8H4"
-              />
-            </svg>
-            <span className="text-sm text-gray-500">Connect another source</span>
-          </button>
-        )}
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          <span className="text-sm text-gray-500">Connect a source</span>
+        </button>
       </div>
 
       {/* Cancel */}

--- a/web/src/contexts/sources-context.tsx
+++ b/web/src/contexts/sources-context.tsx
@@ -12,7 +12,7 @@ import {
 import { useSourceAnalysis } from "@/hooks/use-source-analysis";
 import { useAIInstructions, type AIInstruction } from "@/hooks/use-ai-instructions";
 import { useSourcesPanel, type SourcesTab } from "@/hooks/use-sources-panel";
-import { useDriveAccounts, type DriveAccount } from "@/hooks/use-drive-accounts";
+import { useDriveAccounts } from "@/hooks/use-drive-accounts";
 import type { ChapterEditorHandle } from "@/components/editor/chapter-editor";
 
 // ── Context Value Type ──
@@ -77,10 +77,9 @@ interface SourcesContextValue {
   ) => Promise<void>;
   removeInstruction: (id: string) => Promise<void>;
 
-  // Drive accounts
-  driveAccounts: DriveAccount[];
-  driveConnected: boolean;
-  connectDrive: (loginHint?: string) => Promise<void>;
+  // Drive accounts (user-level — only for connect/disconnect flows)
+  hasUserDriveAccounts: boolean;
+  connectDrive: (loginHint?: string, projectId?: string) => Promise<void>;
   disconnectDrive: (connectionId: string) => Promise<void>;
   refetchDriveAccounts: () => Promise<void>;
 
@@ -167,9 +166,8 @@ export function SourcesProvider({ projectId, editorRef, children }: SourcesProvi
       await Promise.allSettled([analysisInstructions.remove(id), rewriteInstructions.remove(id)]);
     },
 
-    // Drive
-    driveAccounts: driveAccountsHook.accounts,
-    driveConnected: driveAccountsHook.connected,
+    // Drive (user-level — only for connect/disconnect flows)
+    hasUserDriveAccounts: driveAccountsHook.accounts.length > 0,
     connectDrive: driveAccountsHook.connect,
     disconnectDrive: driveAccountsHook.disconnect,
     refetchDriveAccounts: driveAccountsHook.refetch,

--- a/web/src/hooks/use-drive-accounts.ts
+++ b/web/src/hooks/use-drive-accounts.ts
@@ -61,14 +61,16 @@ export function useDriveAccounts(options: UseDriveAccountsOptions = {}) {
     }
   }, [enabled, fetchAccounts]);
 
-  /** Initiate Google OAuth flow. Optional loginHint pre-selects the account. */
+  /** Initiate Google OAuth flow. Optional loginHint pre-selects the account. Optional projectId for auto-link on return. */
   const connect = useCallback(
-    async (loginHint?: string) => {
+    async (loginHint?: string, projectId?: string) => {
       try {
         const token = await getToken();
-        const url = loginHint
-          ? `${API_URL}/drive/authorize?loginHint=${encodeURIComponent(loginHint)}`
-          : `${API_URL}/drive/authorize`;
+        const params = new URLSearchParams();
+        if (loginHint) params.set("loginHint", loginHint);
+        if (projectId) params.set("projectId", projectId);
+        const qs = params.toString();
+        const url = qs ? `${API_URL}/drive/authorize?${qs}` : `${API_URL}/drive/authorize`;
 
         const response = await fetch(url, {
           headers: {

--- a/web/test/components/editor-toolbar.test.tsx
+++ b/web/test/components/editor-toolbar.test.tsx
@@ -18,6 +18,7 @@ vi.mock("@/contexts/sources-context", () => ({
   useSourcesContext: () => ({
     isPanelOpen: false,
     togglePanel: vi.fn(),
+    connections: [],
   }),
 }));
 
@@ -70,7 +71,6 @@ function makeProps(overrides?: Partial<React.ComponentProps<typeof EditorToolbar
     selectionWordCount: 0,
     aiSheetState: "idle" as const,
     onOpenAiRewrite: vi.fn(),
-    driveAccounts: [],
     projectId: "proj-1",
     activeChapterId: "ch-1",
     getToken: vi.fn().mockResolvedValue("token"),


### PR DESCRIPTION
## Summary

- **Fixes cross-project Drive account leakage** — all project UI (Sources, Export) now reads from project-scoped `connections` instead of user-level `driveAccounts`
- **New ConnectSourceSheet** is the sole place user-level accounts are fetched, only for the purpose of linking to the current book
- **Backend encodes `projectId` in OAuth state** as a fallback for iPad Safari where sessionStorage can be lost during tab suspension

## Changes

| File | Change |
|------|--------|
| `sources-context.tsx` | Remove `driveAccounts`/`driveConnected`, add `hasUserDriveAccounts` boolean |
| `connect-source-sheet.tsx` | **New** — link user-level accounts to project, manage accounts with OAuth revocation |
| `library-tab.tsx` | Use project `connections`, migration banner for existing books, connect flow |
| `source-picker.tsx` | Accept `SourceConnection[]` instead of `DriveAccount[]` |
| `sources-section.tsx` | Use `connections`/`unlinkConnection`, label "Remove" instead of "Disconnect" |
| `export-menu.tsx` | Accept `SourceConnection[]`, use `driveConnectionId` for API calls |
| `editor-toolbar.tsx` | Remove `driveAccounts` prop, read `connections` from context |
| `editor/[projectId]/page.tsx` | Remove standalone `useDriveAccounts()` call |
| `drive.ts` (backend) | Encode `projectId` in OAuth state, pass `pid` to success page |
| `drive/success/page.tsx` | Read `pid` from URL as sessionStorage fallback |
| `onboarding-tooltips.tsx` | Add Sources button tooltip for first-run discoverability |
| `editor-toolbar.test.tsx` | Update mock and props for removed `driveAccounts` |

## Test plan

- [ ] Create a new book — Sources Library: empty state, no Drive accounts visible; "Add Documents" opens connect sheet; Export menu has no "Save to Drive"
- [ ] Open existing book with no project connections — migration banner appears; "Connect Now" opens connect sheet; after linking, banner disappears
- [ ] Link a Drive account — Source picker shows only linked account; Export "Save to Drive" shows only linked account; "Your Sources" shows "Remove" label
- [ ] Create a second book — first book's connection does NOT appear
- [ ] "Manage accounts" in connect sheet — full OAuth revocation works
- [ ] OAuth flow on iPad Safari — `pid` fallback auto-links when sessionStorage fails
- [ ] `npm run lint && npm run typecheck && npm test` — all 661 tests pass, lint/typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)