### PR TITLE
fix: eliminate user-level Drive account leakage from project UI

### DIFF
--- a/web/src/components/sources/library-tab.tsx
+++ b/web/src/components/sources/library-tab.tsx
@@ -26,14 +26,8 @@ type ViewMode = "list" | "picker" | "browse" | "connect";
  * Vocabulary: Source = provider, Folder = directory, Document = file.
  */
 export function LibraryTab() {
-  const {
-    sources,
-    isLoadingSources,
-    connections,
-    hasUserDriveAccounts,
-    connectDrive,
-    uploadLocalFile,
-  } = useSourcesContext();
+  const { sources, isLoadingSources, connections, connectDrive, uploadLocalFile } =
+    useSourcesContext();
 
   const [viewMode, setViewMode] = useState<ViewMode>("list");
   const [isUploading, setIsUploading] = useState(false);
@@ -67,15 +61,12 @@ export function LibraryTab() {
   );
 
   const handleAddDocuments = useCallback(() => {
-    if (connections.length === 0) {
-      // No project connections — go straight to connect flow
-      setViewMode("connect");
-    } else if (connections.length === 1) {
+    if (connections.length === 1) {
       // Exactly 1 connection — skip picker, go straight to browse
       setSelectedConnectionIndex(0);
       setViewMode("browse");
     } else {
-      // 2+ connections — show picker
+      // 0 or 2+ connections — show picker (generic choices: Google Drive / This device)
       setViewMode("picker");
     }
   }, [connections.length]);
@@ -133,7 +124,7 @@ export function LibraryTab() {
         <SourcePicker
           connections={connections}
           onSelectConnection={handleSelectConnection}
-          onConnectSource={() => setViewMode("connect")}
+          onConnectDrive={() => setViewMode("connect")}
           onUploadLocal={handleUploadLocal}
           onCancel={() => setViewMode("list")}
         />
@@ -201,35 +192,6 @@ export function LibraryTab() {
 
   // Empty state: no documents in this project
   if (sources.length === 0) {
-    // Migration banner: project has no connections but user has user-level accounts
-    const showMigrationBanner = connections.length === 0 && hasUserDriveAccounts;
-
-    if (showMigrationBanner) {
-      return (
-        <div className="flex flex-col flex-1 min-h-0">
-          {fileInput}
-          <EmptyState
-            icon={
-              <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={1.5}
-                  d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
-                />
-              </svg>
-            }
-            message="Connect your sources to this book"
-            description="Your Google Drive accounts are now managed per book. Connect your accounts to use Drive with this book."
-            action={{
-              label: "Connect Now",
-              onClick: () => setViewMode("connect"),
-            }}
-          />
-        </div>
-      );
-    }
-
     return (
       <div className="flex flex-col flex-1 min-h-0">
         {fileInput}

--- a/web/src/components/sources/source-picker.tsx
+++ b/web/src/components/sources/source-picker.tsx
@@ -7,8 +7,8 @@ interface SourcePickerProps {
   connections: SourceConnection[];
   /** Called when user picks a project-linked connection to browse */
   onSelectConnection: (connection: SourceConnection) => void;
-  /** Called when user wants to connect a source (opens ConnectSourceSheet) */
-  onConnectSource: () => void;
+  /** Called when user wants to connect Google Drive (opens ConnectSourceSheet) */
+  onConnectDrive: () => void;
   /** Called when user wants to upload from this device */
   onUploadLocal: () => void;
   /** Called when user taps Cancel */
@@ -18,8 +18,11 @@ interface SourcePickerProps {
 /**
  * SourcePicker — inline panel for choosing where to add documents from.
  *
- * Shows project-linked Drive connections, "This device" for local upload,
- * and "Connect a source" for linking new accounts.
+ * When project has linked connections: shows each linked account + "This device" + "Connect another source"
+ * When project has NO connections: shows generic "Google Drive" + "This device" (no account emails)
+ *
+ * User-level account details are NEVER shown here. The ConnectSourceSheet
+ * (opened by onConnectDrive) is the only place where account emails appear.
  *
  * 44pt touch targets throughout. iPad-first.
  *
@@ -28,20 +31,41 @@ interface SourcePickerProps {
 export function SourcePicker({
   connections,
   onSelectConnection,
-  onConnectSource,
+  onConnectDrive,
   onUploadLocal,
   onCancel,
 }: SourcePickerProps) {
+  const hasConnections = connections.length > 0;
+
   return (
     <div className="flex flex-col px-4 py-4 flex-1">
       <h3 className="text-sm font-medium text-gray-900 mb-3">Add documents from</h3>
 
       <div className="flex flex-col gap-1">
-        {/* Project-linked Drive connections */}
-        {connections.map((connection) => (
+        {hasConnections ? (
+          <>
+            {/* Project-linked Drive connections (show account emails) */}
+            {connections.map((connection) => (
+              <button
+                key={connection.driveConnectionId}
+                onClick={() => onSelectConnection(connection)}
+                className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+                           transition-colors min-h-[44px] w-full text-left"
+              >
+                <svg className="w-5 h-5 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+                  <path
+                    d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z"
+                    className="text-blue-500"
+                  />
+                </svg>
+                <span className="text-sm text-gray-900 truncate">{connection.email}</span>
+              </button>
+            ))}
+          </>
+        ) : (
+          /* No project connections — show generic "Google Drive" (no emails, no account details) */
           <button
-            key={connection.driveConnectionId}
-            onClick={() => onSelectConnection(connection)}
+            onClick={onConnectDrive}
             className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
                        transition-colors min-h-[44px] w-full text-left"
           >
@@ -51,9 +75,9 @@ export function SourcePicker({
                 className="text-blue-500"
               />
             </svg>
-            <span className="text-sm text-gray-900 truncate">{connection.email}</span>
+            <span className="text-sm text-gray-900">Google Drive</span>
           </button>
-        ))}
+        )}
 
         {/* This device */}
         <button
@@ -77,22 +101,29 @@ export function SourcePicker({
           <span className="text-sm text-gray-900">This device</span>
         </button>
 
-        {/* Connect a source */}
-        <button
-          onClick={onConnectSource}
-          className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
-                     transition-colors min-h-[44px] w-full text-left"
-        >
-          <svg
-            className="w-5 h-5 shrink-0 text-gray-400"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
+        {/* Connect another source (only when at least one already linked) */}
+        {hasConnections && (
+          <button
+            onClick={onConnectDrive}
+            className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+                       transition-colors min-h-[44px] w-full text-left"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-          </svg>
-          <span className="text-sm text-gray-500">Connect a source</span>
-        </button>
+            <svg
+              className="w-5 h-5 shrink-0 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4v16m8-8H4"
+              />
+            </svg>
+            <span className="text-sm text-gray-500">Connect another source</span>
+          </button>
+        )}
       </div>
 
       {/* Cancel */}

--- a/web/src/contexts/sources-context.tsx
+++ b/web/src/contexts/sources-context.tsx
@@ -77,8 +77,7 @@ interface SourcesContextValue {
   ) => Promise<void>;
   removeInstruction: (id: string) => Promise<void>;
 
-  // Drive accounts (user-level — only for connect/disconnect flows)
-  hasUserDriveAccounts: boolean;
+  // Drive accounts (user-level — only for connect/disconnect flows, never surfaced in project UI)
   connectDrive: (loginHint?: string, projectId?: string) => Promise<void>;
   disconnectDrive: (connectionId: string) => Promise<void>;
   refetchDriveAccounts: () => Promise<void>;
@@ -107,7 +106,9 @@ export function SourcesProvider({ projectId, editorRef, children }: SourcesProvi
   const analysis = useSourceAnalysis();
   const analysisInstructions = useAIInstructions("analysis");
   const rewriteInstructions = useAIInstructions("rewrite");
-  const driveAccountsHook = useDriveAccounts();
+  // Disable auto-fetch: user-level accounts are only fetched inside ConnectSourceSheet.
+  // We only need the connect/disconnect/refetch functions from this hook.
+  const driveAccountsHook = useDriveAccounts({ enabled: false });
 
   const value: SourcesContextValue = {
     // Panel
@@ -166,8 +167,7 @@ export function SourcesProvider({ projectId, editorRef, children }: SourcesProvi
       await Promise.allSettled([analysisInstructions.remove(id), rewriteInstructions.remove(id)]);
     },
 
-    // Drive (user-level — only for connect/disconnect flows)
-    hasUserDriveAccounts: driveAccountsHook.accounts.length > 0,
+    // Drive (user-level — only for connect/disconnect flows, never surfaced in project UI)
     connectDrive: driveAccountsHook.connect,
     disconnectDrive: driveAccountsHook.disconnect,
     refetchDriveAccounts: driveAccountsHook.refetch,


### PR DESCRIPTION
## Summary

- **Removes migration banner** that proactively revealed user-level accounts to project UI ("Your Google Drive accounts are now managed per book")
- **Adds generic picker step** before any account emails appear — new book sees "Google Drive" / "This device", not email addresses
- **Removes `hasUserDriveAccounts`** from context — zero user-level data flows through project scope
- **Disables auto-fetch** of user-level accounts in SourcesProvider — only fetched when ConnectSourceSheet explicitly opens

## Root cause

PR #267 fixed the data layer but left the UX flow leaking: "Add Documents" with 0 connections jumped straight to ConnectSourceSheet (showing account emails), and a migration banner explicitly mentioned "Your Google Drive accounts."

## New flow for a new book

1. Sources panel → generic empty state: "Add documents to your library"
2. Click "Add Documents" → Picker: **"Google Drive"** / **"This device"** (no emails)
3. Click "Google Drive" → ConnectSourceSheet opens → account emails appear for linking
4. Click "This device" → file picker opens

Account emails only surface after the user explicitly chooses "Google Drive" from the generic picker.

## Test plan

- [ ] Create new book → Sources Library shows "Add documents to your library" (no mention of Drive accounts)
- [ ] Click "Add Documents" → shows "Google Drive" / "This device" (generic, no emails)
- [ ] Click "Google Drive" → ConnectSourceSheet shows accounts for linking
- [ ] Click "This device" → file picker opens
- [ ] After linking account → "Add Documents" skips picker, goes straight to browse
- [ ] Export menu shows no "Save to Drive" until account is linked to this book
- [ ] Create second book → first book's linked account does NOT appear
- [ ] All 661 tests pass, lint/typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)