### PR TITLE
fix: Sources panel UX — terminology, auto-open, vocabulary

### DIFF
--- a/web/src/components/editor/onboarding-tooltips.tsx
+++ b/web/src/components/editor/onboarding-tooltips.tsx
@@ -32,7 +32,7 @@ const STEPS: OnboardingStep[] = [
   },
   {
     key: "sources",
-    text: "Import reference documents from Google Drive or your device.",
+    text: "Add documents from Google Drive or your device.",
     target: "sources",
   },
   {

--- a/web/src/components/sources/library-tab.tsx
+++ b/web/src/components/sources/library-tab.tsx
@@ -194,6 +194,38 @@ export function LibraryTab() {
 
   // Empty state: no documents in this project
   if (sources.length === 0) {
+    // State A: No connections AND no documents — guide user to connect a source first
+    if (connections.length === 0) {
+      return (
+        <div className="flex flex-col flex-1 min-h-0">
+          {fileInput}
+          <EmptyState
+            icon={
+              <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+                />
+              </svg>
+            }
+            message="Connect a source to get started"
+            description="Link your Google Drive to browse and add documents."
+            action={{
+              label: "Connect Google Drive",
+              onClick: handleConnectDriveOAuth,
+            }}
+            secondaryAction={{
+              label: "Upload from this device",
+              onClick: handleUploadLocal,
+            }}
+          />
+        </div>
+      );
+    }
+
+    // State B: 1+ connections but no documents yet — guide user to add documents
     return (
       <div className="flex flex-col flex-1 min-h-0">
         {fileInput}
@@ -209,12 +241,14 @@ export function LibraryTab() {
             </svg>
           }
           message="Add documents to your library"
-          description="Import from Google Drive or your device."
+          description="Browse your connected source to add documents."
           action={{
             label: "Add Documents",
             onClick: handleAddDocuments,
           }}
         />
+        {/* Show connected sources at bottom */}
+        <SourcesSection onAddSource={handleConnectDriveOAuth} />
       </div>
     );
   }

--- a/web/src/components/sources/source-picker.tsx
+++ b/web/src/components/sources/source-picker.tsx
@@ -121,7 +121,7 @@ export function SourcePicker({
                 d="M12 4v16m8-8H4"
               />
             </svg>
-            <span className="text-sm text-gray-500">Connect another source</span>
+            <span className="text-sm text-gray-500">+ Connect another source</span>
           </button>
         )}
       </div>

--- a/web/src/components/sources/sources-section.tsx
+++ b/web/src/components/sources/sources-section.tsx
@@ -69,9 +69,9 @@ export function SourcesSection({ onAddSource }: SourcesSectionProps) {
           }}
           className="text-xs text-blue-600 hover:text-blue-700 min-h-[44px] min-w-[44px]
                      flex items-center justify-center"
-          aria-label="Add source"
+          aria-label="Connect source"
         >
-          + Add
+          + Connect
         </button>
       </button>
 


### PR DESCRIPTION
## Summary

- **Split empty state by connection count**: New books (0 connections) see "Connect a source to get started" with "Connect Google Drive" primary CTA. Books with 1+ connections see "Add documents to your library" with "Add Documents" CTA and connected sources listed below.
- **Auto-open panel after OAuth return**: Success page sets sessionStorage signal + `?sources=open` URL param (iPad Safari fallback). `SourcesProvider` reads both on mount and opens the panel automatically.
- **Fix vocabulary**: All "research source" instances replaced with correct product terminology. "+ Add" → "+ Connect" in Your Sources section. Onboarding tooltip: "Import reference documents" → "Add documents".

## Files changed (6)

| File | Change |
|------|--------|
| `library-tab.tsx` | Split empty state: 0 connections → "Connect a Source", 1+ → "Add Documents" |
| `drive/success/page.tsx` | Extract `navigateToDestination`, set sessionStorage + URL param, fix vocabulary |
| `sources-context.tsx` | Add auto-open `useEffect` in SourcesProvider |
| `sources-section.tsx` | "+ Add" → "+ Connect", fix aria-label |
| `source-picker.tsx` | Relabel "+ Connect another source" |
| `onboarding-tooltips.tsx` | "Import reference documents" → "Add documents" |

## Test plan

- [ ] New book → open Sources panel → see "Connect a source to get started" with "Connect Google Drive" button (NOT "Add Documents")
- [ ] Click "Connect Google Drive" → OAuth → return → panel auto-opens showing Library tab
- [ ] "Your Sources" section shows "+ Connect" (not "+ Add")
- [ ] After connecting, empty state shows "Add documents to your library" with "Add Documents" button
- [ ] Click "Add Documents" → goes to DriveBrowser (1 connection) or picker (2+)
- [ ] Picker with 2+ connections shows each connection + "This device" + "+ Connect another source"
- [ ] Success page says "Source connected" / "Connecting source..." (not "research source")
- [ ] iPad Safari: verify auto-open works via URL param fallback
- [ ] `npm run lint && npm run typecheck && npm test` — all pass (661 tests, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)