### PR TITLE
fix: remove auto-download on export — require explicit user choice

### DIFF
--- a/web/src/components/project/export-menu.tsx
+++ b/web/src/components/project/export-menu.tsx
@@ -147,8 +147,8 @@ export function ExportMenu({
             jobId: result.jobId,
           });
 
-          // Trigger download automatically
-          await triggerDownload(result.downloadUrl, result.fileName, token);
+          // No auto-download — user must choose a destination explicitly.
+          // The completion toast presents Download and Save to Drive options.
         } else {
           setState({ phase: "error", message: "Export completed but no download available" });
         }
@@ -414,8 +414,9 @@ export function ExportMenu({
               />
             </svg>
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-green-800">Export complete</p>
+              <p className="text-sm font-medium text-green-800">Export ready</p>
               <p className="text-xs text-green-600 truncate mt-0.5">{state.fileName}</p>
+              <p className="text-xs text-gray-500 mt-1">Where would you like to save it?</p>
               <div className="mt-2 flex flex-wrap gap-2">
                 <button
                   onClick={async () => {


### PR DESCRIPTION
## Summary

- **Removed auto-download** that fired immediately on export completion, before the user could choose a destination
- **Reframed completion toast** from "Export complete" (past tense, already happened) to "Export ready — Where would you like to save it?" (asking, user decides)
- Download and Save to Drive buttons were already present — auto-download just bypassed them

The `triggerDownload` utility is retained for the manual Download button.

Closes #302

## Test plan

- [ ] Export Book as PDF — verify file does NOT auto-download
- [ ] Toast appears with "Export ready" and "Where would you like to save it?"
- [ ] Tapping "Download" downloads the file
- [ ] Tapping "Save to Drive" saves to Drive (if connected)
- [ ] Dismissing toast without choosing does nothing (file stays server-side)
- [ ] iPad Safari: same behavior, no auto-download

🤖 Generated with [Claude Code](https://claude.com/claude-code)