### PR TITLE
fix: patch review findings and add markdown cache remediation

### DIFF
--- a/web/src/hooks/use-auto-save.ts
+++ b/web/src/hooks/use-auto-save.ts
@@ -18,7 +18,7 @@ export type SaveStatus =
   | { state: "error"; message: string };
 
 /**
- * Recovery state when IndexedDB content is newer than remote.
+ * Recovery state when IndexedDB content is at least as recent as remote.
  */
 export interface RecoveryPrompt {
   localContent: string;
@@ -300,8 +300,8 @@ export function useAutoSave({
   }, [saveNow]);
 
   /**
-   * Crash recovery check: on mount, compare IndexedDB with remote.
-   * Per US-015: if IndexedDB is newer, prompt user to restore.
+   * Crash recovery check: on mount, compare IndexedDB version with remote.
+   * Per US-015: only prompt when local draft version is not older than remote.
    */
   useEffect(() => {
     if (!chapterId) return;
@@ -312,10 +312,7 @@ export function useAutoSave({
       const draft = await loadDraft(chapterId!);
       if (cancelled) return;
 
-      if (draft && draft.content) {
-        // IndexedDB has content - check if it's newer than remote
-        // If there's a draft with a version matching or greater than the server version,
-        // and it has different content, prompt for recovery
+      if (draft && draft.content && draft.version >= version) {
         setRecoveryPrompt({
           localContent: draft.content,
           localUpdatedAt: draft.updatedAt,

--- a/web/test/hooks/use-auto-save.test.ts
+++ b/web/test/hooks/use-auto-save.test.ts
@@ -413,7 +413,7 @@ describe("useAutoSave", () => {
     );
   });
 
-  it("recovery prompt is set when IndexedDB has a draft", async () => {
+  it("recovery prompt is set when IndexedDB draft version matches remote", async () => {
     mockFetchSuccess();
     mockLoadDraft.mockResolvedValue({
       chapterId: "ch-1",
@@ -432,6 +432,24 @@ describe("useAutoSave", () => {
     expect(result.current.recoveryPrompt).not.toBeNull();
     expect(result.current.recoveryPrompt!.localContent).toBe("<p>Recovered content</p>");
     expect(result.current.recoveryPrompt!.remoteVersion).toBe(1);
+  });
+
+  it("no recovery prompt when IndexedDB draft version is older than remote", async () => {
+    mockFetchSuccess();
+    mockLoadDraft.mockResolvedValue({
+      chapterId: "ch-1",
+      content: "<p>Old draft</p>",
+      updatedAt: Date.now(),
+      version: 1,
+    });
+
+    const { result } = renderHook(() => useAutoSave(makeOptions({ version: 2 })));
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.recoveryPrompt).toBeNull();
   });
 
   it("dismissRecovery clears the prompt and deletes draft from IndexedDB", async () => {

--- a/workers/dc-api/src/routes/drive.ts
+++ b/workers/dc-api/src/routes/drive.ts
@@ -226,15 +226,15 @@ drive.get("/picker-token/:connectionId", pickerTokenRateLimit, async (c) => {
   const connectionId = c.req.param("connectionId");
   const driveService = new DriveService(c.env);
 
-  const tokens = await driveService.getValidTokensByConnection(connectionId);
-  if (!tokens) {
-    driveNotConnected();
-  }
-
   // Verify this connection belongs to the user
   const connections = await driveService.getConnectionsForUser(userId);
   if (!connections.some((conn) => conn.id === connectionId)) {
     driveNotConnected("Connection not found for this user");
+  }
+
+  const tokens = await driveService.getValidTokensByConnection(connectionId);
+  if (!tokens) {
+    driveNotConnected();
   }
 
   // Calculate remaining lifetime in seconds

--- a/workers/dc-api/src/routes/sources.ts
+++ b/workers/dc-api/src/routes/sources.ts
@@ -5,6 +5,7 @@
  * - POST /projects/:projectId/sources - Add Drive sources from Google Picker selection
  * - POST /projects/:projectId/sources/upload - Upload local file (.txt, .md)
  * - GET /projects/:projectId/sources - List sources for a project
+ * - POST /projects/:projectId/sources/remediate-markdown - Reprocess cached local Markdown sources
  * - GET /sources/:sourceId/content - Get cached source content (lazy-fetches from Drive)
  * - DELETE /sources/:sourceId - Remove a source
  * - POST /sources/:sourceId/import-as-chapter - Import source as a new chapter
@@ -114,6 +115,20 @@ sources.get("/projects/:projectId/sources", async (c) => {
   const list = await service.listSources(userId, projectId);
 
   return c.json({ sources: list });
+});
+
+/**
+ * POST /projects/:projectId/sources/remediate-markdown
+ * Reprocess cached local Markdown sources to remove unsafe legacy HTML and rebuild FTS.
+ */
+sources.post("/projects/:projectId/sources/remediate-markdown", async (c) => {
+  const { userId } = c.get("auth");
+  const projectId = c.req.param("projectId");
+
+  const service = new SourceMaterialService(c.env.DB, c.env.EXPORTS_BUCKET);
+  const result = await service.remediateLocalMarkdownSources(userId, projectId);
+
+  return c.json(result);
 });
 
 /**

--- a/workers/dc-api/src/services/chapter.ts
+++ b/workers/dc-api/src/services/chapter.ts
@@ -152,7 +152,7 @@ export class ChapterService {
   async listChapters(userId: string, projectId: string): Promise<Chapter[]> {
     // Verify project ownership
     const project = await this.db
-      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ?`)
+      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`)
       .bind(projectId, userId)
       .first();
 
@@ -188,7 +188,7 @@ export class ChapterService {
         `SELECT ch.id, ch.project_id
          FROM chapters ch
          JOIN projects p ON p.id = ch.project_id
-         WHERE ch.id = ? AND p.user_id = ?`,
+         WHERE ch.id = ? AND p.user_id = ? AND p.status = 'active'`,
       )
       .bind(chapterId, userId)
       .first<{ id: string; project_id: string }>();
@@ -239,11 +239,12 @@ export class ChapterService {
     // Fetch updated chapter
     const updated = await this.db
       .prepare(
-        `SELECT id, project_id, title, sort_order, r2_key, word_count, version, status, created_at, updated_at
-         FROM chapters
-         WHERE id = ?`,
+        `SELECT ch.id, ch.project_id, ch.title, ch.sort_order, ch.r2_key, ch.word_count, ch.version, ch.status, ch.created_at, ch.updated_at
+         FROM chapters ch
+         JOIN projects p ON p.id = ch.project_id
+         WHERE ch.id = ? AND p.user_id = ? AND p.status = 'active'`,
       )
-      .bind(chapterId)
+      .bind(chapterId, userId)
       .first<ChapterRow>();
 
     if (!updated) {
@@ -264,7 +265,7 @@ export class ChapterService {
         `SELECT ch.id, ch.project_id
          FROM chapters ch
          JOIN projects p ON p.id = ch.project_id
-         WHERE ch.id = ? AND p.user_id = ?`,
+         WHERE ch.id = ? AND p.user_id = ? AND p.status = 'active'`,
       )
       .bind(chapterId, userId)
       .first<{ id: string; project_id: string }>();
@@ -371,7 +372,7 @@ export class ChapterService {
                 ch.word_count, ch.version, ch.status, ch.created_at, ch.updated_at
          FROM chapters ch
          JOIN projects p ON p.id = ch.project_id
-         WHERE ch.id = ? AND p.user_id = ?`,
+         WHERE ch.id = ? AND p.user_id = ? AND p.status = 'active'`,
       )
       .bind(chapterId, userId)
       .first<ChapterRow>();

--- a/workers/dc-api/src/services/content.ts
+++ b/workers/dc-api/src/services/content.ts
@@ -65,7 +65,7 @@ export class ContentService {
         `SELECT ch.id, ch.project_id, ch.version, ch.r2_key
          FROM chapters ch
          JOIN projects p ON p.id = ch.project_id
-         WHERE ch.id = ? AND p.user_id = ?`,
+         WHERE ch.id = ? AND p.user_id = ? AND p.status = 'active'`,
       )
       .bind(chapterId, userId)
       .first<ChapterOwnershipRow>();
@@ -139,7 +139,7 @@ export class ContentService {
         `SELECT ch.id, ch.version, ch.r2_key
          FROM chapters ch
          JOIN projects p ON p.id = ch.project_id
-         WHERE ch.id = ? AND p.user_id = ?`,
+         WHERE ch.id = ? AND p.user_id = ? AND p.status = 'active'`,
       )
       .bind(chapterId, userId)
       .first<{ id: string; version: number; r2_key: string | null }>();

--- a/workers/dc-api/src/services/project.ts
+++ b/workers/dc-api/src/services/project.ts
@@ -193,7 +193,7 @@ export class ProjectService {
       .prepare(
         `SELECT id, user_id, title, description, status, created_at, updated_at
          FROM projects
-         WHERE id = ? AND user_id = ?`,
+         WHERE id = ? AND user_id = ? AND status = 'active'`,
       )
       .bind(projectId, userId)
       .first<ProjectRow>();
@@ -240,7 +240,7 @@ export class ProjectService {
   ): Promise<Project> {
     // Verify ownership
     const existing = await this.db
-      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ?`)
+      .prepare(`SELECT id FROM projects WHERE id = ? AND user_id = ? AND status = 'active'`)
       .bind(projectId, userId)
       .first();
 
@@ -279,7 +279,9 @@ export class ProjectService {
     bindings.push(projectId, userId);
 
     await this.db
-      .prepare(`UPDATE projects SET ${updates.join(", ")} WHERE id = ? AND user_id = ?`)
+      .prepare(
+        `UPDATE projects SET ${updates.join(", ")} WHERE id = ? AND user_id = ? AND status = 'active'`,
+      )
       .bind(...bindings)
       .run();
 
@@ -288,7 +290,7 @@ export class ProjectService {
       .prepare(
         `SELECT id, user_id, title, description, status, created_at, updated_at
          FROM projects
-         WHERE id = ? AND user_id = ?`,
+         WHERE id = ? AND user_id = ? AND status = 'active'`,
       )
       .bind(projectId, userId)
       .first<ProjectRow>();

--- a/workers/dc-api/src/services/source-local.ts
+++ b/workers/dc-api/src/services/source-local.ts
@@ -30,15 +30,24 @@ const MIME_TYPE_MAP: Record<string, string> = {
   ".pdf": "application/pdf",
 };
 
+function escapeHtml(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function formatInlineMarkdown(text: string): string {
+  return escapeHtml(text)
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/__(.+?)__/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    .replace(/_(.+?)_/g, "<em>$1</em>");
+}
+
 /** Convert plain text to simple HTML paragraphs */
 export function textToHtml(text: string): string {
   return text
     .split(/\n\n+/)
     .filter((p) => p.trim().length > 0)
-    .map(
-      (p) =>
-        `<p>${p.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").trim()}</p>`,
-    )
+    .map((p) => `<p>${escapeHtml(p).trim()}</p>`)
     .join("\n");
 }
 
@@ -59,7 +68,7 @@ export function markdownToHtml(md: string): string {
         inList = false;
       }
       const level = headingMatch[1].length;
-      htmlLines.push(`<h${level}>${headingMatch[2]}</h${level}>`);
+      htmlLines.push(`<h${level}>${formatInlineMarkdown(headingMatch[2].trim())}</h${level}>`);
       continue;
     }
 
@@ -70,7 +79,7 @@ export function markdownToHtml(md: string): string {
         htmlLines.push("<ul>");
         inList = true;
       }
-      htmlLines.push(`<li>${listMatch[1]}</li>`);
+      htmlLines.push(`<li>${formatInlineMarkdown(listMatch[1].trim())}</li>`);
       continue;
     }
 
@@ -86,14 +95,7 @@ export function markdownToHtml(md: string): string {
     }
 
     // Regular paragraph - apply inline formatting
-    let formatted = line
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
-      .replace(/__(.+?)__/g, "<strong>$1</strong>")
-      .replace(/\*(.+?)\*/g, "<em>$1</em>")
-      .replace(/_(.+?)_/g, "<em>$1</em>");
+    const formatted = formatInlineMarkdown(line);
     htmlLines.push(`<p>${formatted}</p>`);
   }
 

--- a/workers/dc-api/src/services/text-extraction.ts
+++ b/workers/dc-api/src/services/text-extraction.ts
@@ -61,6 +61,17 @@ export interface ExtractionResult {
 }
 
 /**
+ * Sanitize HTML produced from uploaded/ingested sources.
+ * Shared by DOCX extraction and Markdown cache remediation.
+ */
+export function sanitizeSourceHtml(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags: MAMMOTH_ALLOWED_TAGS,
+    allowedAttributes: MAMMOTH_ALLOWED_ATTRIBUTES,
+  });
+}
+
+/**
  * Strip HTML tags to produce plain text.
  * Used for FTS indexing and AI queries.
  */
@@ -105,10 +116,7 @@ export function extractFromMarkdown(content: ArrayBuffer): ExtractionResult {
 export async function extractFromDocx(content: ArrayBuffer): Promise<ExtractionResult> {
   const mammoth = await import("mammoth");
   const result = await mammoth.default.convertToHtml({ arrayBuffer: content });
-  const html = sanitizeHtml(result.value, {
-    allowedTags: MAMMOTH_ALLOWED_TAGS,
-    allowedAttributes: MAMMOTH_ALLOWED_ATTRIBUTES,
-  });
+  const html = sanitizeSourceHtml(result.value);
   const plainText = htmlToPlainText(html);
   return { html, plainText, wordCount: countWords(html) };
 }

--- a/workers/dc-api/test/chapter.test.ts
+++ b/workers/dc-api/test/chapter.test.ts
@@ -147,5 +147,12 @@ describe("ChapterService", () => {
       const other = await seedUser({ id: "other-user-2" });
       await expect(service.getChapter(other.id, ch.id)).rejects.toThrow("Chapter not found");
     });
+
+    it("throws NOT_FOUND when parent project is archived", async () => {
+      const archivedProject = await seedProject(userId, { status: "archived" });
+      const ch = await seedChapter(archivedProject.id);
+
+      await expect(service.getChapter(userId, ch.id)).rejects.toThrow("Chapter not found");
+    });
   });
 });

--- a/workers/dc-api/test/content.test.ts
+++ b/workers/dc-api/test/content.test.ts
@@ -59,6 +59,15 @@ describe("ContentService", () => {
         service.saveContent(other.id, ch.id, { content: "test", version: 1 }),
       ).rejects.toThrow("Chapter not found");
     });
+
+    it("throws NOT_FOUND when chapter belongs to archived project", async () => {
+      const archivedProject = await seedProject(userId, { status: "archived" });
+      const ch = await seedChapter(archivedProject.id, { version: 1 });
+
+      await expect(
+        service.saveContent(userId, ch.id, { content: "<p>blocked</p>", version: 1 }),
+      ).rejects.toThrow("Chapter not found");
+    });
   });
 
   describe("getContent", () => {

--- a/workers/dc-api/test/project.test.ts
+++ b/workers/dc-api/test/project.test.ts
@@ -99,6 +99,13 @@ describe("ProjectService", () => {
       const other = await seedUser({ id: "other-user" });
       await expect(service.getProject(other.id, proj.id)).rejects.toThrow("Project not found");
     });
+
+    it("throws NOT_FOUND for archived project", async () => {
+      const archived = await seedProject(userId, { status: "archived" });
+      await seedChapter(archived.id, { sortOrder: 1 });
+
+      await expect(service.getProject(userId, archived.id)).rejects.toThrow("Project not found");
+    });
   });
 
   describe("deleteProject", () => {

--- a/workers/dc-api/test/text-extraction.test.ts
+++ b/workers/dc-api/test/text-extraction.test.ts
@@ -70,6 +70,17 @@ describe("text-extraction", () => {
       expect(result.plainText).toContain("bold");
       expect(result.wordCount).toBeGreaterThan(0);
     });
+
+    it("escapes HTML in headings and list items", () => {
+      const md = "# <img src=x onerror=alert(1)>\n- <script>alert(1)</script>";
+      const content = new TextEncoder().encode(md);
+      const result = extractFromMarkdown(content.buffer as ArrayBuffer);
+
+      expect(result.html).toContain("<h1>&lt;img src=x onerror=alert(1)&gt;</h1>");
+      expect(result.html).toContain("<li>&lt;script&gt;alert(1)&lt;/script&gt;</li>");
+      expect(result.html).not.toContain("<script>");
+      expect(result.html).not.toContain("<img ");
+    });
   });
 
   describe("extractPlainTextFromHtml", () => {


### PR DESCRIPTION
## Summary
- patch code-review findings 1-4 with production-safe fixes and regression tests:
  - enforce active-project status guards across chapter/content/project service queries.
  - check Drive connection ownership before token lookup in `GET /drive/picker-token/:connectionId`.
  - only show auto-save crash recovery when local draft version is not older than remote.
  - harden Markdown conversion by escaping inline HTML in headings/list items.
- add post-deploy remediation path for legacy Markdown cache entries:
  - `POST /projects/:projectId/sources/remediate-markdown`
  - `SourceMaterialService.remediateLocalMarkdownSources(...)` sanitizes cached HTML, rebuilds plain text + FTS, updates cache metadata.

## Regression Tests
- `web/test/hooks/use-auto-save.test.ts`
  - recovery prompt shown only when local draft version matches remote
  - no prompt when local draft version is older than remote
- `workers/dc-api/test/content.test.ts`
  - save content rejected when chapter belongs to archived project
- `workers/dc-api/test/chapter.test.ts`
  - chapter fetch rejected when project is archived
- `workers/dc-api/test/project.test.ts`
  - archived project is not returned
- `workers/dc-api/test/text-extraction.test.ts`
  - Markdown headings/list items escape injected HTML
- `workers/dc-api/test/source-material.test.ts`
  - remediation sanitizes cached HTML, rebuilds TXT + FTS, updates metadata
  - remediation reports missing cache objects
- `workers/dc-api/test/integration.test.ts`
  - picker token route rejects foreign connection before token lookup
  - remediation endpoint sanitizes legacy markdown cache

## Verification
- `npm run lint`
- `npm run typecheck`
- `npm run test`
