### PR TITLE
fix: always show destination picker on export

### DIFF
--- a/docs/design/source-review/design-spec.md
+++ b/docs/design/source-review/design-spec.md
@@ -1754,7 +1754,7 @@ The Export Manager handles destination selection, folder browsing within cloud s
 
 ### Destination Picker (Bottom Sheet)
 
-Shown when 2+ destinations exist (at least one Drive connection) and no default is set.
+Shown after every export unless a remembered default is set.
 
 ```
 ┌─────────────────────────────────────────┐
@@ -1835,8 +1835,9 @@ Save to Files
 
 | Scenario                                  | Behavior                                                       |
 | ----------------------------------------- | -------------------------------------------------------------- |
-| No Drive connected, no default            | Download directly — single destination, no picker              |
+| No Drive connected, no default            | Picker shown with "This Device" as the only option             |
 | Default Drive but connection disconnected | Detect null `drive_connection_id` → picker with error          |
 | Default Drive but folder deleted          | Drive API 404 on upload → picker with error                    |
 | New source connected                      | Appears as new destination in picker                           |
 | Multiple rapid exports                    | Rate limit (5/min); preference check is fast (single DB query) |
+| Picker dismissed while export ready       | "Export ready" toast with link to reopen picker                |

--- a/docs/pm/prd-app.md
+++ b/docs/pm/prd-app.md
@@ -165,8 +165,9 @@ All originals remain in user Drive.
 - **This Device** — standard browser download; OS controls save location (Downloads on desktop, share sheet on iPad Safari)
 - **Google Drive** — save to a selected folder in the user's connected Drive account; default folder: `{Book Title}/_exports/`
 - Folder browsing within Drive destinations (folders only, breadcrumb navigation, create new folder)
-- When only one destination exists (no Drive connected), export downloads directly — no picker shown
-- When multiple destinations exist (Drive connected), show Export Destination Picker bottom sheet
+- Export Destination Picker shown after every export unless a remembered default is set
+- When no Drive is connected, the picker shows "This Device" as the only destination
+- When Drive is connected, the picker shows both "This Device" and connected Drive accounts
 
 **Remembered Defaults (per-project):**
 


### PR DESCRIPTION
## Summary

- **Remove auto-download bypass** when no Drive is connected. The destination picker now appears after every export unless a remembered default is set, enforcing the design principle "no file leaves server without explicit user consent."
- **Add "Export ready" recovery toast** — when the user dismisses the picker, a persistent blue toast shows the filename with a "Choose destination" link to reopen the picker. Dismissing the toast (✕) fully resets the export state.
- **Align docs** — updated design spec and PRD to match the corrected behavior; removed contradictory "skip picker when single destination" language.

## Test plan

- [ ] No Drive connected, no preference → picker appears with "This Device" only
- [ ] Drive connected, no preference → picker appears with both options
- [ ] Dismiss picker → "Export ready" toast appears with filename
- [ ] Tap "Choose destination" on toast → picker reopens
- [ ] Dismiss toast (✕) → export dismissed, state resets to idle
- [ ] Saved device default → auto-download with green confirmation toast (unchanged)
- [ ] Saved Drive default → auto-save to Drive with green confirmation toast (unchanged)
- [ ] Stale Drive default → picker appears as fallback (unchanged)
- [ ] `npm run typecheck` / `npm run lint` / `npm test` all pass

**Known pre-existing issue (not in scope):** If user taps Export before preference fetch completes, `preference` is null and picker shows even when a default exists. Small race window — follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)