### PR TITLE
fix: bridge post-OAuth flow to Drive browser in library

### DIFF
--- a/web/src/app/(protected)/drive/success/page.tsx
+++ b/web/src/app/(protected)/drive/success/page.tsx
@@ -9,6 +9,7 @@ const SOURCE_LINK_KEY = "dc_pending_source_link";
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
 const OPEN_SOURCES_KEY = "dc_open_sources_panel";
+const POST_OAUTH_CONNECTION_KEY = "dc_post_oauth_connection";
 
 /**
  * Module-level snapshot for the pending source link project ID.
@@ -98,6 +99,9 @@ export default function DriveSuccessPage() {
     if (sourceLinkProjectId) {
       try {
         sessionStorage.setItem(OPEN_SOURCES_KEY, "true");
+        if (connectionId) {
+          sessionStorage.setItem(POST_OAUTH_CONNECTION_KEY, connectionId);
+        }
       } catch {
         // sessionStorage unavailable — URL param fallback below handles this
       }
@@ -105,7 +109,7 @@ export default function DriveSuccessPage() {
     // Append URL param as iPad Safari fallback (sessionStorage can be lost on tab suspension)
     const destination = sourceLinkProjectId ? `${base}?sources=open` : base;
     router.push(destination);
-  }, [sourceLinkProjectId, router]);
+  }, [sourceLinkProjectId, connectionId, router]);
 
   // Auto-redirect after async flows complete
   useEffect(() => {

--- a/web/src/components/sources/sources-section.tsx
+++ b/web/src/components/sources/sources-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useSourcesContext } from "@/contexts/sources-context";
 
 /**
@@ -23,11 +23,18 @@ interface SourcesSectionProps {
 }
 
 export function SourcesSection({ onAddSource }: SourcesSectionProps) {
-  const { connections, unlinkConnection } = useSourcesContext();
+  const { connections, unlinkConnection, sources } = useSourcesContext();
 
-  const [expanded, setExpanded] = useState(connections.length === 0);
+  const [expanded, setExpanded] = useState(connections.length === 0 || sources.length === 0);
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [isUnlinking, setIsUnlinking] = useState(false);
+
+  // React to post-OAuth state: expand when connections exist but no documents yet
+  useEffect(() => {
+    if (connections.length > 0 && sources.length === 0) {
+      setExpanded(true);
+    }
+  }, [connections.length, sources.length]);
 
   const handleUnlink = useCallback(
     async (connectionId: string) => {


### PR DESCRIPTION
## Summary

- Forward the Drive connection ID through sessionStorage after OAuth so the library tab can auto-browse the newly connected Drive and show a confirmation toast
- Differentiate the empty state when Drive is connected but no documents exist yet ("Your Drive is connected / Browse Drive" vs generic "Add sources")
- Make the "Your Sources" section reactively expand post-OAuth via useEffect, not just on initial mount

## Test plan

- [ ] Create new book, connect Google Drive via OAuth -> verify auto-browse into Drive files + toast "Google Drive connected"
- [ ] Return to library with connected Drive but 0 documents -> verify "Browse Drive" CTA and Drive icon (not book icon)
- [ ] Existing user with documents -> verify normal list mode unchanged, "Your Sources" collapsed
- [ ] Slow network (throttle in DevTools) -> verify fallback empty state shows "Browse Drive" after 10s timeout
- [ ] iPad Safari -> verify sessionStorage signal works on redirect (same pattern as existing `dc_open_sources_panel`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)