### PR TITLE
rename Sources to Library in UI labels

### DIFF
--- a/web/src/components/editor/editor-toolbar.tsx
+++ b/web/src/components/editor/editor-toolbar.tsx
@@ -88,7 +88,7 @@ export function EditorToolbar({
           onClick={togglePanel}
           className={`h-9 px-2.5 flex items-center gap-1.5 rounded-lg text-sm font-medium
                      transition-colors ${isPanelOpen ? "bg-blue-50 text-blue-700" : "text-gray-600 hover:bg-gray-50"}`}
-          aria-label={isPanelOpen ? "Close sources panel" : "Open sources panel"}
+          aria-label={isPanelOpen ? "Close library panel" : "Open library panel"}
           aria-pressed={isPanelOpen}
         >
           <svg
@@ -105,7 +105,7 @@ export function EditorToolbar({
               d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
             />
           </svg>
-          <span className="hidden sm:inline">Sources</span>
+          <span className="hidden sm:inline">Library</span>
         </button>
 
         {selectionWordCount > 0 && aiSheetState === "idle" && (

--- a/web/src/components/sources/project-source-list.tsx
+++ b/web/src/components/sources/project-source-list.tsx
@@ -92,7 +92,7 @@ export function ProjectSourceList() {
               type="text"
               value={searchQuery}
               onChange={(e) => handleSearch(e.target.value)}
-              placeholder="Search sources..."
+              placeholder="Search documents..."
               className="w-full h-9 pl-8 pr-8 text-sm border border-gray-200 rounded-lg
                          focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             />

--- a/web/src/components/sources/review-tab.tsx
+++ b/web/src/components/sources/review-tab.tsx
@@ -150,7 +150,7 @@ export function SourceDetailView({ onBack }: SourceDetailViewProps) {
         }
         message="Select a source to view its content"
         action={{
-          label: "Back to Sources",
+          label: "Back to Library",
           onClick: onBack,
         }}
       />
@@ -165,7 +165,7 @@ export function SourceDetailView({ onBack }: SourceDetailViewProps) {
           <button
             onClick={onBack}
             className="p-1 text-gray-400 hover:text-gray-600 min-h-[44px] min-w-[44px] flex items-center justify-center"
-            aria-label="Back to Sources"
+            aria-label="Back to Library"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path

--- a/web/src/components/sources/sources-panel-overlay.tsx
+++ b/web/src/components/sources/sources-panel-overlay.tsx
@@ -6,7 +6,7 @@ import { AssistTab } from "./assist-tab";
 import type { SourcesTab } from "@/hooks/use-sources-panel";
 
 const TABS: { id: SourcesTab; label: string }[] = [
-  { id: "sources", label: "Sources" },
+  { id: "sources", label: "Library" },
   { id: "ask", label: "Ask" },
 ];
 
@@ -34,7 +34,7 @@ export function SourcesPanelOverlay() {
                    bg-background shadow-xl sources-panel-slide-in flex flex-col lg:hidden"
         role="dialog"
         aria-modal="true"
-        aria-label="Sources panel"
+        aria-label="Library panel"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 h-12 border-b border-border shrink-0">
@@ -60,7 +60,7 @@ export function SourcesPanelOverlay() {
             onClick={closePanel}
             className="p-1.5 text-gray-400 hover:text-gray-600 transition-colors
                        min-h-[44px] min-w-[44px] flex items-center justify-center"
-            aria-label="Close sources panel"
+            aria-label="Close library panel"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path

--- a/web/src/components/sources/sources-panel.tsx
+++ b/web/src/components/sources/sources-panel.tsx
@@ -6,7 +6,7 @@ import { AssistTab } from "./assist-tab";
 import type { SourcesTab } from "@/hooks/use-sources-panel";
 
 const TABS: { id: SourcesTab; label: string }[] = [
-  { id: "sources", label: "Sources" },
+  { id: "sources", label: "Library" },
   { id: "ask", label: "Ask" },
 ];
 
@@ -46,7 +46,7 @@ export function SourcesPanel() {
           onClick={closePanel}
           className="p-1.5 text-gray-400 hover:text-gray-600 transition-colors
                      min-h-[44px] min-w-[44px] flex items-center justify-center"
-          aria-label="Close sources panel"
+          aria-label="Close library panel"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path


### PR DESCRIPTION
## Summary
- Toolbar button: "Sources" → "Library"
- Panel tab labels (desktop + mobile): "Sources" → "Library"
- Search placeholder: "Search sources..." → "Search documents..."
- Review tab back button: "Back to Sources" → "Back to Library"
- All related aria-labels updated to match

## Test plan
- [ ] Open editor, verify toolbar button says "Library"
- [ ] Open the panel, verify tab says "Library" (not "Sources")
- [ ] On mobile viewport, verify overlay panel tab says "Library"
- [ ] With documents added, verify search placeholder says "Search documents..."
- [ ] Open a document detail, verify back button says "Back to Library"

🤖 Generated with [Claude Code](https://claude.com/claude-code)