### PR TITLE
feat: Library/Desk UX — browse-first Library, multi-select Desk

### DIFF
--- a/docs/design/library-desk-spec.md
+++ b/docs/design/library-desk-spec.md
@@ -1,0 +1,134 @@
+# Library & Desk — Design Spec
+
+## Overview
+
+The Library panel has two tabs: **Library** and **Desk**.
+
+- **Library** = the stacks. Browse your connected sources (Google Drive, local files), peek into documents, and tag what you need.
+- **Desk** = your workspace. Tagged documents are "checked out" here. This is where you work with them — view content, run AI analysis, pull insights into your book.
+
+## Mental Model
+
+The metaphor is a physical library:
+
+1. You walk into the library (browse your Drive)
+2. You find books you need (scan documents)
+3. You check them out (tag with the bookmark icon)
+4. You bring them to your desk (they appear in the Desk tab)
+5. You study them, take notes, synthesize (AI analysis)
+6. When done, you return them (untag)
+
+## Library Tab
+
+### States
+
+**No connections (empty):**
+- Book icon
+- "Add documents to reference while you write."
+- "Your originals are never changed."
+- Single CTA: "Add Source" → opens Source Type Picker
+
+**Connected (default):**
+- Connection header showing account email (dropdown switcher if multiple)
+- Drive file browser: folders and documents
+- Breadcrumb navigation for folder hierarchy
+- Documents show a **bookmark icon** on the right side of each row:
+  - Gray outline = not on desk
+  - Filled blue = on desk
+- Tap bookmark to tag/untag (no modal, no confirmation — instant with toast)
+- Tap document row to peek (preview content)
+- Footer: Connections section with Browse/Remove and "+ Connect a Source"
+
+### Tagging Interaction
+
+- Bookmark icon on every document row in browse view
+- Single tap toggles tag state
+- Toast confirms: "Added [name] to desk" / "Removed [name] from desk"
+- Tagging = creating a SourceMaterial record (addDriveSources)
+- Untagging = removing the SourceMaterial record (removeSource)
+- Tagged state is derived from `sources` array matching by `driveFileId`
+
+## Desk Tab
+
+### States
+
+**Empty (nothing tagged):**
+- Desk icon
+- "Tag documents from the Library to work with them here."
+- No action button — the action is in the Library tab
+
+**Has tagged documents:**
+- Document list with checkboxes for multi-select
+- "Select all" toggle at the top
+- Each document row shows: checkbox, document icon, title, bookmark (untag) icon
+- Below the document list: instruction area and analyze button
+
+### Multi-Select Analysis
+
+Users select one or more documents from their desk, write an instruction, and run analysis.
+The AI receives the content of all selected documents as context.
+
+**Use cases:**
+- Analyze these docs and propose a chapter outline
+- Pull all references to [topic] across these documents
+- Summarize the key arguments across this research
+- Suggest how these sources connect to each other
+
+### Context Limits & Deep Analysis (Future)
+
+When the selected documents exceed what fits in a single AI context window:
+
+**Current behavior:**
+- Allow selection of any number of documents
+- For small selections (fits in context): analyze immediately with SSE streaming
+- For large selections: show messaging that batch processing will be needed
+
+**Future: Deep Analysis (map-reduce pattern):**
+
+1. **Map phase:** Process documents in batches (e.g., 5-10 at a time). Each batch
+   produces an intermediate summary/analysis against the user's instruction.
+2. **Reduce phase:** Synthesize all intermediate results into one coherent output.
+3. **Async execution:** Job runs in the background. User can leave and come back.
+   Result is stored and waiting on their Desk.
+
+This mirrors how humans actually do research synthesis — read a stack, take notes,
+read another stack, take notes, then synthesize notes into structure.
+
+**Product positioning:** Deep Analysis is a natural premium feature. It does real work
+over real time, and the perceived value is clear.
+
+**Technical path:**
+- Async job queue (Cloudflare Queues or Durable Objects)
+- Intermediate results stored in D1 or KV
+- Progress tracking: "Processed 15 of 32 documents..."
+- Notification when complete (in-app, optionally email)
+
+## Vocabulary
+
+Consistent terminology across all UI:
+
+| Term | Meaning | Usage |
+|------|---------|-------|
+| Source | A repository/provider | Google Drive, local storage |
+| Folder | A directory within a Source | Drive folders |
+| Document | A specific file | Files the user works with |
+| Library | Browse view of connected sources | "Library" tab |
+| Desk | Tagged documents workspace | "Desk" tab |
+| Tag | Mark a document for desk use | Bookmark icon in browse |
+
+Never say "research", "reference materials", "files", or "items" as synonyms for documents.
+
+## Tab Structure
+
+| Tab | ID | Component | Purpose |
+|-----|-----|-----------|---------|
+| Library | `library` | LibraryTab | Browse sources, tag documents |
+| Desk | `desk` | DeskTab | Work with tagged documents, AI analysis |
+
+## Design Decisions Log
+
+- **2026-02-24:** Renamed "Sources"/"Ask" tabs to "Library"/"Desk"
+- **2026-02-24:** Library defaults to browse view when connected (no intermediate empty state)
+- **2026-02-24:** Inline bookmark tagging in browse view (no modal, tap to toggle)
+- **2026-02-24:** Desk tab shows tagged documents with multi-select for AI analysis
+- **2026-02-24:** Deep Analysis (map-reduce) documented as future premium feature

--- a/web/src/components/sources/assist-tab.tsx
+++ b/web/src/components/sources/assist-tab.tsx
@@ -52,7 +52,7 @@ export function AssistTab() {
 
   const handleAnalyze = useCallback(() => {
     if (!sourceId || !instruction.trim()) return;
-    analyze(projectId, sourceId, instruction);
+    analyze(projectId, [sourceId], instruction);
   }, [sourceId, instruction, projectId, analyze]);
 
   const handleRetry = useCallback(() => {

--- a/web/src/components/sources/desk-tab.tsx
+++ b/web/src/components/sources/desk-tab.tsx
@@ -1,0 +1,362 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+import { useSourcesContext } from "@/contexts/sources-context";
+import { InstructionPicker } from "./instruction-picker";
+import { EmptyState } from "./empty-state";
+import { useToast } from "@/components/toast";
+
+/**
+ * Desk tab — tagged documents workspace with multi-select AI analysis.
+ *
+ * Shows documents the user has "checked out" from the Library (tagged via bookmark).
+ * Users select one or more documents, write an instruction, and run AI analysis.
+ * Results can be copied or inserted into the current chapter.
+ */
+export function DeskTab() {
+  const {
+    sources,
+    removeSource,
+    analyze,
+    analysisText,
+    isAnalyzing,
+    isAnalysisComplete,
+    analysisError,
+    resetAnalysis,
+    analysisInstructions,
+    createInstruction,
+    updateInstruction,
+    removeInstruction,
+    editorRef,
+    projectId,
+    isPanelOpen,
+    closePanel,
+  } = useSourcesContext();
+
+  const { showToast } = useToast();
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [instruction, setInstruction] = useState("Summarize key points");
+
+  // Only active (tagged) sources appear on the desk
+  const deskSources = useMemo(
+    () => sources.filter((s) => s.status === "active"),
+    [sources],
+  );
+
+  const allSelected = deskSources.length > 0 && selectedIds.size === deskSources.length;
+
+  const toggleSelect = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleSelectAll = useCallback(() => {
+    if (allSelected) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(deskSources.map((s) => s.id)));
+    }
+  }, [allSelected, deskSources]);
+
+  const handleUntag = useCallback(
+    async (sourceId: string, title: string) => {
+      try {
+        await removeSource(sourceId);
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          next.delete(sourceId);
+          return next;
+        });
+        showToast(`Removed "${title}" from desk`);
+      } catch (err) {
+        console.error("Failed to remove from desk:", err);
+      }
+    },
+    [removeSource, showToast],
+  );
+
+  const handleAnalyze = useCallback(() => {
+    const ids = Array.from(selectedIds);
+    if (ids.length === 0 || !instruction.trim()) return;
+    analyze(projectId, ids, instruction);
+  }, [selectedIds, instruction, projectId, analyze]);
+
+  const handleRetry = useCallback(() => {
+    resetAnalysis();
+    handleAnalyze();
+  }, [resetAnalysis, handleAnalyze]);
+
+  const handleCopy = useCallback(async () => {
+    if (!analysisText) return;
+    try {
+      await navigator.clipboard.writeText(analysisText);
+      showToast("Copied to clipboard");
+    } catch {
+      showToast("Failed to copy");
+    }
+  }, [analysisText, showToast]);
+
+  const handleInsert = useCallback(() => {
+    if (!analysisText) return;
+    const editor = editorRef.current?.getEditor();
+    if (!editor) return;
+
+    const { from, to } = editor.state.selection;
+    const hasCursor = from === to && from > 0;
+
+    if (hasCursor) {
+      editor.chain().focus().insertContent(`<p>${analysisText}</p>`).run();
+      showToast("Inserted at cursor");
+    } else {
+      editor.chain().focus("end").insertContent(`<p>${analysisText}</p>`).run();
+      showToast("Added to end of chapter");
+    }
+
+    const isPortrait = window.matchMedia("(max-width: 1023px)").matches;
+    if (isPortrait && isPanelOpen) {
+      closePanel();
+    }
+  }, [analysisText, editorRef, showToast, isPanelOpen, closePanel]);
+
+  const handleSelectInstruction = useCallback((text: string) => {
+    setInstruction(text);
+  }, []);
+
+  // Empty desk
+  if (deskSources.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={1.5}
+              d="M4 7v10c0 2 1 3 3 3h10c2 0 3-1 3-3V7M4 7c0-2 1-3 3-3h10c2 0 3 1 3 3M4 7h16"
+            />
+          </svg>
+        }
+        message="Tag documents from the Library to work with them here."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 overflow-auto min-h-0">
+        {/* Document list header */}
+        <div className="px-4 py-2 border-b border-gray-100 flex items-center gap-2">
+          <button
+            onClick={toggleSelectAll}
+            className="flex items-center gap-2 text-xs text-gray-500 hover:text-gray-700
+                       transition-colors min-h-[32px]"
+          >
+            <span
+              className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 transition-colors ${
+                allSelected
+                  ? "bg-blue-600 border-blue-600"
+                  : "border-gray-300"
+              }`}
+            >
+              {allSelected && (
+                <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </span>
+            {allSelected ? "Deselect all" : "Select all"}
+          </button>
+          <span className="text-[10px] text-gray-400 ml-auto">
+            {selectedIds.size > 0 ? `${selectedIds.size} selected` : `${deskSources.length} on desk`}
+          </span>
+        </div>
+
+        {/* Document rows */}
+        <div>
+          {deskSources.map((source) => {
+            const isSelected = selectedIds.has(source.id);
+            return (
+              <div
+                key={source.id}
+                className="flex items-center w-full border-b border-gray-50 hover:bg-gray-50"
+              >
+                {/* Checkbox + title (tap to select) */}
+                <button
+                  onClick={() => toggleSelect(source.id)}
+                  className="flex items-center gap-2 flex-1 min-w-0 px-4 min-h-[44px] cursor-pointer"
+                >
+                  <span
+                    className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 transition-colors ${
+                      isSelected
+                        ? "bg-blue-600 border-blue-600"
+                        : "border-gray-300"
+                    }`}
+                  >
+                    {isSelected && (
+                      <svg className="w-3 h-3 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M5 13l4 4L19 7" />
+                      </svg>
+                    )}
+                  </span>
+                  <svg
+                    className="w-4 h-4 text-blue-400 shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                    />
+                  </svg>
+                  <span className="text-sm text-gray-900 truncate flex-1 text-left">
+                    {source.title}
+                  </span>
+                </button>
+
+                {/* Untag (remove from desk) */}
+                <button
+                  onClick={() => handleUntag(source.id, source.title)}
+                  className="p-2 mr-1 shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center
+                             text-blue-600 hover:text-gray-400 transition-colors"
+                  aria-label="Remove from desk"
+                >
+                  <svg className="w-5 h-5" fill="currentColor" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={1.5}
+                      d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+                    />
+                  </svg>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Analysis section */}
+        <div className="px-4 py-4 space-y-4">
+          {/* Instruction area */}
+          <div>
+            <label className="text-xs font-medium text-gray-500 mb-1.5 block">Instruction</label>
+            <textarea
+              value={instruction}
+              onChange={(e) => setInstruction(e.target.value)}
+              disabled={isAnalyzing}
+              className="w-full p-3 text-sm border border-gray-200 rounded-lg resize-none
+                         focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
+                         disabled:opacity-50 disabled:cursor-not-allowed"
+              rows={3}
+              placeholder="What would you like to know about these documents?"
+              maxLength={2000}
+            />
+            <div className="mt-2">
+              <InstructionPicker
+                instructions={analysisInstructions}
+                type="analysis"
+                onSelect={handleSelectInstruction}
+                onCreate={async (input) => {
+                  await createInstruction(input);
+                }}
+                onUpdate={updateInstruction}
+                onRemove={removeInstruction}
+              />
+            </div>
+          </div>
+
+          {/* Analyze button */}
+          <button
+            onClick={handleAnalyze}
+            disabled={selectedIds.size === 0 || !instruction.trim() || isAnalyzing}
+            className="w-full h-10 rounded-lg bg-blue-600 text-sm font-medium text-white
+                       hover:bg-blue-700 transition-colors min-h-[44px]
+                       disabled:opacity-50 disabled:cursor-not-allowed
+                       flex items-center justify-center gap-2"
+          >
+            {isAnalyzing ? (
+              <>
+                <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="10"
+                    stroke="currentColor"
+                    strokeWidth="4"
+                  />
+                  <path
+                    className="opacity-75"
+                    fill="currentColor"
+                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                  />
+                </svg>
+                Analyzing...
+              </>
+            ) : selectedIds.size === 0 ? (
+              "Select documents to analyze"
+            ) : (
+              `Analyze ${selectedIds.size} document${selectedIds.size !== 1 ? "s" : ""}`
+            )}
+          </button>
+
+          {/* Streaming response */}
+          {(analysisText || isAnalyzing || analysisError) && (
+            <div className="space-y-2">
+              <h3 className="text-xs font-medium text-gray-500">Analysis</h3>
+              <div className="p-3 bg-gray-50 rounded-lg text-sm text-gray-900 leading-relaxed whitespace-pre-wrap min-h-[60px]">
+                {analysisText}
+                {isAnalyzing && (
+                  <span
+                    className="inline-block w-0.5 h-4 bg-blue-600 ml-0.5 align-text-bottom animate-pulse"
+                    aria-hidden="true"
+                  />
+                )}
+                {analysisError && (
+                  <div className="mt-2">
+                    <p className="text-xs text-red-600 mb-1">{analysisError}</p>
+                    <button
+                      onClick={handleRetry}
+                      className="text-xs text-blue-600 hover:text-blue-700 min-h-[32px]"
+                    >
+                      Tap to retry
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Action bar (shown when analysis is complete) */}
+      {isAnalysisComplete && analysisText && !analysisError && (
+        <div className="px-4 py-3 border-t border-gray-100 flex gap-2 shrink-0">
+          <button
+            onClick={handleCopy}
+            className="flex-1 h-10 rounded-lg border border-gray-300 text-sm font-medium text-gray-700
+                       hover:bg-gray-50 transition-colors min-h-[44px]"
+          >
+            Copy
+          </button>
+          <button
+            onClick={handleInsert}
+            className="flex-1 h-10 rounded-lg bg-blue-600 text-sm font-medium text-white
+                       hover:bg-blue-700 transition-colors min-h-[44px]"
+          >
+            Insert into Chapter
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/sources/drive-browser.tsx
+++ b/web/src/components/sources/drive-browser.tsx
@@ -9,6 +9,12 @@ interface DriveBrowserProps {
   rootLabel?: string;
   accountEmail?: string;
   onDocumentTap: (file: DriveFile) => void;
+  /** driveFileIds that are tagged (on the Desk) */
+  taggedFileIds: Set<string>;
+  /** Tag a document (add to Desk) */
+  onTag: (file: DriveFile) => void;
+  /** Untag a document (remove from Desk) */
+  onUntag: (file: DriveFile) => void;
 }
 
 interface BreadcrumbItem {
@@ -36,6 +42,9 @@ export function DriveBrowser({
   onReconnect,
   rootLabel,
   onDocumentTap,
+  taggedFileIds,
+  onTag,
+  onUntag,
 }: DriveBrowserProps) {
   const [currentFolder, setCurrentFolder] = useState("root");
   const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbItem[]>([
@@ -186,29 +195,52 @@ export function DriveBrowser({
             ))}
 
             {/* Documents */}
-            {documents.map((doc) => (
-              <button
-                key={doc.id}
-                onClick={() => onDocumentTap(doc)}
-                className="flex items-center gap-2 w-full px-3 min-h-[44px] border-b border-gray-50
-                           hover:bg-gray-50 cursor-pointer"
-              >
-                <svg
-                  className="w-5 h-5 text-blue-400 shrink-0"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+            {documents.map((doc) => {
+              const isTagged = taggedFileIds.has(doc.id);
+              return (
+                <div
+                  key={doc.id}
+                  className="flex items-center w-full border-b border-gray-50 hover:bg-gray-50"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                  />
-                </svg>
-                <span className="text-sm text-gray-900 truncate flex-1 text-left">{doc.name}</span>
-              </button>
-            ))}
+                  <button
+                    onClick={() => onDocumentTap(doc)}
+                    className="flex items-center gap-2 flex-1 min-w-0 px-3 min-h-[44px] cursor-pointer"
+                  >
+                    <svg
+                      className="w-5 h-5 text-blue-400 shrink-0"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                      />
+                    </svg>
+                    <span className="text-sm text-gray-900 truncate flex-1 text-left">
+                      {doc.name}
+                    </span>
+                  </button>
+                  <button
+                    onClick={() => (isTagged ? onUntag(doc) : onTag(doc))}
+                    className={`p-2 mr-1 shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center
+                               transition-colors ${isTagged ? "text-blue-600" : "text-gray-300 hover:text-gray-500"}`}
+                    aria-label={isTagged ? "Remove from desk" : "Add to desk"}
+                  >
+                    <svg className="w-5 h-5" fill={isTagged ? "currentColor" : "none"} stroke="currentColor" viewBox="0 0 24 24">
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              );
+            })}
 
             {/* Pagination */}
             {hasMore && (

--- a/web/src/components/sources/sources-panel-overlay.tsx
+++ b/web/src/components/sources/sources-panel-overlay.tsx
@@ -2,12 +2,12 @@
 
 import { useSourcesContext } from "@/contexts/sources-context";
 import { LibraryTab } from "./library-tab";
-import { AssistTab } from "./assist-tab";
+import { DeskTab } from "./desk-tab";
 import type { SourcesTab } from "@/hooks/use-sources-panel";
 
 const TABS: { id: SourcesTab; label: string }[] = [
-  { id: "sources", label: "Library" },
-  { id: "ask", label: "Ask" },
+  { id: "library", label: "Library" },
+  { id: "desk", label: "Desk" },
 ];
 
 /**
@@ -75,8 +75,8 @@ export function SourcesPanelOverlay() {
 
         {/* Content */}
         <div className="flex-1 overflow-auto flex flex-col">
-          {activeTab === "sources" && <LibraryTab />}
-          {activeTab === "ask" && <AssistTab />}
+          {activeTab === "library" && <LibraryTab />}
+          {activeTab === "desk" && <DeskTab />}
         </div>
 
         {/* Safe area */}

--- a/web/src/components/sources/sources-panel.tsx
+++ b/web/src/components/sources/sources-panel.tsx
@@ -2,12 +2,12 @@
 
 import { useSourcesContext } from "@/contexts/sources-context";
 import { LibraryTab } from "./library-tab";
-import { AssistTab } from "./assist-tab";
+import { DeskTab } from "./desk-tab";
 import type { SourcesTab } from "@/hooks/use-sources-panel";
 
 const TABS: { id: SourcesTab; label: string }[] = [
-  { id: "sources", label: "Library" },
-  { id: "ask", label: "Ask" },
+  { id: "library", label: "Library" },
+  { id: "desk", label: "Desk" },
 ];
 
 /**
@@ -61,8 +61,8 @@ export function SourcesPanel() {
 
       {/* Content */}
       <div className="flex-1 overflow-auto flex flex-col">
-        {activeTab === "sources" && <LibraryTab />}
-        {activeTab === "ask" && <AssistTab />}
+        {activeTab === "library" && <LibraryTab />}
+        {activeTab === "desk" && <DeskTab />}
       </div>
     </div>
   );

--- a/web/src/components/sources/sources-section.tsx
+++ b/web/src/components/sources/sources-section.tsx
@@ -59,7 +59,7 @@ export function SourcesSection({ onBrowseConnection, onAddSource }: SourcesSecti
       {/* Connection rows */}
       <div className="flex flex-col gap-1">
         {connections.length === 0 ? (
-          <p className="text-xs text-gray-400 py-2 px-1">No sources connected to this book.</p>
+          <p className="text-xs text-gray-400 py-2 px-1">No sources connected.</p>
         ) : (
           connections.map((connection) => (
             <div key={connection.id}>

--- a/web/src/contexts/sources-context.tsx
+++ b/web/src/contexts/sources-context.tsx
@@ -56,7 +56,7 @@ interface SourcesContextValue {
   unlinkConnection: (connectionId: string) => Promise<void>;
 
   // AI Analysis
-  analyze: (projectId: string, sourceId: string, instruction: string) => void;
+  analyze: (projectId: string, sourceIds: string[], instruction: string) => void;
   analysisText: string;
   isAnalyzing: boolean;
   isAnalysisComplete: boolean;

--- a/web/src/hooks/use-source-analysis.ts
+++ b/web/src/hooks/use-source-analysis.ts
@@ -9,7 +9,7 @@ const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 const ANALYSIS_TIMEOUT_MS = 30_000;
 
 interface UseSourceAnalysisReturn {
-  analyze: (projectId: string, sourceId: string, instruction: string) => void;
+  analyze: (projectId: string, sourceIds: string[], instruction: string) => void;
   streamingText: string;
   isStreaming: boolean;
   isComplete: boolean;
@@ -60,7 +60,7 @@ export function useSourceAnalysis(): UseSourceAnalysisReturn {
   }, []);
 
   const analyze = useCallback(
-    async (projectId: string, sourceId: string, instruction: string) => {
+    async (projectId: string, sourceIds: string[], instruction: string) => {
       // Abort any existing request
       abortControllerRef.current?.abort();
       if (rafRef.current) {
@@ -98,7 +98,7 @@ export function useSourceAnalysis(): UseSourceAnalysisReturn {
             "Content-Type": "application/json",
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify({ sourceId, instruction }),
+          body: JSON.stringify({ sourceIds, instruction }),
           signal: abortController.signal,
         });
 

--- a/web/src/hooks/use-sources-panel.ts
+++ b/web/src/hooks/use-sources-panel.ts
@@ -2,7 +2,7 @@
 
 import { useState, useCallback } from "react";
 
-export type SourcesTab = "sources" | "ask";
+export type SourcesTab = "library" | "desk";
 
 interface UseSourcesPanelReturn {
   activeTab: SourcesTab;
@@ -24,7 +24,7 @@ interface UseSourcesPanelReturn {
  * Manages tab selection, source selection, detail view, and panel visibility.
  */
 export function useSourcesPanel(): UseSourcesPanelReturn {
-  const [activeTab, setActiveTab] = useState<SourcesTab>("sources");
+  const [activeTab, setActiveTab] = useState<SourcesTab>("library");
   const [selectedSourceId, setSelectedSourceId] = useState<string | null>(null);
   const [detailSourceId, setDetailSourceId] = useState<string | null>(null);
   const [isPanelOpen, setIsPanelOpen] = useState(false);
@@ -36,13 +36,13 @@ export function useSourcesPanel(): UseSourcesPanelReturn {
   const openSourceReview = useCallback((sourceId: string) => {
     setSelectedSourceId(sourceId);
     setDetailSourceId(sourceId);
-    setActiveTab("sources");
+    setActiveTab("library");
     setIsPanelOpen(true);
   }, []);
 
   const openSourceAnalysis = useCallback((sourceId: string) => {
     setSelectedSourceId(sourceId);
-    setActiveTab("ask");
+    setActiveTab("desk");
     setIsPanelOpen(true);
   }, []);
 

--- a/workers/dc-api/src/routes/research.ts
+++ b/workers/dc-api/src/routes/research.ts
@@ -244,7 +244,9 @@ research.post("/projects/:projectId/research/analyze", researchQueryRateLimit, a
   const { userId } = c.get("auth");
   const projectId = c.req.param("projectId");
 
-  const body = (await c.req.json().catch(() => ({}))) as Partial<AnalysisInput>;
+  const body = (await c.req.json().catch(() => ({}))) as Partial<AnalysisInput> & {
+    sourceId?: string;
+  };
 
   // Verify project ownership
   const project = await c.env.DB.prepare(
@@ -266,8 +268,11 @@ research.post("/projects/:projectId/research/analyze", researchQueryRateLimit, a
 
   const service = new AIAnalysisService(c.env.DB, c.env.EXPORTS_BUCKET, provider);
 
+  // Accept sourceIds array or legacy sourceId string
+  const sourceIds = body.sourceIds ?? (body.sourceId ? [body.sourceId] : []);
+
   const input: AnalysisInput = {
-    sourceId: body.sourceId ?? "",
+    sourceIds,
     instruction: body.instruction ?? "",
   };
 


### PR DESCRIPTION
## Summary
- **Library tab** defaults to Drive browse view when connected — no more intermediate empty states or buried Browse buttons
- **Inline bookmark tagging** on document rows in browse view — tap to add/remove from Desk without opening each document
- **Desk tab** (replaces Ask) shows tagged documents with multi-select checkboxes and AI analysis
- **Multi-source analysis** — select multiple documents, write one instruction, analyze across all of them
- **API updated** to accept `sourceIds[]` with equal character budget distribution across sources
- **Design spec** at `docs/design/library-desk-spec.md` captures the full vision including deep analysis (map-reduce) for future

## Test plan
- [ ] Open Library with no connections — see empty state with "Add Source" button
- [ ] Connect Google Drive — Library shows Drive contents immediately (no empty state)
- [ ] Browse folders, see bookmark icons on document rows
- [ ] Tap bookmark — document tagged, toast shows "Added to desk"
- [ ] Tap filled bookmark — document untagged, toast shows "Removed from desk"
- [ ] Switch to Desk tab — see tagged documents with checkboxes
- [ ] Select multiple documents, tap "Analyze N documents"
- [ ] Verify streaming analysis works with multiple sources
- [ ] Untag from Desk tab via bookmark icon
- [ ] Empty Desk shows "Tag documents from the Library to work with them here."
- [ ] Select all / deselect all toggle works
- [ ] Mobile overlay panel renders correctly with new tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)