### PR TITLE
polish: Library/Desk vocabulary alignment and Desk tab badge

### DIFF
--- a/web/src/components/editor/onboarding-tooltips.tsx
+++ b/web/src/components/editor/onboarding-tooltips.tsx
@@ -179,7 +179,7 @@ function getPositionClasses(target: OnboardingStep["target"]): string {
       // Near the left edge where the sidebar lives
       return "top-1/3 left-4 lg:left-[270px]";
     case "sources":
-      // Near the top-right where the Sources button is in the toolbar
+      // Near the top-right where the Library button is in the toolbar
       return "top-16 right-4 lg:right-[200px]";
     case "text-selection":
       // Center of the content area, slightly below middle

--- a/web/src/components/sources/review-tab.tsx
+++ b/web/src/components/sources/review-tab.tsx
@@ -14,7 +14,7 @@ interface SourceDetailViewProps {
 /**
  * SourceDetailView - View full parsed source content, select text, insert into chapter.
  *
- * Rendered inline in the Sources tab's "detail" mode. Previously the Review tab.
+ * Rendered inline in the Library tab's "detail" mode (source content viewer).
  *
  * Insert behavior:
  * 1. Insert at cursor position if one exists in the editor

--- a/web/src/components/sources/sources-panel-overlay.tsx
+++ b/web/src/components/sources/sources-panel-overlay.tsx
@@ -1,21 +1,30 @@
 "use client";
 
+import { useMemo } from "react";
 import { useSourcesContext } from "@/contexts/sources-context";
 import { LibraryTab } from "./library-tab";
 import { DeskTab } from "./desk-tab";
 import type { SourcesTab } from "@/hooks/use-sources-panel";
-
-const TABS: { id: SourcesTab; label: string }[] = [
-  { id: "library", label: "Library" },
-  { id: "desk", label: "Desk" },
-];
 
 /**
  * Portrait/mobile overlay wrapper for the Sources panel.
  * Fixed position, full screen, backdrop + slide-in animation.
  */
 export function SourcesPanelOverlay() {
-  const { activeTab, setActiveTab, isPanelOpen, closePanel } = useSourcesContext();
+  const { activeTab, setActiveTab, isPanelOpen, closePanel, sources } = useSourcesContext();
+
+  const deskCount = useMemo(
+    () => sources.filter((s) => s.status === "active").length,
+    [sources],
+  );
+
+  const tabs: { id: SourcesTab; label: string }[] = useMemo(
+    () => [
+      { id: "library", label: "Library" },
+      { id: "desk", label: deskCount > 0 ? `Desk (${deskCount})` : "Desk" },
+    ],
+    [deskCount],
+  );
 
   if (!isPanelOpen) return null;
 
@@ -39,7 +48,7 @@ export function SourcesPanelOverlay() {
         {/* Header */}
         <div className="flex items-center justify-between px-4 h-12 border-b border-border shrink-0">
           <div className="flex items-center gap-1">
-            {TABS.map((tab) => (
+            {tabs.map((tab) => (
               <button
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}

--- a/web/src/components/sources/sources-panel.tsx
+++ b/web/src/components/sources/sources-panel.tsx
@@ -1,14 +1,10 @@
 "use client";
 
+import { useMemo } from "react";
 import { useSourcesContext } from "@/contexts/sources-context";
 import { LibraryTab } from "./library-tab";
 import { DeskTab } from "./desk-tab";
 import type { SourcesTab } from "@/hooks/use-sources-panel";
-
-const TABS: { id: SourcesTab; label: string }[] = [
-  { id: "library", label: "Library" },
-  { id: "desk", label: "Desk" },
-];
 
 /**
  * Main Sources panel container.
@@ -16,7 +12,20 @@ const TABS: { id: SourcesTab; label: string }[] = [
  * Width: w-[320px] on desktop, full on overlay.
  */
 export function SourcesPanel() {
-  const { activeTab, setActiveTab, closePanel, isPanelOpen } = useSourcesContext();
+  const { activeTab, setActiveTab, closePanel, isPanelOpen, sources } = useSourcesContext();
+
+  const deskCount = useMemo(
+    () => sources.filter((s) => s.status === "active").length,
+    [sources],
+  );
+
+  const tabs: { id: SourcesTab; label: string }[] = useMemo(
+    () => [
+      { id: "library", label: "Library" },
+      { id: "desk", label: deskCount > 0 ? `Desk (${deskCount})` : "Desk" },
+    ],
+    [deskCount],
+  );
 
   if (!isPanelOpen) return null;
 
@@ -25,7 +34,7 @@ export function SourcesPanel() {
       {/* Header */}
       <div className="flex items-center justify-between px-4 h-12 border-b border-border shrink-0">
         <div className="flex items-center gap-1">
-          {TABS.map((tab) => (
+          {tabs.map((tab) => (
             <button
               key={tab.id}
               onClick={() => setActiveTab(tab.id)}

--- a/web/src/components/sources/sources-section.tsx
+++ b/web/src/components/sources/sources-section.tsx
@@ -5,7 +5,7 @@ import { useSourcesContext } from "@/contexts/sources-context";
 import type { SourceConnection } from "@/hooks/use-sources";
 
 /**
- * SourcesSection - always-visible connections section in the Sources tab.
+ * SourcesSection - always-visible connections section in the Library tab.
  *
  * Shows project-scoped connections with Browse + Remove actions.
  * No collapsible behavior - connections are permanent anchors in the


### PR DESCRIPTION
## Summary
- Align DocumentPeekView with tagging model: "Study This" → "Add to Desk" / "On Desk" toggle with untag support
- Add document count badge to Desk tab label — "Desk (3)" when documents are tagged, plain "Desk" when empty
- Fix stale vocabulary in comments: "Sources tab" → "Library tab", "Sources button" → "Library button"

## Changes
- `document-peek-view.tsx` — Rename study → tag vocabulary, add untag toggle, derive state reactively from sources
- `sources-panel.tsx` / `sources-panel-overlay.tsx` — Dynamic Desk tab label with active document count
- `sources-section.tsx` / `review-tab.tsx` / `onboarding-tooltips.tsx` — Comment vocabulary fixes

## Test plan
- [ ] Open Library, tap a document to peek, verify "Add to Desk" button
- [ ] Tap "Add to Desk", verify toast says `Added "X" to desk` and button flips to "On Desk" (blue)
- [ ] Tap "On Desk", verify untag works with toast `Removed "X" from desk`
- [ ] Verify Desk tab label shows count when documents are tagged
- [ ] Verify Desk tab label shows plain "Desk" when empty
- [ ] Test on iPad overlay panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)