### PR TITLE
fix: convert remaining blocking refetches to optimistic updates (#360)

### DIFF
--- a/web/src/hooks/use-project-actions.ts
+++ b/web/src/hooks/use-project-actions.ts
@@ -136,10 +136,14 @@ export function useProjectActions({ getToken, projectId }: UseProjectActionsOpti
           return null;
         }
 
-        const result = (await response.json()) as { id: string };
+        const result = (await response.json()) as { id: string; project?: ProjectSummary };
 
-        // Refresh project list so new copy appears
-        await fetchProjects();
+        // Optimistic: append from response if available, otherwise refetch
+        if (result.project) {
+          setProjects((prev) => [...prev, result.project!]);
+        } else {
+          await fetchProjects();
+        }
 
         return result.id;
       } catch (err) {


### PR DESCRIPTION
## Summary

- **uploadLocalFile**: Append new source from upload response instead of refetching entire list
- **restoreSource**: Append restored source from PATCH response instead of refetching
- **unlinkConnection**: Optimistic connection removal with rollback; reduced from double refetch (connections + sources) to single source sync
- **useAIInstructions create/update/remove**: All three CRUD operations now use optimistic local state with rollback on failure
- **duplicateProject**: Append from response when project data included; fallback to refetch

Closes #360

## Test plan

- [ ] Upload a local file to desk - appears instantly without panel flicker
- [ ] Remove a source, then undo (restore) - instant feedback both ways
- [ ] Unlink a Drive connection - connection disappears immediately, sources update
- [ ] Create/edit/delete a saved instruction - instant UI response
- [ ] Duplicate a project - new copy appears in list without full reload
- [ ] Verify rollback: disconnect network, try instruction CRUD - should revert on failure

Generated with [Claude Code](https://claude.com/claude-code)