### PR TITLE
fix: desk tagging and editor panel text selection

### DIFF
--- a/web/src/components/editor/editor-panel.tsx
+++ b/web/src/components/editor/editor-panel.tsx
@@ -81,19 +81,11 @@ export function EditorPanelOverlay({ isOpen, onClose, children }: EditorPanelPro
 
   return (
     <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-40 bg-black/30 editor-panel-backdrop-fade-in lg:hidden"
-        onClick={onClose}
-        aria-hidden="true"
-      />
-
-      {/* Panel */}
+      {/* Panel — non-modal so users can still select text in the editor */}
       <div
         className="editor-panel-overlay fixed inset-y-0 left-0 z-50 w-full max-w-[380px]
                    bg-[var(--color-background)] shadow-xl editor-panel-slide-in flex flex-col lg:hidden"
-        role="dialog"
-        aria-modal="true"
+        role="complementary"
         aria-label="Chapter editor"
       >
         {/* Header */}


### PR DESCRIPTION
## Summary
- **Desk tagging:** Previously-removed (archived) documents silently failed when re-tagged for the desk — API returned 201 with empty sources array, toast showed success but nothing appeared. Now re-activates the archived row instead of skipping it.
- **Editor panel:** Removed the full-screen backdrop from `EditorPanelOverlay` so users can select chapter text while the panel is open on portrait/tablet viewports. Panel is now non-modal (`role="complementary"`), dismissible via the close button.

## Test plan
- [ ] Tag a document for the desk from the Library → verify it appears on the Desk tab
- [ ] Remove a document from the desk, then re-tag it → verify it reappears
- [ ] Open the Chapter Editor panel on portrait iPad → verify text in the editor is selectable
- [ ] Verify the close (X) button still dismisses the editor panel overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)