### PR TITLE
fix: complete Editor Panel migration — remove deprecated AI Rewrite bottom sheet

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -125,15 +125,17 @@ function EditorPageInner() {
   // Without this, clicking outside the editor leaves editorSelectedText
   // set from the previous selection, causing the instruction panel to
   // show "Selected text" when nothing is visually selected.
+  // Exception: keep selection alive while the editor panel is open —
+  // the panel needs the selected text to offer rewrite instructions.
   const handleEditorBlur = useCallback(() => {
-    // Small delay so clicks on panel buttons can read the selection first
     setTimeout(() => {
+      if (editorPanelOpen) return; // Panel needs the selection
       const editor = editorRef.current?.getEditor();
       if (!editor?.isFocused) {
         setEditorSelectedText("");
       }
     }, 200);
-  }, []);
+  }, [editorPanelOpen]);
 
   const handleToggleEditorPanel = useCallback(() => {
     setEditorPanelOpen((prev) => !prev);
@@ -310,9 +312,6 @@ function EditorPageInner() {
               onSaveRetry={saveNow}
               viewMode={viewMode}
               onViewModeChange={setViewMode}
-              selectionWordCount={selectionWordCount}
-              aiSheetState={aiSheetState}
-              onOpenAiRewrite={handleOpenAiRewrite}
               isEditorPanelOpen={editorPanelOpen}
               onToggleEditorPanel={handleToggleEditorPanel}
               projectId={projectId}
@@ -373,14 +372,6 @@ function EditorPageInner() {
             setDeleteChapterDialogOpen(false);
             setChapterToDelete(null);
           }}
-          // AI Rewrite
-          aiSheetState={aiSheetState}
-          aiCurrentResult={aiCurrentResult}
-          aiErrorMessage={aiErrorMessage}
-          onAIAccept={handleAIAccept}
-          onAIRetry={handleAIRetry}
-          onAIDiscard={handleAIDiscard}
-          onGoDeeper={handleGoDeeper}
         />
 
         <SourcesPanelOverlay />
@@ -395,6 +386,9 @@ function EditorPageInner() {
             onRetry={handleAIRetry}
             onDiscard={handleAIDiscard}
             onGoDeeper={handleGoDeeper}
+            onRewriteWithInstruction={() => {
+              handleOpenAiRewrite();
+            }}
           />
         </EditorPanelOverlay>
       </div>

--- a/web/src/components/editor/chapter-editor-panel.tsx
+++ b/web/src/components/editor/chapter-editor-panel.tsx
@@ -1,8 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
-import type { AIRewriteResult } from "@/components/editor/ai-rewrite-sheet";
-import type { SheetState } from "@/hooks/use-ai-rewrite";
+import type { AIRewriteResult, SheetState } from "@/hooks/use-ai-rewrite";
 import { StreamingResponse } from "./streaming-response";
 import { useSourcesContext } from "@/contexts/sources-context";
 import { InstructionPicker } from "@/components/sources/instruction-picker";

--- a/web/src/components/editor/editor-dialogs.tsx
+++ b/web/src/components/editor/editor-dialogs.tsx
@@ -2,13 +2,10 @@
 
 import { useRouter } from "next/navigation";
 import type { ProjectData } from "@/types/editor";
-import type { AIRewriteResult } from "./ai-rewrite-sheet";
-import type { SheetState } from "@/hooks/use-ai-rewrite";
 import { DeleteProjectDialog } from "@/components/project/delete-project-dialog";
 import { RenameProjectDialog } from "@/components/project/rename-project-dialog";
 import { DuplicateProjectDialog } from "@/components/project/duplicate-project-dialog";
 import { DeleteChapterDialog } from "@/components/project/delete-chapter-dialog";
-import { AIRewriteSheet } from "./ai-rewrite-sheet";
 
 interface EditorDialogsProps {
   projectData: ProjectData | null;
@@ -35,15 +32,6 @@ interface EditorDialogsProps {
   chapterToDelete: string | null;
   onDeleteChapter: () => Promise<void>;
   onCloseDeleteChapterDialog: () => void;
-
-  // AI Rewrite
-  aiSheetState: SheetState;
-  aiCurrentResult: AIRewriteResult | null;
-  aiErrorMessage: string | null;
-  onAIAccept: (result: AIRewriteResult) => Promise<void>;
-  onAIRetry: (result: AIRewriteResult, instruction: string) => Promise<void>;
-  onAIDiscard: (result: AIRewriteResult) => Promise<void>;
-  onGoDeeper: (result: AIRewriteResult) => void;
 }
 
 /**
@@ -73,13 +61,6 @@ export function EditorDialogs({
   chapterToDelete,
   onDeleteChapter,
   onCloseDeleteChapterDialog,
-  aiSheetState,
-  aiCurrentResult,
-  aiErrorMessage,
-  onAIAccept,
-  onAIRetry,
-  onAIDiscard,
-  onGoDeeper,
 }: EditorDialogsProps) {
   const router = useRouter();
 
@@ -131,15 +112,6 @@ export function EditorDialogs({
         onCancel={onCloseDeleteChapterDialog}
       />
 
-      <AIRewriteSheet
-        sheetState={aiSheetState}
-        result={aiCurrentResult}
-        errorMessage={aiErrorMessage}
-        onAccept={onAIAccept}
-        onRetry={onAIRetry}
-        onDiscard={onAIDiscard}
-        onGoDeeper={onGoDeeper}
-      />
     </>
   );
 }

--- a/web/src/components/editor/editor-toolbar.tsx
+++ b/web/src/components/editor/editor-toolbar.tsx
@@ -2,7 +2,6 @@
 
 import type { ProjectData } from "@/types/editor";
 import type { SaveStatus } from "@/hooks/use-auto-save";
-import type { SheetState } from "@/hooks/use-ai-rewrite";
 import type { ProjectSummary } from "@/hooks/use-project-actions";
 import { ProjectSwitcher } from "@/components/project/project-switcher";
 import { SaveIndicator } from "./save-indicator";
@@ -23,11 +22,6 @@ interface EditorToolbarProps {
   // View mode (#318)
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
-
-  // AI Rewrite
-  selectionWordCount: number;
-  aiSheetState: SheetState;
-  onOpenAiRewrite: () => void;
 
   // Editor Panel (#317)
   isEditorPanelOpen?: boolean;
@@ -62,9 +56,6 @@ export function EditorToolbar({
   onSaveRetry,
   viewMode,
   onViewModeChange,
-  selectionWordCount,
-  aiSheetState,
-  onOpenAiRewrite,
   isEditorPanelOpen = false,
   onToggleEditorPanel,
   projectId,
@@ -157,34 +148,6 @@ export function EditorToolbar({
           </svg>
           <span className="hidden sm:inline">Library</span>
         </button>
-
-        {selectionWordCount > 0 && aiSheetState === "idle" && (
-          <>
-            <button
-              onClick={onOpenAiRewrite}
-              className="h-9 px-2.5 flex items-center gap-1.5 rounded-lg text-sm font-medium
-                         text-blue-700 hover:bg-blue-50 transition-colors"
-              aria-label="AI Rewrite selected text"
-            >
-              <svg
-                className="w-4 h-4 shrink-0"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z"
-                />
-              </svg>
-              <span className="hidden sm:inline">AI Rewrite</span>
-            </button>
-            <div className="w-px h-5 bg-border" aria-hidden="true" />
-          </>
-        )}
 
         <ExportMenu
           projectId={projectId}

--- a/web/src/hooks/use-ai-rewrite.ts
+++ b/web/src/hooks/use-ai-rewrite.ts
@@ -1,9 +1,23 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
-import type { AIRewriteResult } from "@/components/editor/ai-rewrite-sheet";
 
 export type SheetState = "idle" | "streaming" | "complete";
+
+export interface AIRewriteResult {
+  /** AI interaction ID from the API */
+  interactionId: string;
+  /** The original selected text before AI rewrite */
+  originalText: string;
+  /** The AI-generated rewrite suggestion */
+  rewriteText: string;
+  /** The instruction the user gave to the AI */
+  instruction: string;
+  /** Which attempt number this is (1-based) */
+  attemptNumber: number;
+  /** Which AI tier produced this result */
+  tier: "edge" | "frontier";
+}
 
 interface UseAIRewriteOptions {
   /** Function to get the auth token */

--- a/web/src/hooks/use-editor-ai.ts
+++ b/web/src/hooks/use-editor-ai.ts
@@ -1,8 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import { useAIRewrite, type SheetState } from "@/hooks/use-ai-rewrite";
-import type { AIRewriteResult } from "@/components/editor/ai-rewrite-sheet";
+import { useAIRewrite, type SheetState, type AIRewriteResult } from "@/hooks/use-ai-rewrite";
 import type { ChapterEditorHandle } from "@/components/editor/chapter-editor";
 
 interface Chapter {

--- a/web/test/components/editor-panel.test.tsx
+++ b/web/test/components/editor-panel.test.tsx
@@ -144,35 +144,35 @@ describe("EditorPanelOverlay", () => {
     expect(container.firstChild).toBeNull();
   });
 
-  it("has role=dialog for overlay panel", () => {
+  it("has role=complementary for non-modal overlay (allows editor text selection)", () => {
     render(
       <EditorPanelOverlay isOpen={true} onClose={vi.fn()}>
         <div>Content</div>
       </EditorPanelOverlay>,
     );
-    expect(screen.getByRole("dialog", { name: "Chapter editor" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("complementary", { name: "Chapter editor" }),
+    ).toBeInTheDocument();
   });
 
-  it("has aria-modal=true for overlay panel", () => {
+  it("does not have aria-modal (non-modal panel)", () => {
     render(
       <EditorPanelOverlay isOpen={true} onClose={vi.fn()}>
         <div>Content</div>
       </EditorPanelOverlay>,
     );
-    expect(screen.getByRole("dialog")).toHaveAttribute("aria-modal", "true");
+    const panel = screen.getByRole("complementary", { name: "Chapter editor" });
+    expect(panel).not.toHaveAttribute("aria-modal");
   });
 
-  it("calls onClose when backdrop is clicked", () => {
+  it("calls onClose when close button is clicked", () => {
     const onClose = vi.fn();
-    const { container } = render(
+    render(
       <EditorPanelOverlay isOpen={true} onClose={onClose}>
         <div>Content</div>
       </EditorPanelOverlay>,
     );
-    // Click the backdrop (first child is the backdrop div)
-    const backdrop = container.querySelector("[aria-hidden='true']");
-    expect(backdrop).toBeInTheDocument();
-    fireEvent.click(backdrop!);
+    fireEvent.click(screen.getByLabelText("Close editor panel"));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/test/components/editor-toolbar.test.tsx
+++ b/web/test/components/editor-toolbar.test.tsx
@@ -5,12 +5,10 @@ import { EditorToolbar } from "@/components/editor/editor-toolbar";
 /**
  * Tests for EditorToolbar — the top toolbar for the writing environment.
  *
- * Contains: ProjectSwitcher, SaveIndicator, AI Rewrite button,
- * ExportMenu, SettingsMenu.
+ * Contains: ProjectSwitcher, SaveIndicator, Editor panel toggle,
+ * Library toggle, ExportMenu, SettingsMenu.
  *
  * Mock strategy: We mock all child components to isolate toolbar behavior.
- * The key behavior to test is the conditional rendering of the AI Rewrite button
- * based on selectionWordCount and aiSheetState.
  */
 
 // Mock SourcesContext used by toolbar for Sources toggle button
@@ -70,9 +68,6 @@ function makeProps(overrides?: Partial<React.ComponentProps<typeof EditorToolbar
     onSaveRetry: vi.fn(),
     viewMode: "chapter" as const,
     onViewModeChange: vi.fn(),
-    selectionWordCount: 0,
-    aiSheetState: "idle" as const,
-    onOpenAiRewrite: vi.fn(),
     projectId: "proj-1",
     activeChapterId: "ch-1",
     getToken: vi.fn().mockResolvedValue("token"),
@@ -121,43 +116,31 @@ describe("EditorToolbar", () => {
   });
 
   // ────────────────────────────────────────────
-  // AI Rewrite button conditional rendering
+  // Editor Panel toggle button
   // ────────────────────────────────────────────
 
-  it("does not show AI Rewrite button when no text is selected", () => {
-    render(<EditorToolbar {...makeProps({ selectionWordCount: 0 })} />);
+  it("renders Editor panel toggle button when onToggleEditorPanel is provided", () => {
+    render(<EditorToolbar {...makeProps({ onToggleEditorPanel: vi.fn() })} />);
 
-    expect(screen.queryByLabelText("AI Rewrite selected text")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Open editor panel")).toBeInTheDocument();
   });
 
-  it("shows AI Rewrite button when text is selected and sheet is idle", () => {
-    render(<EditorToolbar {...makeProps({ selectionWordCount: 5, aiSheetState: "idle" })} />);
+  it("calls onToggleEditorPanel when Editor button is clicked", () => {
+    const onToggleEditorPanel = vi.fn();
+    render(<EditorToolbar {...makeProps({ onToggleEditorPanel })} />);
 
-    expect(screen.getByLabelText("AI Rewrite selected text")).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText("Open editor panel"));
+    expect(onToggleEditorPanel).toHaveBeenCalledTimes(1);
   });
 
-  it("does not show AI Rewrite button when sheet is streaming", () => {
-    render(<EditorToolbar {...makeProps({ selectionWordCount: 5, aiSheetState: "streaming" })} />);
-
-    expect(screen.queryByLabelText("AI Rewrite selected text")).not.toBeInTheDocument();
-  });
-
-  it("does not show AI Rewrite button when sheet is complete", () => {
-    render(<EditorToolbar {...makeProps({ selectionWordCount: 5, aiSheetState: "complete" })} />);
-
-    expect(screen.queryByLabelText("AI Rewrite selected text")).not.toBeInTheDocument();
-  });
-
-  it("calls onOpenAiRewrite when AI Rewrite button is clicked", () => {
-    const onOpenAiRewrite = vi.fn();
+  it("shows active state when editor panel is open", () => {
     render(
       <EditorToolbar
-        {...makeProps({ selectionWordCount: 5, aiSheetState: "idle", onOpenAiRewrite })}
+        {...makeProps({ isEditorPanelOpen: true, onToggleEditorPanel: vi.fn() })}
       />,
     );
 
-    fireEvent.click(screen.getByLabelText("AI Rewrite selected text"));
-    expect(onOpenAiRewrite).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText("Close editor panel")).toBeInTheDocument();
   });
 
   // ────────────────────────────────────────────

--- a/web/test/hooks/use-ai-rewrite.test.ts
+++ b/web/test/hooks/use-ai-rewrite.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useAIRewrite } from "@/hooks/use-ai-rewrite";
-import type { AIRewriteResult } from "@/components/editor/ai-rewrite-sheet";
+import { useAIRewrite, type AIRewriteResult } from "@/hooks/use-ai-rewrite";
 
 /**
  * Tests for useAIRewrite — the AI rewrite state machine hook.


### PR DESCRIPTION
## Summary
- Removes the old `AIRewriteSheet` bottom sheet from `EditorDialogs` — it was still rendering alongside the new Chapter Editor panel
- Removes the toolbar "AI Rewrite" sparkle button — the "Editor" toggle is now the sole entry point
- Fixes text selection persistence: `editorSelectedText` no longer clears on blur while the Editor panel is open (root cause of the empty panel state)
- Wires missing `onRewriteWithInstruction` prop on the overlay `ChapterEditorPanel`
- Moves `AIRewriteResult` type from the deprecated `ai-rewrite-sheet.tsx` to `use-ai-rewrite.ts`
- Updates tests for non-modal overlay behavior (role=complementary, no backdrop)

## Test plan
- [x] `tsc --noEmit` passes (web + API)
- [x] 199/199 tests pass
- [ ] Open Editor panel on iPad portrait → select text in chapter → panel shows "Selected text" disclosure and instruction chips
- [ ] Tap an instruction chip → rewrite streams into the panel (no bottom sheet appears)
- [ ] Accept/Discard → panel persists, ready for next selection
- [ ] Verify no "AI Rewrite" button in toolbar — only "Editor" toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)