### PR TITLE
fix: increase suggestion chip height to 36px minimum

### DIFF
--- a/web/src/components/editor/chapter-editor-panel.tsx
+++ b/web/src/components/editor/chapter-editor-panel.tsx
@@ -240,8 +240,8 @@ export function ChapterEditorPanel({
                   aria-selected={editedInstruction === inst.instructionText}
                   onClick={() => handleChipSelect(inst.instructionText)}
                   disabled={isStreaming}
-                  className={`h-8 px-3 text-xs font-medium rounded-full transition-colors
-                             min-h-[32px] border
+                  className={`h-9 px-3 text-xs font-medium rounded-full transition-colors
+                             min-h-[36px] border
                              ${
                                editedInstruction === inst.instructionText
                                  ? "bg-[var(--dc-color-interactive-escalation-subtle)] text-[var(--dc-color-interactive-escalation)] border-[var(--dc-color-interactive-escalation-border)]"


### PR DESCRIPTION
## Summary
- Suggestion chips in ChapterEditorPanel used `h-8`/`min-h-[32px]` (32px), below the PRD-specified 36px minimum
- Updated to `h-9`/`min-h-[36px]` for proper touch target sizing on iPad Safari

Closes #365

## Test plan
- [ ] Verify suggestion chips in the editor panel meet 36px min height
- [ ] Spot-check touch targets on iPad Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)