### PR TITLE
fix: Help page accordion keyboard navigation (#368)

### DIFF
--- a/web/src/app/(protected)/help/page.tsx
+++ b/web/src/app/(protected)/help/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useRef, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { ToastProvider } from "@/components/toast";
 import { AccordionSection } from "@/components/help/accordion-section";
@@ -209,6 +209,38 @@ export default function HelpPage() {
 function HelpPageContent() {
   const router = useRouter();
   const [feedbackOpen, setFeedbackOpen] = useState(false);
+  const accordionRef = useRef<HTMLDivElement>(null);
+
+  /** ArrowUp/Down/Home/End navigation between accordion section headers */
+  const handleAccordionKeyDown = useCallback((e: React.KeyboardEvent) => {
+    const container = accordionRef.current;
+    if (!container) return;
+
+    const headers = Array.from(container.querySelectorAll<HTMLElement>("h3 > button"));
+    const currentIndex = headers.indexOf(e.target as HTMLElement);
+    if (currentIndex === -1) return;
+
+    let nextIndex: number | null = null;
+    switch (e.key) {
+      case "ArrowDown":
+        nextIndex = (currentIndex + 1) % headers.length;
+        break;
+      case "ArrowUp":
+        nextIndex = (currentIndex - 1 + headers.length) % headers.length;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = headers.length - 1;
+        break;
+      default:
+        return;
+    }
+
+    e.preventDefault();
+    headers[nextIndex].focus();
+  }, []);
 
   const handleReplayTour = () => {
     resetOnboarding();
@@ -221,7 +253,7 @@ function HelpPageContent() {
       <h1 className="font-serif text-3xl font-semibold text-gray-900 mb-8">Help</h1>
 
       {/* FAQ Sections */}
-      <div>
+      <div ref={accordionRef} onKeyDown={handleAccordionKeyDown}>
         {FAQ_SECTIONS.map((section) => (
           <AccordionSection
             key={section.id}


### PR DESCRIPTION
## Summary
- Adds ArrowUp/Down keyboard navigation between accordion section headers on the Help page (wraps at ends)
- Adds Home/End to jump to first/last section header
- Only activates when focus is on an accordion header button — does not interfere with other keyboard interactions

## Test plan
- [ ] Tab to first accordion header, press ArrowDown — focus moves to next section header
- [ ] Press ArrowUp from first header — focus wraps to last header
- [ ] Press Home — focus jumps to first header
- [ ] Press End — focus jumps to last header
- [ ] Enter/Space still toggles accordion open/closed
- [ ] `npm run typecheck` clean

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)