### PR TITLE
feat: toolbar polish — P2 design issues (#390-#395)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -31,6 +31,22 @@
   --dc-color-surface-tertiary: #f3f4f6;
   /* Toggle indicator, panel backgrounds */
   --dc-color-surface-primary: #ffffff;
+
+  /* Layout tokens (#395) */
+  --dc-toolbar-height: 48px;
+  --dc-toolbar-padding-x: 16px;
+  --dc-toolbar-gap: 8px;
+  --dc-toggle-height: 44px;
+  --dc-toggle-option-height: 40px;
+  --dc-toggle-option-min-width: 72px;
+  --dc-panel-toggle-height: 44px;
+
+  /* Motion tokens (#395) */
+  --dc-motion-fast: 150ms;
+  --dc-motion-normal: 200ms;
+  --dc-motion-ease-in-out: ease-in-out;
+  --dc-motion-ease-out: ease-out;
+  --dc-motion-ease-in: ease-in;
 }
 
 @theme inline {

--- a/web/src/app/styles/editor-panel.css
+++ b/web/src/app/styles/editor-panel.css
@@ -23,8 +23,21 @@
   }
 }
 
+@keyframes editor-panel-slide-out {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
 .editor-panel-slide-in {
   animation: editor-panel-slide-in 200ms ease-out;
+}
+
+.editor-panel-slide-out {
+  animation: editor-panel-slide-out 200ms ease-in forwards;
 }
 
 .editor-panel-backdrop-fade-in {

--- a/web/src/components/editor/chapter-editor-panel.tsx
+++ b/web/src/components/editor/chapter-editor-panel.tsx
@@ -325,12 +325,18 @@ export function ChapterEditorPanel({
           </div>
         )}
 
-        {/* Streaming response area */}
+        {/* Streaming response area (#390) */}
         {hasResult && (
           <div>
             <div className="flex items-center justify-between mb-2">
               <h3 className="text-xs font-medium text-[var(--dc-color-interactive-escalation)]">
-                Rewrite
+                {panelState === "streaming"
+                  ? "Rewriting\u2026"
+                  : panelState === "error"
+                    ? "Could not finish the rewrite."
+                    : result.attemptNumber > 1
+                      ? "Here is another take."
+                      : "Here is a rewrite."}
               </h3>
               {isStreaming && (
                 <span className="text-xs text-[var(--dc-color-interactive-escalation)] flex items-center gap-1">


### PR DESCRIPTION
## Summary

- **#395**: Add layout and motion CSS design tokens (`--dc-toolbar-*`, `--dc-motion-*`)
- **#392**: Add `role="toolbar"`, `aria-label`, `aria-orientation` to editor toolbar
- **#393**: Add `aria-live="polite"` announcements for view/panel toggle state changes
- **#394**: Add keyboard shortcuts — `Cmd+Shift+E` (Editor), `Cmd+Shift+L` (Library), `Cmd+Shift+B` (Chapter/Book toggle)
- **#390**: Replace static "Rewrite" header with contextual copy based on streaming state
- **#391**: Add exit animations to Editor Panel using `useDelayedUnmount` hook

## Test plan

- [ ] Verify layout/motion tokens in globals.css
- [ ] Screen reader: toolbar announced as toolbar, panel/view changes announced via live region
- [ ] Keyboard shortcuts work on Mac (Cmd+Shift) and Windows (Ctrl+Shift)
- [ ] Editor panel slides out with 200ms animation instead of instant disappear
- [ ] Chapter editor panel header changes contextually during streaming
- [ ] `npm run typecheck` and `npm run lint` pass
- [ ] All 523 tests pass

Closes #390, closes #391, closes #392, closes #393, closes #394, closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)