### PR TITLE
feat: implement highlight flash on rewrite accept (#325)

### DIFF
--- a/web/src/app/styles/editor.css
+++ b/web/src/app/styles/editor.css
@@ -153,10 +153,13 @@
   animation: slide-up 0.3s ease-out;
 }
 
-/* AI Rewrite - highlight flash on accepted text replacement */
+/* AI Rewrite - highlight flash on accepted text replacement (#325)
+ * Uses --dc-color-interactive-primary (blue) with 30% opacity.
+ * Animation duration: 1.5s per design spec.
+ */
 @keyframes highlight-flash {
   0% {
-    background-color: rgba(59, 130, 246, 0.3);
+    background-color: color-mix(in srgb, var(--dc-color-interactive-primary) 30%, transparent);
   }
   100% {
     background-color: transparent;
@@ -165,6 +168,7 @@
 
 .ai-rewrite-highlight {
   animation: highlight-flash 1.5s ease-out;
+  border-radius: 2px;
 }
 
 /* Respect prefers-reduced-motion */

--- a/web/src/components/editor/text-editor.tsx
+++ b/web/src/components/editor/text-editor.tsx
@@ -5,7 +5,13 @@ import StarterKit from "@tiptap/starter-kit";
 import Placeholder from "@tiptap/extension-placeholder";
 import { useEffect, useCallback, useImperativeHandle, forwardRef, useRef } from "react";
 import { useTextSelection } from "@/hooks/use-text-selection";
-import { FootnoteRef, FootnoteContent, FootnoteSection, FootnotePlugin } from "@/extensions";
+import {
+  FootnoteRef,
+  FootnoteContent,
+  FootnoteSection,
+  FootnotePlugin,
+  HighlightFlash,
+} from "@/extensions";
 
 /** Handle exposed by TextEditor for programmatic operations */
 export interface TextEditorHandle {
@@ -92,6 +98,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(function
       FootnoteContent,
       FootnoteSection,
       FootnotePlugin,
+      HighlightFlash,
     ],
     content,
     editable,
@@ -234,18 +241,16 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(function
           .insertContent(replacementText)
           .run();
 
+        // Flash highlight on the replaced text range
         requestAnimationFrame(() => {
-          const editorElement = editor.view.dom;
           const { from: cursorPos } = editor.state.selection;
           const highlightFrom = cursorPos - replacementText.length;
 
-          editor.chain().setTextSelection({ from: highlightFrom, to: cursorPos }).run();
+          // Trigger the highlight flash decoration
+          editor.commands.flashHighlight({ from: highlightFrom, to: cursorPos });
 
-          editorElement.classList.add("ai-rewrite-highlight");
-          setTimeout(() => {
-            editorElement.classList.remove("ai-rewrite-highlight");
-            editor.chain().setTextSelection(cursorPos).run();
-          }, 1500);
+          // Collapse selection to end of inserted text
+          editor.chain().setTextSelection(cursorPos).run();
         });
 
         return true;

--- a/web/src/extensions/highlight-flash.ts
+++ b/web/src/extensions/highlight-flash.ts
@@ -1,0 +1,112 @@
+import { Extension } from "@tiptap/core";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+import { Decoration, DecorationSet } from "@tiptap/pm/view";
+
+const HIGHLIGHT_DURATION_MS = 1500;
+
+const highlightFlashKey = new PluginKey("highlightFlash");
+
+interface HighlightFlashStorage {
+  from: number;
+  to: number;
+  startTime: number;
+}
+
+// Shared storage reference for the plugin
+let sharedStorage: { activeHighlight: HighlightFlashStorage | null } | null = null;
+
+/**
+ * HighlightFlash - Temporary inline decoration for AI rewrite feedback.
+ *
+ * Creates a short-lived highlight on a text range to provide visual feedback
+ * when AI rewrite is accepted. The highlight fades out using CSS animation.
+ *
+ * Usage:
+ *   editor.commands.flashHighlight({ from, to })
+ *
+ * The decoration auto-removes after 1.5s. Respects prefers-reduced-motion
+ * via CSS (animation disabled in editor.css).
+ */
+export const HighlightFlash = Extension.create({
+  name: "highlightFlash",
+
+  addStorage() {
+    const storage = {
+      activeHighlight: null as HighlightFlashStorage | null,
+    };
+    sharedStorage = storage;
+    return storage;
+  },
+
+  addCommands() {
+    return {
+      flashHighlight:
+        ({ from, to }: { from: number; to: number }) =>
+        ({ editor, tr }) => {
+          // Store the highlight range
+          const startTime = Date.now();
+          this.storage.activeHighlight = {
+            from,
+            to,
+            startTime,
+          };
+
+          // Force a view update by dispatching a transaction
+          editor.view.dispatch(tr);
+
+          // Schedule removal after animation duration
+          setTimeout(() => {
+            if (this.storage.activeHighlight?.startTime === startTime) {
+              this.storage.activeHighlight = null;
+              // Force another update to remove the decoration
+              if (editor.view && !editor.isDestroyed) {
+                editor.view.dispatch(editor.state.tr);
+              }
+            }
+          }, HIGHLIGHT_DURATION_MS);
+
+          return true;
+        },
+    };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: highlightFlashKey,
+
+        props: {
+          decorations(state) {
+            const highlight = sharedStorage?.activeHighlight;
+            if (!highlight) return DecorationSet.empty;
+
+            // Validate range is within document bounds
+            const docSize = state.doc.content.size;
+            const from = Math.max(0, Math.min(highlight.from, docSize));
+            const to = Math.max(from, Math.min(highlight.to, docSize));
+
+            if (from >= to) return DecorationSet.empty;
+
+            const decoration = Decoration.inline(from, to, {
+              class: "ai-rewrite-highlight",
+            });
+
+            return DecorationSet.create(state.doc, [decoration]);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    highlightFlash: {
+      /**
+       * Flash a temporary highlight on a text range.
+       * Used for AI rewrite accept feedback.
+       */
+      flashHighlight: (options: { from: number; to: number }) => ReturnType;
+    };
+  }
+}

--- a/web/src/extensions/index.ts
+++ b/web/src/extensions/index.ts
@@ -6,6 +6,9 @@
  * - FootnoteContent: Block entry at bottom of chapter
  * - FootnoteSection: Wrapper container for all footnote entries
  * - FootnotePlugin: Auto-renumbering and orphan cleanup
+ *
+ * Highlight flash:
+ * - HighlightFlash: Temporary decoration for AI rewrite feedback
  */
 
 export { FootnoteRef } from "./footnote-ref";
@@ -13,3 +16,4 @@ export { FootnoteContent } from "./footnote-content";
 export { FootnoteSection } from "./footnote-section";
 export { FootnotePlugin } from "./footnote-plugin";
 export { insertFootnote, insertClipWithFootnote } from "./footnote-commands";
+export { HighlightFlash } from "./highlight-flash";


### PR DESCRIPTION
## Summary

- Add visual feedback when user accepts AI rewrite by flashing the replaced text with a blue highlight
- Create `HighlightFlash` Tiptap extension using ProseMirror decorations to highlight only the replaced text range (not the entire editor)
- Use design token `--dc-color-interactive-primary` at 30% opacity per spec
- Animation duration: 1.5s per design spec
- Respects `prefers-reduced-motion: reduce` via CSS media query

## Test plan

- [ ] Select text in editor, trigger AI rewrite, tap "Use This" - replaced text flashes blue
- [ ] Flash lasts 1.5 seconds then fades out
- [ ] With system reduced motion enabled, no animation occurs
- [ ] Panel stays open after accept
- [ ] No toast notification appears
- [ ] Works on iPad Safari

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)