### PR TITLE
refactor: extract duplicated focus trap logic into useFocusTrap hook (#375)

### DIFF
--- a/web/src/components/feedback/feedback-sheet.tsx
+++ b/web/src/components/feedback/feedback-sheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback } from "react";
 import { useAuth } from "@clerk/nextjs";
 import { useToast } from "@/components/toast";
 import { useFeedbackContext } from "@/hooks/use-feedback-context";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || "";
 
@@ -33,7 +34,7 @@ export function FeedbackSheet({ isOpen, onClose }: FeedbackSheetProps) {
   const { showToast } = useToast();
   const { collectContext } = useFeedbackContext();
 
-  const sheetRef = useRef<HTMLDivElement>(null);
+  const sheetRef = useFocusTrap({ isOpen, onEscape: onClose });
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   const [type, setType] = useState<FeedbackType | null>(null);
@@ -60,52 +61,6 @@ export function FeedbackSheet({ isOpen, onClose }: FeedbackSheetProps) {
       setIsSubmitting(false);
     }
   }, [isOpen]);
-
-  // Focus trap and Escape handler
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent) => {
-      if (!isOpen) return;
-
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-        return;
-      }
-
-      if (event.key !== "Tab") return;
-
-      const focusableElements = sheetRef.current?.querySelectorAll<HTMLElement>(
-        'button:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
-      );
-
-      if (!focusableElements || focusableElements.length === 0) return;
-
-      const firstElement = focusableElements[0];
-      const lastElement = focusableElements[focusableElements.length - 1];
-
-      if (event.shiftKey) {
-        if (document.activeElement === firstElement) {
-          event.preventDefault();
-          lastElement.focus();
-        }
-      } else {
-        if (document.activeElement === lastElement) {
-          event.preventDefault();
-          firstElement.focus();
-        }
-      }
-    },
-    [isOpen, onClose],
-  );
-
-  useEffect(() => {
-    if (isOpen) {
-      document.addEventListener("keydown", handleKeyDown);
-    }
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isOpen, handleKeyDown]);
 
   // Body scroll lock
   useEffect(() => {

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
 import {
   DndContext,
   closestCenter,
@@ -637,12 +638,6 @@ function InlineRenameInput({
 }
 
 /**
- * Focusable element selector for focus management
- */
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
-
-/**
  * Mobile sidebar overlay component
  * Used when sidebar is shown as overlay in portrait mode
  *
@@ -662,80 +657,7 @@ export function SidebarOverlay({
   onClose: () => void;
   children: React.ReactNode;
 }) {
-  const panelRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<Element | null>(null);
-  const prevIsOpenRef = useRef(false);
-
-  // Focus management: capture trigger, focus first element, return focus on close
-  useEffect(() => {
-    const wasOpen = prevIsOpenRef.current;
-    prevIsOpenRef.current = isOpen;
-
-    if (isOpen && !wasOpen) {
-      // Opening: capture the element that triggered the overlay
-      triggerRef.current = document.activeElement;
-
-      // Focus the first focusable element inside the panel
-      if (panelRef.current) {
-        const firstFocusable = panelRef.current.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-        if (firstFocusable) {
-          firstFocusable.focus();
-        }
-      }
-    } else if (!isOpen && wasOpen) {
-      // Closing: return focus to the trigger element
-      const trigger = triggerRef.current;
-      triggerRef.current = null;
-      if (trigger instanceof HTMLElement) {
-        trigger.focus();
-      }
-    }
-  }, [isOpen]);
-
-  // Escape key handler
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, onClose]);
-
-  // Focus trap: keep focus within the dialog
-  const handleFocusTrap = useCallback((event: KeyboardEvent) => {
-    if (event.key !== "Tab" || !panelRef.current) return;
-
-    const focusableElements = panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
-    if (focusableElements.length === 0) return;
-
-    const firstElement = focusableElements[0];
-    const lastElement = focusableElements[focusableElements.length - 1];
-
-    if (event.shiftKey) {
-      if (document.activeElement === firstElement) {
-        event.preventDefault();
-        lastElement.focus();
-      }
-    } else {
-      if (document.activeElement === lastElement) {
-        event.preventDefault();
-        firstElement.focus();
-      }
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    document.addEventListener("keydown", handleFocusTrap);
-    return () => document.removeEventListener("keydown", handleFocusTrap);
-  }, [isOpen, handleFocusTrap]);
+  const panelRef = useFocusTrap({ isOpen, onEscape: onClose });
 
   if (!isOpen) return null;
 

--- a/web/src/hooks/use-focus-trap.ts
+++ b/web/src/hooks/use-focus-trap.ts
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+
+/**
+ * Focusable element selector for focus management.
+ * Matches all interactive elements that can receive focus.
+ */
+export const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+interface UseFocusTrapOptions {
+  /** Whether the focus trap is currently active */
+  isOpen: boolean;
+  /** Optional callback invoked when Escape is pressed */
+  onEscape?: () => void;
+}
+
+/**
+ * useFocusTrap - Manages focus trapping within a container element.
+ *
+ * Handles:
+ * - Capturing the trigger element (document.activeElement) when the trap activates
+ * - Focusing the first focusable element within the container on activation
+ * - Tab/Shift+Tab cycling within the container boundary
+ * - Focus restoration to the trigger element on deactivation
+ * - Optional Escape key callback
+ *
+ * @param options.isOpen - Whether the focus trap is active
+ * @param options.onEscape - Optional callback for Escape key
+ * @returns A ref to attach to the container element
+ */
+export function useFocusTrap({ isOpen, onEscape }: UseFocusTrapOptions) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<Element | null>(null);
+  const prevIsOpenRef = useRef(false);
+
+  // Focus management: capture trigger on open, focus first element, restore on close
+  useEffect(() => {
+    const wasOpen = prevIsOpenRef.current;
+    prevIsOpenRef.current = isOpen;
+
+    if (isOpen && !wasOpen) {
+      // Opening: capture the element that triggered the overlay
+      triggerRef.current = document.activeElement;
+
+      // Focus the first focusable element inside the container
+      if (containerRef.current) {
+        const firstFocusable = containerRef.current.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+        if (firstFocusable) {
+          firstFocusable.focus();
+        }
+      }
+    } else if (!isOpen && wasOpen) {
+      // Closing: return focus to the trigger element
+      const trigger = triggerRef.current;
+      triggerRef.current = null;
+      if (trigger instanceof HTMLElement) {
+        trigger.focus();
+      }
+    }
+  }, [isOpen]);
+
+  // Escape key handler
+  useEffect(() => {
+    if (!isOpen || !onEscape) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onEscape();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen, onEscape]);
+
+  // Focus trap: Tab/Shift+Tab cycling within the container
+  const handleFocusTrap = useCallback((event: KeyboardEvent) => {
+    if (event.key !== "Tab" || !containerRef.current) return;
+
+    const focusableElements =
+      containerRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    if (focusableElements.length === 0) return;
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (event.shiftKey) {
+      if (document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      }
+    } else {
+      if (document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    document.addEventListener("keydown", handleFocusTrap);
+    return () => document.removeEventListener("keydown", handleFocusTrap);
+  }, [isOpen, handleFocusTrap]);
+
+  return containerRef;
+}


### PR DESCRIPTION
## Summary
- Extracted duplicated focus trap logic from OverlayPanel, SidebarOverlay, and FeedbackSheet into a shared `useFocusTrap` hook
- Hook handles trigger capture, Tab/Shift+Tab cycling, focus restoration on unmount, and optional Escape callback
- Exported canonical `FOCUSABLE_SELECTOR` for reuse
- Net diff: 118 insertions, 214 deletions (-96 lines)

Closes #375

## Test plan
- [ ] OverlayPanel: Tab/Shift+Tab cycles within panel, Escape closes, focus restores to trigger
- [ ] SidebarOverlay: Tab/Shift+Tab cycles within overlay, Escape closes, focus restores
- [ ] FeedbackSheet: Tab/Shift+Tab cycles within sheet, Escape closes, focus restores
- [ ] Verify on iPad Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)