### PR TITLE
refactor: migrate hardcoded Tailwind colors to semantic design tokens (#370)

### DIFF
--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -180,7 +180,9 @@ export default function DashboardPage() {
             </Link>
           </div>
 
-          <p className="mt-4 text-sm text-gray-400">Your first chapter will be waiting for you.</p>
+          <p className="mt-4 text-sm text-[var(--dc-color-text-placeholder)]">
+            Your first chapter will be waiting for you.
+          </p>
 
           <div className="mt-3">
             <input
@@ -201,7 +203,7 @@ export default function DashboardPage() {
             <button
               onClick={() => fileInputRef.current?.click()}
               disabled={isImporting}
-              className="text-sm text-gray-400 hover:text-gray-700 transition-colors
+              className="text-sm text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-secondary)] transition-colors
                          disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isImporting ? "Importing..." : "Import from a backup file"}
@@ -213,7 +215,7 @@ export default function DashboardPage() {
             <button
               onClick={handleSignOut}
               disabled={isSigningOut}
-              className="text-sm text-gray-400 hover:text-gray-700 transition-colors
+              className="text-sm text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-secondary)] transition-colors
                          disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isSigningOut ? "Signing out\u2026" : "Sign out"}
@@ -243,7 +245,7 @@ export default function DashboardPage() {
         {projects.map((project) => (
           <div
             key={project.id}
-            className="relative bg-white border border-gray-200 rounded-xl p-5 hover:shadow-md transition-shadow group"
+            className="relative bg-[var(--dc-color-surface-primary)] border border-gray-200 rounded-xl p-5 hover:shadow-md transition-shadow group"
           >
             {/* Clickable card body */}
             <Link href={`/editor/${project.id}`} className="block min-h-[100px]">
@@ -254,10 +256,10 @@ export default function DashboardPage() {
                 <span>
                   {project.chapterCount} {project.chapterCount === 1 ? "chapter" : "chapters"}
                 </span>
-                <span className="text-gray-300">&middot;</span>
+                <span className="text-[var(--dc-color-border-strong)]">&middot;</span>
                 <span className="tabular-nums">{project.wordCount.toLocaleString()} words</span>
               </div>
-              <p className="mt-3 text-xs text-gray-400">
+              <p className="mt-3 text-xs text-[var(--dc-color-text-placeholder)]">
                 Last edited {relativeTime(project.updatedAt)}
               </p>
             </Link>
@@ -273,13 +275,17 @@ export default function DashboardPage() {
                   e.stopPropagation();
                   setOpenMenuId(openMenuId === project.id ? null : project.id);
                 }}
-                className="h-9 w-9 flex items-center justify-center rounded-lg hover:bg-gray-100
+                className="h-9 w-9 flex items-center justify-center rounded-lg hover:bg-[var(--dc-color-surface-tertiary)]
                            transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
                 aria-label={`Actions for ${project.title}`}
                 aria-haspopup="true"
                 aria-expanded={openMenuId === project.id}
               >
-                <svg className="w-5 h-5 text-gray-500" fill="currentColor" viewBox="0 0 24 24">
+                <svg
+                  className="w-5 h-5 text-[var(--dc-color-text-muted)]"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                >
                   <circle cx="12" cy="6" r="1.5" />
                   <circle cx="12" cy="12" r="1.5" />
                   <circle cx="12" cy="18" r="1.5" />
@@ -289,7 +295,7 @@ export default function DashboardPage() {
               {/* Overflow menu dropdown */}
               {openMenuId === project.id && (
                 <div
-                  className="absolute right-0 top-full mt-1 w-48 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50"
+                  className="absolute right-0 top-full mt-1 w-48 bg-[var(--dc-color-surface-primary)] rounded-lg shadow-lg border border-gray-200 py-1 z-50"
                   role="menu"
                 >
                   <button
@@ -298,7 +304,7 @@ export default function DashboardPage() {
                       setRenameValue(project.title);
                       setRenameTarget(project);
                     }}
-                    className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                    className="w-full text-left px-4 py-2.5 text-sm text-[var(--dc-color-text-secondary)] hover:bg-[var(--dc-color-surface-tertiary)]
                                transition-colors min-h-[44px] flex items-center gap-2"
                     role="menuitem"
                   >
@@ -322,7 +328,7 @@ export default function DashboardPage() {
                       setOpenMenuId(null);
                       setDuplicateTarget(project);
                     }}
-                    className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+                    className="w-full text-left px-4 py-2.5 text-sm text-[var(--dc-color-text-secondary)] hover:bg-[var(--dc-color-surface-tertiary)]
                                transition-colors min-h-[44px] flex items-center gap-2"
                     role="menuitem"
                   >
@@ -393,7 +399,7 @@ export default function DashboardPage() {
         <button
           onClick={() => fileInputRef.current?.click()}
           disabled={isImporting}
-          className="text-sm text-gray-400 hover:text-gray-700 transition-colors
+          className="text-sm text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-secondary)] transition-colors
                      disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isImporting ? "Importing..." : "Import from a backup file"}
@@ -402,7 +408,7 @@ export default function DashboardPage() {
         <div className="mt-2">
           <Link
             href="/help"
-            className="text-sm text-gray-400 hover:text-gray-700 transition-colors"
+            className="text-sm text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-secondary)] transition-colors"
           >
             Help
           </Link>
@@ -417,8 +423,11 @@ export default function DashboardPage() {
           aria-modal="true"
           aria-labelledby="rename-dialog-title"
         >
-          <div className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
-            <h2 id="rename-dialog-title" className="text-lg font-semibold text-gray-900 mb-4">
+          <div className="bg-[var(--dc-color-surface-primary)] rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
+            <h2
+              id="rename-dialog-title"
+              className="text-lg font-semibold text-[var(--dc-color-text-primary)] mb-4"
+            >
               Rename Book
             </h2>
             <input
@@ -438,7 +447,7 @@ export default function DashboardPage() {
               <button
                 onClick={() => setRenameTarget(null)}
                 disabled={isRenaming}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg
+                className="px-4 py-2 text-sm font-medium text-[var(--dc-color-text-secondary)] bg-[var(--dc-color-surface-tertiary)] rounded-lg
                            hover:bg-gray-200 transition-colors min-h-[44px]
                            disabled:opacity-50 disabled:cursor-not-allowed"
               >
@@ -466,11 +475,14 @@ export default function DashboardPage() {
           aria-modal="true"
           aria-labelledby="duplicate-dialog-title"
         >
-          <div className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
-            <h2 id="duplicate-dialog-title" className="text-lg font-semibold text-gray-900 mb-2">
+          <div className="bg-[var(--dc-color-surface-primary)] rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
+            <h2
+              id="duplicate-dialog-title"
+              className="text-lg font-semibold text-[var(--dc-color-text-primary)] mb-2"
+            >
               Duplicate Book
             </h2>
-            <p className="text-sm text-gray-600 mb-6">
+            <p className="text-sm text-[var(--dc-color-text-muted)] mb-6">
               Duplicate &ldquo;{duplicateTarget.title}&rdquo;? This creates a full copy of all
               chapters.
             </p>
@@ -478,7 +490,7 @@ export default function DashboardPage() {
               <button
                 onClick={() => setDuplicateTarget(null)}
                 disabled={isDuplicating}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg
+                className="px-4 py-2 text-sm font-medium text-[var(--dc-color-text-secondary)] bg-[var(--dc-color-surface-tertiary)] rounded-lg
                            hover:bg-gray-200 transition-colors min-h-[44px]
                            disabled:opacity-50 disabled:cursor-not-allowed"
               >

--- a/web/src/app/(protected)/help/page.tsx
+++ b/web/src/app/(protected)/help/page.tsx
@@ -250,7 +250,9 @@ function HelpPageContent() {
   return (
     <div className="mx-auto max-w-[640px] px-4 py-8 pb-[env(safe-area-inset-bottom)]">
       {/* Page heading */}
-      <h1 className="font-serif text-3xl font-semibold text-gray-900 mb-8">Help</h1>
+      <h1 className="font-serif text-3xl font-semibold text-[var(--dc-color-text-primary)] mb-8">
+        Help
+      </h1>
 
       {/* FAQ Sections */}
       <div ref={accordionRef} onKeyDown={handleAccordionKeyDown}>
@@ -263,8 +265,12 @@ function HelpPageContent() {
           >
             {section.items.map((item, i) => (
               <div key={i}>
-                <h4 className="text-sm font-medium text-gray-900 mb-1">{item.q}</h4>
-                <p className="text-sm leading-relaxed text-gray-600">{item.a}</p>
+                <h4 className="text-sm font-medium text-[var(--dc-color-text-primary)] mb-1">
+                  {item.q}
+                </h4>
+                <p className="text-sm leading-relaxed text-[var(--dc-color-text-muted)]">
+                  {item.a}
+                </p>
               </div>
             ))}
           </AccordionSection>
@@ -272,9 +278,11 @@ function HelpPageContent() {
       </div>
 
       {/* Footer actions */}
-      <div className="mt-10 rounded-xl border border-gray-200 bg-gray-50 p-6 text-center">
-        <h2 className="text-base font-semibold text-gray-900 mb-2">Still need help?</h2>
-        <p className="text-sm text-gray-600 mb-4">
+      <div className="mt-10 rounded-xl border border-gray-200 bg-[var(--dc-color-surface-secondary)] p-6 text-center">
+        <h2 className="text-base font-semibold text-[var(--dc-color-text-primary)] mb-2">
+          Still need help?
+        </h2>
+        <p className="text-sm text-[var(--dc-color-text-muted)] mb-4">
           We read every report and use your feedback to improve DraftCrane.
         </p>
         <div className="flex flex-col items-center gap-3">
@@ -287,7 +295,7 @@ function HelpPageContent() {
           </button>
           <button
             onClick={handleReplayTour}
-            className="text-sm text-gray-500 hover:text-gray-700 transition-colors min-h-[44px]"
+            className="text-sm text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)] transition-colors min-h-[44px]"
           >
             Replay the tour
           </button>

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -41,7 +41,7 @@ export default async function ProtectedLayout({ children }: ProtectedLayoutProps
         {/* Logo/Title - links to dashboard */}
         <Link
           href="/dashboard"
-          className="flex h-11 items-center font-serif text-xl font-semibold text-gray-900"
+          className="flex h-11 items-center font-serif text-xl font-semibold text-[var(--dc-color-text-primary)]"
         >
           DraftCrane
         </Link>
@@ -50,11 +50,11 @@ export default async function ProtectedLayout({ children }: ProtectedLayoutProps
         <div className="flex items-center gap-2">
           <Link
             href="/help"
-            className="flex h-11 w-11 items-center justify-center rounded-lg hover:bg-gray-100 transition-colors"
+            className="flex h-11 w-11 items-center justify-center rounded-lg hover:bg-[var(--dc-color-surface-tertiary)] transition-colors"
             aria-label="Help"
           >
             <svg
-              className="h-5 w-5 text-gray-500"
+              className="h-5 w-5 text-[var(--dc-color-text-muted)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -14,15 +14,15 @@ import Link from "next/link";
  */
 export default function LandingPage() {
   return (
-    <div className="flex min-h-dvh flex-col items-center justify-center bg-white px-6 py-12">
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-[var(--dc-color-surface-primary)] px-6 py-12">
       <main className="flex max-w-xl flex-col items-center text-center">
         {/* Logo/Title - serif font for book-writing theme */}
-        <h1 className="mb-4 font-serif text-5xl font-semibold tracking-tight text-gray-900">
+        <h1 className="mb-4 font-serif text-5xl font-semibold tracking-tight text-[var(--dc-color-text-primary)]">
           DraftCrane
         </h1>
 
         {/* Tagline — seeds Author/Editor metaphor (#387) */}
-        <p className="mb-8 font-serif text-xl leading-relaxed text-gray-600">
+        <p className="mb-8 font-serif text-xl leading-relaxed text-[var(--dc-color-text-muted)]">
           Write your book.
           <br />
           Keep your files.
@@ -31,7 +31,7 @@ export default function LandingPage() {
         </p>
 
         {/* Description — author-friendly language, introduces Editor role */}
-        <p className="mb-10 max-w-md text-lg leading-relaxed text-gray-500">
+        <p className="mb-10 max-w-md text-lg leading-relaxed text-[var(--dc-color-text-muted)]">
           A quiet place to write your nonfiction book, chapter by chapter. When your prose needs
           tightening, your Editor is one tap away &mdash; select text, ask for a rewrite, and decide
           what stays. Your chapters live in your Google Drive, always yours.
@@ -46,21 +46,24 @@ export default function LandingPage() {
         </Link>
 
         {/* Secondary link for existing users */}
-        <p className="mt-6 text-sm text-gray-500">
+        <p className="mt-6 text-sm text-[var(--dc-color-text-muted)]">
           Already have an account?{" "}
-          <Link href="/sign-in" className="font-medium text-gray-700 underline hover:text-gray-900">
+          <Link
+            href="/sign-in"
+            className="font-medium text-[var(--dc-color-text-secondary)] underline hover:text-[var(--dc-color-text-primary)]"
+          >
             Sign in
           </Link>
         </p>
       </main>
 
       {/* Footer with legal links */}
-      <footer className="mt-auto pb-8 pt-12 text-center text-sm text-gray-400">
+      <footer className="mt-auto pb-8 pt-12 text-center text-sm text-[var(--dc-color-text-placeholder)]">
         <div className="flex justify-center gap-6">
-          <Link href="/privacy" className="hover:text-gray-600">
+          <Link href="/privacy" className="hover:text-[var(--dc-color-text-muted)]">
             Privacy Policy
           </Link>
-          <Link href="/terms" className="hover:text-gray-600">
+          <Link href="/terms" className="hover:text-[var(--dc-color-text-muted)]">
             Terms of Service
           </Link>
         </div>

--- a/web/src/app/privacy/page.tsx
+++ b/web/src/app/privacy/page.tsx
@@ -13,22 +13,27 @@ export const metadata: Metadata = {
  */
 export default function PrivacyPolicyPage() {
   return (
-    <div className="min-h-dvh bg-white px-6 py-12">
+    <div className="min-h-dvh bg-[var(--dc-color-surface-primary)] px-6 py-12">
       <article className="mx-auto max-w-2xl">
         {/* Back link */}
-        <Link href="/" className="mb-8 inline-block text-sm text-gray-500 hover:text-gray-700">
+        <Link
+          href="/"
+          className="mb-8 inline-block text-sm text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)]"
+        >
           &larr; Back to DraftCrane
         </Link>
 
-        <h1 className="mb-2 font-serif text-4xl font-semibold tracking-tight text-gray-900">
+        <h1 className="mb-2 font-serif text-4xl font-semibold tracking-tight text-[var(--dc-color-text-primary)]">
           Privacy Policy
         </h1>
-        <p className="mb-10 text-sm text-gray-500">Effective date: February 16, 2026</p>
+        <p className="mb-10 text-sm text-[var(--dc-color-text-muted)]">
+          Effective date: February 16, 2026
+        </p>
 
-        <div className="space-y-8 text-base leading-relaxed text-gray-700">
+        <div className="space-y-8 text-base leading-relaxed text-[var(--dc-color-text-secondary)]">
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               What DraftCrane Is
             </h2>
             <p>
@@ -41,18 +46,20 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Information We Collect
             </h2>
 
-            <h3 className="mb-2 mt-4 text-lg font-semibold text-gray-800">Account information</h3>
+            <h3 className="mb-2 mt-4 text-lg font-semibold text-[var(--dc-color-text-primary)]">
+              Account information
+            </h3>
             <p>
               When you create an account, we collect your name, email address, and profile
               information through our authentication provider, Clerk. If you sign in with Google, we
               receive basic profile information (name, email, profile photo) from Google OAuth.
             </p>
 
-            <h3 className="mb-2 mt-4 text-lg font-semibold text-gray-800">
+            <h3 className="mb-2 mt-4 text-lg font-semibold text-[var(--dc-color-text-primary)]">
               Google Drive file metadata
             </h3>
             <p>
@@ -61,7 +68,9 @@ export default function PrivacyPolicyPage() {
               metadata in our database to power the dashboard and chapter list.
             </p>
 
-            <h3 className="mb-2 mt-4 text-lg font-semibold text-gray-800">Manuscript content</h3>
+            <h3 className="mb-2 mt-4 text-lg font-semibold text-[var(--dc-color-text-primary)]">
+              Manuscript content
+            </h3>
             <p>
               When you open a chapter in the editor, DraftCrane reads the chapter content from your
               Google Drive to display it. When you use the AI rewrite feature, the selected text is
@@ -69,7 +78,9 @@ export default function PrivacyPolicyPage() {
               stored on our servers. Your Google Drive is the canonical store for your writing.
             </p>
 
-            <h3 className="mb-2 mt-4 text-lg font-semibold text-gray-800">Usage data</h3>
+            <h3 className="mb-2 mt-4 text-lg font-semibold text-[var(--dc-color-text-primary)]">
+              Usage data
+            </h3>
             <p>
               We collect basic usage information such as pages visited and features used to improve
               the product. We do not use third-party analytics or advertising trackers.
@@ -78,13 +89,15 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Google Drive Access
             </h2>
             <p>
               DraftCrane requests the{" "}
-              <code className="rounded bg-gray-100 px-1.5 py-0.5 text-sm">drive.file</code> scope
-              from Google. This is the most restrictive file-access scope available. It means:
+              <code className="rounded bg-[var(--dc-color-surface-tertiary)] px-1.5 py-0.5 text-sm">
+                drive.file
+              </code>{" "}
+              scope from Google. This is the most restrictive file-access scope available. It means:
             </p>
             <ul className="mt-3 list-disc space-y-2 pl-6">
               <li>
@@ -104,7 +117,9 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">AI Processing</h2>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
+              AI Processing
+            </h2>
             <p>
               When you use the AI rewrite feature, the text you select is sent to OpenAI (our AI
               provider) for processing. Here is what you should know:
@@ -132,7 +147,7 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Where Your Data Lives
             </h2>
             <ul className="list-disc space-y-2 pl-6">
@@ -158,7 +173,9 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Authentication</h2>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
+              Authentication
+            </h2>
             <p>
               DraftCrane uses Clerk as its authentication provider. When you sign in, Clerk handles
               your credentials securely. DraftCrane never sees or stores your password. If you sign
@@ -168,7 +185,7 @@ export default function PrivacyPolicyPage() {
                 href="https://clerk.com/privacy"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-gray-900 underline hover:text-gray-700"
+                className="text-[var(--dc-color-text-primary)] underline hover:text-[var(--dc-color-text-secondary)]"
               >
                 Clerk&apos;s Privacy Policy
               </a>
@@ -178,7 +195,7 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               What We Do Not Do
             </h2>
             <ul className="list-disc space-y-2 pl-6">
@@ -194,7 +211,7 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Deleting Your Data
             </h2>
             <p>You can request account deletion at any time by contacting us. When you do:</p>
@@ -214,7 +231,9 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Data Security</h2>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
+              Data Security
+            </h2>
             <p>
               We use industry-standard security practices to protect your data. All connections use
               HTTPS. OAuth tokens are encrypted at rest with AES-256-GCM. Our infrastructure runs on
@@ -225,7 +244,7 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Changes to This Policy
             </h2>
             <p>
@@ -236,12 +255,14 @@ export default function PrivacyPolicyPage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Contact</h2>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
+              Contact
+            </h2>
             <p>
               If you have questions about this privacy policy or your data, contact us at{" "}
               <a
                 href="mailto:privacy@draftcrane.app"
-                className="text-gray-900 underline hover:text-gray-700"
+                className="text-[var(--dc-color-text-primary)] underline hover:text-[var(--dc-color-text-secondary)]"
               >
                 privacy@draftcrane.app
               </a>
@@ -251,12 +272,12 @@ export default function PrivacyPolicyPage() {
         </div>
 
         {/* Footer links */}
-        <footer className="mt-12 border-t border-gray-200 pt-6 text-sm text-gray-500">
+        <footer className="mt-12 border-t border-gray-200 pt-6 text-sm text-[var(--dc-color-text-muted)]">
           <div className="flex gap-6">
-            <Link href="/terms" className="hover:text-gray-700">
+            <Link href="/terms" className="hover:text-[var(--dc-color-text-secondary)]">
               Terms of Service
             </Link>
-            <Link href="/" className="hover:text-gray-700">
+            <Link href="/" className="hover:text-[var(--dc-color-text-secondary)]">
               Home
             </Link>
           </div>

--- a/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -13,14 +13,19 @@ import Link from "next/link";
  */
 export default function SignInPage() {
   return (
-    <div className="flex min-h-dvh flex-col items-center justify-center bg-gray-50 px-6 py-12">
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-[var(--dc-color-surface-secondary)] px-6 py-12">
       {/* Header with back to home */}
       <div className="mb-8 text-center">
-        <Link href="/" className="mb-4 inline-block text-sm text-gray-500 hover:text-gray-700">
+        <Link
+          href="/"
+          className="mb-4 inline-block text-sm text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)]"
+        >
           Back to DraftCrane
         </Link>
-        <h1 className="text-2xl font-semibold text-gray-900">Welcome back</h1>
-        <p className="mt-2 text-gray-600">Sign in to continue writing your book</p>
+        <h1 className="text-2xl font-semibold text-[var(--dc-color-text-primary)]">Welcome back</h1>
+        <p className="mt-2 text-[var(--dc-color-text-muted)]">
+          Sign in to continue writing your book
+        </p>
       </div>
 
       {/* Clerk SignIn component with enhanced styling */}

--- a/web/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/web/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -13,14 +13,21 @@ import Link from "next/link";
  */
 export default function SignUpPage() {
   return (
-    <div className="flex min-h-dvh flex-col items-center justify-center bg-gray-50 px-6 py-12">
+    <div className="flex min-h-dvh flex-col items-center justify-center bg-[var(--dc-color-surface-secondary)] px-6 py-12">
       {/* Header with back to home */}
       <div className="mb-8 text-center">
-        <Link href="/" className="mb-4 inline-block text-sm text-gray-500 hover:text-gray-700">
+        <Link
+          href="/"
+          className="mb-4 inline-block text-sm text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)]"
+        >
           Back to DraftCrane
         </Link>
-        <h1 className="text-2xl font-semibold text-gray-900">Start writing your book</h1>
-        <p className="mt-2 text-gray-600">Create your free account to get started</p>
+        <h1 className="text-2xl font-semibold text-[var(--dc-color-text-primary)]">
+          Start writing your book
+        </h1>
+        <p className="mt-2 text-[var(--dc-color-text-muted)]">
+          Create your free account to get started
+        </p>
       </div>
 
       {/* Clerk SignUp component with enhanced styling */}
@@ -52,13 +59,19 @@ export default function SignUpPage() {
       />
 
       {/* Consent notice */}
-      <p className="mt-6 max-w-md text-center text-xs leading-relaxed text-gray-500">
+      <p className="mt-6 max-w-md text-center text-xs leading-relaxed text-[var(--dc-color-text-muted)]">
         By signing up, you agree to our{" "}
-        <Link href="/terms" className="text-gray-700 underline hover:text-gray-900">
+        <Link
+          href="/terms"
+          className="text-[var(--dc-color-text-secondary)] underline hover:text-[var(--dc-color-text-primary)]"
+        >
           Terms of Service
         </Link>{" "}
         and{" "}
-        <Link href="/privacy" className="text-gray-700 underline hover:text-gray-900">
+        <Link
+          href="/privacy"
+          className="text-[var(--dc-color-text-secondary)] underline hover:text-[var(--dc-color-text-primary)]"
+        >
           Privacy Policy
         </Link>
         .

--- a/web/src/app/styles/editor.css
+++ b/web/src/app/styles/editor.css
@@ -56,7 +56,7 @@
   margin-left: 0;
   margin-right: 0;
   font-style: italic;
-  color: #6b7280;
+  color: var(--dc-color-text-muted);
 }
 
 .text-editor-content strong {
@@ -81,7 +81,7 @@
   font-size: 0.75em;
   vertical-align: super;
   line-height: 0;
-  color: #2563eb;
+  color: var(--dc-color-interactive-primary);
   cursor: default;
   font-weight: 500;
   user-select: all;
@@ -91,7 +91,7 @@
   margin-top: 1.5em;
   padding-top: 1em;
   font-size: 0.875em;
-  color: #6b7280;
+  color: var(--dc-color-text-muted);
   line-height: 1.5;
 }
 
@@ -103,7 +103,7 @@
 .text-editor-content .footnote-content::before {
   content: "[" attr(data-footnote-label) "] ";
   font-weight: 600;
-  color: #374151;
+  color: var(--dc-color-text-secondary);
 }
 
 /* Separator between body text and footnotes — the <hr> before .footnotes */
@@ -120,7 +120,7 @@
 /* Placeholder styling for empty editor */
 .text-editor-content.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
-  color: #9ca3af;
+  color: var(--dc-color-text-placeholder);
   pointer-events: none;
   position: absolute;
   height: 0;

--- a/web/src/app/styles/sources.css
+++ b/web/src/app/styles/sources.css
@@ -8,7 +8,7 @@
 .source-content {
   font-size: 16px;
   line-height: 1.7;
-  color: #374151;
+  color: var(--dc-color-text-secondary);
 }
 
 .source-content h1 {
@@ -16,7 +16,7 @@
   font-weight: 700;
   margin: 1.5em 0 0.5em;
   font-family: var(--font-serif);
-  color: #111827;
+  color: var(--dc-color-text-primary);
 }
 
 .source-content h2 {
@@ -24,7 +24,7 @@
   font-weight: 600;
   margin: 1.25em 0 0.5em;
   font-family: var(--font-serif);
-  color: #111827;
+  color: var(--dc-color-text-primary);
 }
 
 .source-content h3 {
@@ -32,7 +32,7 @@
   font-weight: 600;
   margin: 1em 0 0.4em;
   font-family: var(--font-serif);
-  color: #111827;
+  color: var(--dc-color-text-primary);
 }
 
 .source-content p {
@@ -61,11 +61,11 @@
   border-left: 3px solid #e5e7eb;
   padding-left: 1em;
   font-style: italic;
-  color: #6b7280;
+  color: var(--dc-color-text-muted);
 }
 
 .source-content a {
-  color: #2563eb;
+  color: var(--dc-color-interactive-primary);
   text-decoration: none;
 }
 
@@ -96,7 +96,7 @@
 }
 
 .source-content th {
-  background-color: #f9fafb;
+  background-color: var(--dc-color-surface-secondary);
   font-weight: 600;
 }
 

--- a/web/src/app/styles/workspace.css
+++ b/web/src/app/styles/workspace.css
@@ -162,7 +162,7 @@
     min-width: var(--workspace-sidebar-min-width);
     max-width: var(--workspace-sidebar-max-width);
     border-right: 1px solid var(--color-border);
-    background: #f9fafb;
+    background: var(--dc-color-surface-secondary);
     overflow: hidden;
   }
 
@@ -386,7 +386,7 @@
   /* Styling */
   padding: 8px 12px;
   border-radius: 9999px;
-  background: #2563eb;
+  background: var(--dc-color-interactive-primary);
   color: white;
   font-size: 14px;
   font-weight: 500;
@@ -409,7 +409,7 @@
 }
 
 .workspace-sidebar-pill:hover {
-  background: #1d4ed8;
+  background: var(--dc-color-interactive-primary-on-subtle);
 }
 
 .workspace-sidebar-pill:focus {

--- a/web/src/app/terms/page.tsx
+++ b/web/src/app/terms/page.tsx
@@ -13,22 +13,27 @@ export const metadata: Metadata = {
  */
 export default function TermsOfServicePage() {
   return (
-    <div className="min-h-dvh bg-white px-6 py-12">
+    <div className="min-h-dvh bg-[var(--dc-color-surface-primary)] px-6 py-12">
       <article className="mx-auto max-w-2xl">
         {/* Back link */}
-        <Link href="/" className="mb-8 inline-block text-sm text-gray-500 hover:text-gray-700">
+        <Link
+          href="/"
+          className="mb-8 inline-block text-sm text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)]"
+        >
           &larr; Back to DraftCrane
         </Link>
 
-        <h1 className="mb-2 font-serif text-4xl font-semibold tracking-tight text-gray-900">
+        <h1 className="mb-2 font-serif text-4xl font-semibold tracking-tight text-[var(--dc-color-text-primary)]">
           Terms of Service
         </h1>
-        <p className="mb-10 text-sm text-gray-500">Effective date: February 16, 2026</p>
+        <p className="mb-10 text-sm text-[var(--dc-color-text-muted)]">
+          Effective date: February 16, 2026
+        </p>
 
-        <div className="space-y-8 text-base leading-relaxed text-gray-700">
+        <div className="space-y-8 text-base leading-relaxed text-[var(--dc-color-text-secondary)]">
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               What DraftCrane Is
             </h2>
             <p>
@@ -45,7 +50,9 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Your Account</h2>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
+              Your Account
+            </h2>
             <p>
               To use DraftCrane, you create an account using your email address or Google account.
               You are responsible for keeping your account credentials secure. If you believe your
@@ -55,7 +62,7 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Your Content and Intellectual Property
             </h2>
             <p>
@@ -76,14 +83,16 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Google Drive Access
             </h2>
             <p>
               DraftCrane stores your manuscripts in your Google Drive account using the{" "}
-              <code className="rounded bg-gray-100 px-1.5 py-0.5 text-sm">drive.file</code> scope.
-              This means DraftCrane can only access files and folders that it creates. It cannot
-              access any other files in your Drive.
+              <code className="rounded bg-[var(--dc-color-surface-tertiary)] px-1.5 py-0.5 text-sm">
+                drive.file
+              </code>{" "}
+              scope. This means DraftCrane can only access files and folders that it creates. It
+              cannot access any other files in your Drive.
             </p>
             <p className="mt-3">
               Your files always remain in your Google Drive, under your control. If you stop using
@@ -94,7 +103,7 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               AI-Assisted Writing
             </h2>
             <p>DraftCrane offers AI rewrite tools powered by OpenAI. When you use these tools:</p>
@@ -120,7 +129,7 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Data Portability
             </h2>
             <p>
@@ -137,7 +146,9 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Acceptable Use</h2>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
+              Acceptable Use
+            </h2>
             <p>You agree not to use DraftCrane to:</p>
             <ul className="mt-3 list-disc space-y-2 pl-6">
               <li>
@@ -157,7 +168,7 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Service Availability
             </h2>
             <p>
@@ -173,7 +184,7 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Account Termination
             </h2>
             <p>
@@ -201,7 +212,7 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Limitation of Liability
             </h2>
             <p>
@@ -218,7 +229,7 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
               Changes to These Terms
             </h2>
             <p>
@@ -231,12 +242,14 @@ export default function TermsOfServicePage() {
 
           {/* ------------------------------------------------------------ */}
           <section>
-            <h2 className="mb-3 font-serif text-2xl font-semibold text-gray-900">Contact</h2>
+            <h2 className="mb-3 font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
+              Contact
+            </h2>
             <p>
               If you have questions about these terms, contact us at{" "}
               <a
                 href="mailto:support@draftcrane.app"
-                className="text-gray-900 underline hover:text-gray-700"
+                className="text-[var(--dc-color-text-primary)] underline hover:text-[var(--dc-color-text-secondary)]"
               >
                 support@draftcrane.app
               </a>
@@ -246,12 +259,12 @@ export default function TermsOfServicePage() {
         </div>
 
         {/* Footer links */}
-        <footer className="mt-12 border-t border-gray-200 pt-6 text-sm text-gray-500">
+        <footer className="mt-12 border-t border-gray-200 pt-6 text-sm text-[var(--dc-color-text-muted)]">
           <div className="flex gap-6">
-            <Link href="/privacy" className="hover:text-gray-700">
+            <Link href="/privacy" className="hover:text-[var(--dc-color-text-secondary)]">
               Privacy Policy
             </Link>
-            <Link href="/" className="hover:text-gray-700">
+            <Link href="/" className="hover:text-[var(--dc-color-text-secondary)]">
               Home
             </Link>
           </div>

--- a/web/src/components/editor/crash-recovery-dialog.tsx
+++ b/web/src/components/editor/crash-recovery-dialog.tsx
@@ -26,11 +26,14 @@ export function CrashRecoveryDialog({ recovery, onAccept, onDismiss }: CrashReco
       aria-labelledby="recovery-title"
       aria-describedby="recovery-description"
     >
-      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
-        <h2 id="recovery-title" className="text-lg font-semibold text-gray-900 mb-2">
+      <div className="bg-[var(--dc-color-surface-primary)] rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
+        <h2
+          id="recovery-title"
+          className="text-lg font-semibold text-[var(--dc-color-text-primary)] mb-2"
+        >
           Unsaved Changes Found
         </h2>
-        <p id="recovery-description" className="text-sm text-gray-600 mb-6">
+        <p id="recovery-description" className="text-sm text-[var(--dc-color-text-muted)] mb-6">
           We found unsaved changes from {timeAgo}. This may have been caused by a browser crash or
           unexpected closure. Would you like to restore your work?
         </p>
@@ -38,7 +41,7 @@ export function CrashRecoveryDialog({ recovery, onAccept, onDismiss }: CrashReco
         <div className="flex gap-3 justify-end">
           <button
             onClick={onDismiss}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg
+            className="px-4 py-2 text-sm font-medium text-[var(--dc-color-text-secondary)] bg-[var(--dc-color-surface-tertiary)] rounded-lg
                        hover:bg-gray-200 transition-colors min-h-[44px]"
           >
             Discard

--- a/web/src/components/editor/editor-writing-area.tsx
+++ b/web/src/components/editor/editor-writing-area.tsx
@@ -77,7 +77,7 @@ export function EditorWritingArea({
         ) : (
           <h1
             className="text-3xl font-semibold text-foreground mb-6 outline-none cursor-text
-                       hover:bg-gray-50 focus:bg-gray-50 focus:ring-2 focus:ring-blue-500
+                       hover:bg-[var(--dc-color-surface-secondary)] focus:bg-[var(--dc-color-surface-secondary)] focus:ring-2 focus:ring-blue-500
                        rounded px-1 -mx-1 transition-colors"
             onClick={onTitleEdit}
             onKeyDown={(e) => {

--- a/web/src/components/editor/floating-action-bar.tsx
+++ b/web/src/components/editor/floating-action-bar.tsx
@@ -41,7 +41,7 @@ export function FloatingActionBar({ selection, onRewrite }: FloatingActionBarPro
     <div
       role="toolbar"
       aria-label="AI text actions"
-      className="absolute z-50 flex items-center gap-2 bg-white border border-gray-200
+      className="absolute z-50 flex items-center gap-2 bg-[var(--dc-color-surface-primary)] border border-gray-200
                  rounded-xl shadow-lg px-2 py-1 select-none
                  transform -translate-x-1/2"
       style={{

--- a/web/src/components/editor/onboarding-tooltips.tsx
+++ b/web/src/components/editor/onboarding-tooltips.tsx
@@ -175,7 +175,7 @@ export function OnboardingTooltips() {
           <PointerArrow position={arrowPosition} />
 
           {/* Step label */}
-          <p className="mb-2 text-xs text-gray-500">
+          <p className="mb-2 text-xs text-[var(--dc-color-text-muted)]">
             Step {currentStep + 1} of {STEPS.length}
           </p>
 
@@ -185,7 +185,7 @@ export function OnboardingTooltips() {
               <div
                 key={i}
                 className={`h-1.5 rounded-full transition-all duration-200 ${
-                  i === currentStep ? "w-6 bg-blue-600" : "w-1.5 bg-gray-300"
+                  i === currentStep ? "w-6 bg-blue-600" : "w-1.5 bg-[var(--dc-color-border-strong)]"
                 }`}
                 aria-hidden="true"
               />
@@ -193,13 +193,15 @@ export function OnboardingTooltips() {
           </div>
 
           {/* Step text */}
-          <p className="mb-4 text-sm leading-relaxed text-gray-700">{step.text}</p>
+          <p className="mb-4 text-sm leading-relaxed text-[var(--dc-color-text-secondary)]">
+            {step.text}
+          </p>
 
           {/* Actions - 44pt minimum touch targets */}
           <div className="flex items-center justify-between">
             <button
               onClick={handleSkip}
-              className="min-h-[44px] px-3 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+              className="min-h-[44px] px-3 text-sm text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)] transition-colors"
             >
               Skip
             </button>

--- a/web/src/components/editor/text-editor.tsx
+++ b/web/src/components/editor/text-editor.tsx
@@ -275,7 +275,9 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(function
   );
 
   if (!editor) {
-    return <div className="min-h-[400px] animate-pulse bg-gray-100 rounded-lg" />;
+    return (
+      <div className="min-h-[400px] animate-pulse bg-[var(--dc-color-surface-tertiary)] rounded-lg" />
+    );
   }
 
   return (
@@ -289,7 +291,7 @@ export const TextEditor = forwardRef<TextEditorHandle, TextEditorProps>(function
                      [&_.text-editor-content]:text-lg
                      [&_.text-editor-content]:leading-relaxed
                      [&_.is-editor-empty]:before:content-[attr(data-placeholder)]
-                     [&_.is-editor-empty]:before:text-gray-400
+                     [&_.is-editor-empty]:before:text-[var(--dc-color-text-placeholder)]
                      [&_.is-editor-empty]:before:float-left
                      [&_.is-editor-empty]:before:pointer-events-none
                      [&_.is-editor-empty]:before:h-0"
@@ -302,7 +304,7 @@ function EditorToolbar({ editor }: { editor: Editor }) {
   const buttonClass = useCallback(
     (isActive: boolean) =>
       `p-2 rounded-lg transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center
-       ${isActive ? "bg-blue-100 text-blue-700" : "hover:bg-gray-100 text-gray-600"}`,
+       ${isActive ? "bg-blue-100 text-blue-700" : "hover:bg-[var(--dc-color-surface-tertiary)] text-[var(--dc-color-text-muted)]"}`,
     [],
   );
 

--- a/web/src/components/feedback/feedback-sheet.tsx
+++ b/web/src/components/feedback/feedback-sheet.tsx
@@ -132,24 +132,29 @@ export function FeedbackSheet({ isOpen, onClose }: FeedbackSheetProps) {
         aria-label="Report a problem"
         className={
           isLandscape
-            ? "fixed inset-y-0 right-0 z-50 w-full max-w-[380px] bg-white rounded-l-2xl shadow-2xl border-l border-gray-200 sheet-slide-right flex flex-col"
-            : "fixed bottom-0 left-0 right-0 z-50 bg-white rounded-t-2xl shadow-2xl border-t border-gray-200 sheet-slide-up max-h-[80vh] flex flex-col"
+            ? "fixed inset-y-0 right-0 z-50 w-full max-w-[380px] bg-[var(--dc-color-surface-primary)] rounded-l-2xl shadow-2xl border-l border-gray-200 sheet-slide-right flex flex-col"
+            : "fixed bottom-0 left-0 right-0 z-50 bg-[var(--dc-color-surface-primary)] rounded-t-2xl shadow-2xl border-t border-gray-200 sheet-slide-up max-h-[80vh] flex flex-col"
         }
       >
         {/* Drag handle — portrait only */}
         {!isLandscape && (
           <div className="flex justify-center pt-3 pb-1">
-            <div className="w-10 h-1 rounded-full bg-gray-300" aria-hidden="true" />
+            <div
+              className="w-10 h-1 rounded-full bg-[var(--dc-color-border-strong)]"
+              aria-hidden="true"
+            />
           </div>
         )}
 
         {/* Header */}
         <div className="flex items-center justify-between px-6 pb-3 pt-4 border-b border-gray-100">
-          <h2 className="text-lg font-semibold text-gray-900">Report a Problem</h2>
+          <h2 className="text-lg font-semibold text-[var(--dc-color-text-primary)]">
+            Report a Problem
+          </h2>
           <button
             type="button"
             onClick={onClose}
-            className="flex h-11 w-11 items-center justify-center rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors -mr-2"
+            className="flex h-11 w-11 items-center justify-center rounded-lg text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-muted)] hover:bg-[var(--dc-color-surface-tertiary)] transition-colors -mr-2"
             aria-label="Close"
           >
             <svg
@@ -173,7 +178,7 @@ export function FeedbackSheet({ isOpen, onClose }: FeedbackSheetProps) {
         <div className="flex-1 overflow-auto px-6 py-4 space-y-4">
           {/* Type selector - radio cards */}
           <fieldset>
-            <legend className="text-sm font-medium text-gray-700 mb-2">
+            <legend className="text-sm font-medium text-[var(--dc-color-text-secondary)] mb-2">
               What kind of feedback?
             </legend>
             <div className="grid grid-cols-2 gap-3" role="radiogroup">
@@ -191,7 +196,7 @@ export function FeedbackSheet({ isOpen, onClose }: FeedbackSheetProps) {
                            transition-colors ${
                              type === "bug"
                                ? "border-red-200 bg-red-50 text-red-600"
-                               : "border-gray-300 text-gray-700 hover:bg-gray-50"
+                               : "border-[var(--dc-color-border-strong)] text-[var(--dc-color-text-secondary)] hover:bg-[var(--dc-color-surface-secondary)]"
                            }`}
               >
                 {/* Bug icon */}
@@ -225,7 +230,7 @@ export function FeedbackSheet({ isOpen, onClose }: FeedbackSheetProps) {
                            transition-colors ${
                              type === "suggestion"
                                ? "border-blue-200 bg-blue-50 text-blue-600"
-                               : "border-gray-300 text-gray-700 hover:bg-gray-50"
+                               : "border-[var(--dc-color-border-strong)] text-[var(--dc-color-text-secondary)] hover:bg-[var(--dc-color-surface-secondary)]"
                            }`}
               >
                 {/* Lightbulb icon */}
@@ -252,7 +257,7 @@ export function FeedbackSheet({ isOpen, onClose }: FeedbackSheetProps) {
           <div>
             <label
               htmlFor="feedback-description"
-              className="text-sm font-medium text-gray-700 mb-2 block"
+              className="text-sm font-medium text-[var(--dc-color-text-secondary)] mb-2 block"
             >
               Tell us more
             </label>
@@ -268,8 +273,8 @@ export function FeedbackSheet({ isOpen, onClose }: FeedbackSheetProps) {
                   : "What would make DraftCrane better for you?"
               }
               maxLength={2000}
-              className="w-full min-h-[120px] rounded-lg border border-gray-300 p-3 text-base leading-relaxed
-                         placeholder:text-gray-400
+              className="w-full min-h-[120px] rounded-lg border border-[var(--dc-color-border-strong)] p-3 text-base leading-relaxed
+                         placeholder:text-[var(--dc-color-text-placeholder)]
                          focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent
                          disabled:opacity-50 disabled:cursor-not-allowed
                          resize-none"
@@ -277,14 +282,14 @@ export function FeedbackSheet({ isOpen, onClose }: FeedbackSheetProps) {
             />
             {/* Character count hint */}
             {description.length > 0 && description.trim().length < 10 && (
-              <p className="mt-1 text-xs text-gray-400">
+              <p className="mt-1 text-xs text-[var(--dc-color-text-placeholder)]">
                 {10 - description.trim().length} more characters needed
               </p>
             )}
           </div>
 
           {/* Context disclosure */}
-          <p className="flex items-start gap-1.5 text-xs text-gray-400">
+          <p className="flex items-start gap-1.5 text-xs text-[var(--dc-color-text-placeholder)]">
             <svg
               className="h-3.5 w-3.5 mt-0.5 shrink-0"
               fill="none"

--- a/web/src/components/help/accordion-section.tsx
+++ b/web/src/components/help/accordion-section.tsx
@@ -57,15 +57,15 @@ export function AccordionSection({
           aria-expanded={isOpen}
           aria-controls={panelId}
           className="flex w-full items-center gap-3 py-4 text-left min-h-[48px]
-                     text-base font-medium text-gray-900
-                     hover:text-gray-700 transition-colors"
+                     text-base font-medium text-[var(--dc-color-text-primary)]
+                     hover:text-[var(--dc-color-text-secondary)] transition-colors"
         >
-          <span className="flex h-6 w-6 shrink-0 items-center justify-center text-gray-500">
+          <span className="flex h-6 w-6 shrink-0 items-center justify-center text-[var(--dc-color-text-muted)]">
             {icon}
           </span>
           <span className="flex-1">{title}</span>
           <svg
-            className={`h-5 w-5 shrink-0 text-gray-400 transition-transform duration-150 ${
+            className={`h-5 w-5 shrink-0 text-[var(--dc-color-text-placeholder)] transition-transform duration-150 ${
               isOpen ? "rotate-180" : ""
             }`}
             viewBox="0 0 20 20"

--- a/web/src/components/instruction-list.tsx
+++ b/web/src/components/instruction-list.tsx
@@ -254,7 +254,10 @@ export function InstructionList({
     return (
       <div className="space-y-1">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="h-12 rounded-lg bg-gray-100 animate-pulse" />
+          <div
+            key={i}
+            className="h-12 rounded-lg bg-[var(--dc-color-surface-tertiary)] animate-pulse"
+          />
         ))}
       </div>
     );
@@ -364,7 +367,7 @@ export function InstructionList({
         role="listbox"
         aria-label={`${type} instructions`}
         onKeyDown={handleKeyDown}
-        className="border border-[var(--dc-color-border-strong)] rounded-lg overflow-hidden bg-white"
+        className="border border-[var(--dc-color-border-strong)] rounded-lg overflow-hidden bg-[var(--dc-color-surface-primary)]"
       >
         {/* Recents section */}
         {showRecents && (
@@ -636,9 +639,9 @@ interface TokenSet {
 }
 
 const primaryTokens: TokenSet = {
-  textInteractive: "text-blue-600",
-  rowHover: "hover:bg-gray-50",
-  rowActive: "active:bg-gray-100",
+  textInteractive: "text-[var(--dc-color-interactive-primary)]",
+  rowHover: "hover:bg-[var(--dc-color-surface-secondary)]",
+  rowActive: "active:bg-[var(--dc-color-surface-tertiary)]",
 };
 
 const escalationTokens: TokenSet = {

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -243,7 +243,7 @@ export function Sidebar({
   return (
     <aside
       className="flex flex-col h-full w-[260px] min-w-[240px] max-w-[280px]
-                 bg-gray-50 border-r border-border"
+                 bg-[var(--dc-color-surface-secondary)] border-r border-border"
       role="navigation"
       aria-label="Chapter navigation"
     >
@@ -345,7 +345,7 @@ export function Sidebar({
       <div className="px-4 py-2 border-t border-border">
         <button
           onClick={onAddChapter}
-          className="w-full py-3 px-4 rounded-lg border border-dashed border-gray-300
+          className="w-full py-3 px-4 rounded-lg border border-dashed border-[var(--dc-color-border-strong)]
                      text-muted-foreground hover:border-blue-500 hover:text-blue-600
                      focus:outline-none focus:ring-2 focus:ring-blue-500
                      transition-colors flex items-center justify-center gap-2
@@ -371,7 +371,7 @@ export function Sidebar({
       </div>
 
       {/* Total word count */}
-      <div className="px-4 py-3 border-t border-border bg-gray-100">
+      <div className="px-4 py-3 border-t border-border bg-[var(--dc-color-surface-tertiary)]">
         <div className="flex items-center justify-between text-sm">
           <span className="text-muted-foreground">Total</span>
           <span className="font-medium text-foreground tabular-nums">
@@ -469,8 +469,8 @@ function ChapterListItem({
   return (
     <div
       className={`group w-full flex items-center min-h-[48px] transition-colors
-                 ${isActive ? "bg-blue-100 text-blue-900" : "hover:bg-gray-100 text-foreground"}
-                 ${isDragOverlay ? "shadow-lg rounded-lg bg-white border border-blue-300" : ""}`}
+                 ${isActive ? "bg-blue-100 text-blue-900" : "hover:bg-[var(--dc-color-surface-tertiary)] text-foreground"}
+                 ${isDragOverlay ? "shadow-lg rounded-lg bg-[var(--dc-color-surface-primary)] border border-blue-300" : ""}`}
       role="listitem"
     >
       {/* Drag handle */}
@@ -610,7 +610,7 @@ function InlineRenameInput({
     <div
       className={`w-full px-4 py-3 flex items-center justify-between
                  min-h-[48px] transition-colors
-                 ${isActive ? "bg-blue-100 text-blue-900" : "bg-gray-100 text-foreground"}`}
+                 ${isActive ? "bg-blue-100 text-blue-900" : "bg-[var(--dc-color-surface-tertiary)] text-foreground"}`}
       role="listitem"
     >
       <input
@@ -621,7 +621,7 @@ function InlineRenameInput({
         onBlur={handleCommit}
         onKeyDown={handleKeyDown}
         maxLength={200}
-        className="flex-1 min-w-0 text-sm font-medium bg-white
+        className="flex-1 min-w-0 text-sm font-medium bg-[var(--dc-color-surface-primary)]
                    border border-blue-500 rounded px-2 py-1 outline-none
                    focus:ring-2 focus:ring-blue-500"
         aria-label="Chapter title"

--- a/web/src/components/project/accounts-sheet.tsx
+++ b/web/src/components/project/accounts-sheet.tsx
@@ -55,21 +55,23 @@ export function AccountsSheet({
 
       {/* Panel */}
       <div
-        className="fixed top-0 right-0 h-full w-full max-w-sm bg-white shadow-xl z-50
+        className="fixed top-0 right-0 h-full w-full max-w-sm bg-[var(--dc-color-surface-primary)] shadow-xl z-50
                    flex flex-col"
         role="dialog"
         aria-label="Google Accounts"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-4 h-14 border-b border-gray-200 shrink-0">
-          <h2 className="text-lg font-semibold text-gray-900">Google Accounts</h2>
+          <h2 className="text-lg font-semibold text-[var(--dc-color-text-primary)]">
+            Google Accounts
+          </h2>
           <button
             onClick={onClose}
-            className="w-9 h-9 flex items-center justify-center rounded-lg hover:bg-gray-100 min-h-[44px] min-w-[44px]"
+            className="w-9 h-9 flex items-center justify-center rounded-lg hover:bg-[var(--dc-color-surface-tertiary)] min-h-[44px] min-w-[44px]"
             aria-label="Close"
           >
             <svg
-              className="w-5 h-5 text-gray-500"
+              className="w-5 h-5 text-[var(--dc-color-text-muted)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -87,14 +89,16 @@ export function AccountsSheet({
         {/* Content */}
         <div className="flex-1 overflow-auto px-4 py-4">
           {/* Explanation */}
-          <p className="text-xs text-gray-500 mb-4">
+          <p className="text-xs text-[var(--dc-color-text-muted)] mb-4">
             Connected accounts let you browse Google Drive for source materials and back up your
             manuscript. You can connect multiple accounts.
           </p>
 
           {accounts.length === 0 ? (
             <div className="text-center py-8">
-              <p className="text-sm text-gray-500 mb-4">No Google accounts connected</p>
+              <p className="text-sm text-[var(--dc-color-text-muted)] mb-4">
+                No Google accounts connected
+              </p>
               <button
                 onClick={onConnectAccount}
                 className="px-4 py-2.5 bg-blue-600 text-white text-sm font-medium rounded-lg
@@ -108,13 +112,13 @@ export function AccountsSheet({
               {accounts.map((account) => (
                 <div
                   key={account.id}
-                  className="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+                  className="flex items-center justify-between p-3 bg-[var(--dc-color-surface-secondary)] rounded-lg"
                 >
                   <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium text-gray-900 truncate">
+                    <div className="text-sm font-medium text-[var(--dc-color-text-primary)] truncate">
                       {account.email}
                     </div>
-                    <div className="text-xs text-gray-500">
+                    <div className="text-xs text-[var(--dc-color-text-muted)]">
                       Connected {formatDate(account.connectedAt)}
                     </div>
                   </div>

--- a/web/src/components/project/delete-chapter-dialog.tsx
+++ b/web/src/components/project/delete-chapter-dialog.tsx
@@ -49,7 +49,7 @@ export function DeleteChapterDialog({
       aria-labelledby="delete-chapter-title"
       aria-describedby="delete-chapter-description"
     >
-      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
+      <div className="bg-[var(--dc-color-surface-primary)] rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
         {/* Warning icon */}
         <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
           <svg
@@ -69,16 +69,19 @@ export function DeleteChapterDialog({
 
         <h2
           id="delete-chapter-title"
-          className="text-lg font-semibold text-gray-900 mb-2 text-center"
+          className="text-lg font-semibold text-[var(--dc-color-text-primary)] mb-2 text-center"
         >
           Delete Chapter
         </h2>
 
-        <p id="delete-chapter-description" className="text-sm text-gray-600 mb-2 text-center">
+        <p
+          id="delete-chapter-description"
+          className="text-sm text-[var(--dc-color-text-muted)] mb-2 text-center"
+        >
           Are you sure you want to delete &ldquo;{chapterTitle}&rdquo;?
         </p>
 
-        <p className="text-sm text-gray-500 mb-6 text-center">
+        <p className="text-sm text-[var(--dc-color-text-muted)] mb-6 text-center">
           This action cannot be undone. If connected to Google Drive, the file will be moved to
           trash.
         </p>
@@ -87,7 +90,7 @@ export function DeleteChapterDialog({
           <button
             onClick={onCancel}
             disabled={isDeleting}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg
+            className="px-4 py-2 text-sm font-medium text-[var(--dc-color-text-secondary)] bg-[var(--dc-color-surface-tertiary)] rounded-lg
                        hover:bg-gray-200 transition-colors min-h-[44px]
                        disabled:opacity-50 disabled:cursor-not-allowed"
           >

--- a/web/src/components/project/delete-project-dialog.tsx
+++ b/web/src/components/project/delete-project-dialog.tsx
@@ -49,7 +49,7 @@ export function DeleteProjectDialog({
       aria-labelledby="delete-project-title"
       aria-describedby="delete-project-description"
     >
-      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
+      <div className="bg-[var(--dc-color-surface-primary)] rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
         {/* Warning icon */}
         <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-red-100">
           <svg
@@ -69,16 +69,19 @@ export function DeleteProjectDialog({
 
         <h2
           id="delete-project-title"
-          className="text-lg font-semibold text-gray-900 mb-2 text-center"
+          className="text-lg font-semibold text-[var(--dc-color-text-primary)] mb-2 text-center"
         >
           Delete Project
         </h2>
 
-        <p id="delete-project-description" className="text-sm text-gray-600 mb-2 text-center">
+        <p
+          id="delete-project-description"
+          className="text-sm text-[var(--dc-color-text-muted)] mb-2 text-center"
+        >
           Are you sure you want to delete &ldquo;{projectTitle}&rdquo;?
         </p>
 
-        <p className="text-sm text-gray-500 mb-6 text-center">
+        <p className="text-sm text-[var(--dc-color-text-muted)] mb-6 text-center">
           Your Google Drive files will not be affected.
         </p>
 
@@ -86,7 +89,7 @@ export function DeleteProjectDialog({
           <button
             onClick={onCancel}
             disabled={isDeleting}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg
+            className="px-4 py-2 text-sm font-medium text-[var(--dc-color-text-secondary)] bg-[var(--dc-color-surface-tertiary)] rounded-lg
                        hover:bg-gray-200 transition-colors min-h-[44px]
                        disabled:opacity-50 disabled:cursor-not-allowed"
           >

--- a/web/src/components/project/drive-folder-picker.tsx
+++ b/web/src/components/project/drive-folder-picker.tsx
@@ -117,7 +117,7 @@ export function DriveFolderPicker({
           aria-label="Back"
         >
           <svg
-            className="w-5 h-5 text-gray-600"
+            className="w-5 h-5 text-[var(--dc-color-text-muted)]"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -130,19 +130,21 @@ export function DriveFolderPicker({
             />
           </svg>
         </button>
-        <span className="text-sm font-medium text-gray-900">Choose Folder</span>
+        <span className="text-sm font-medium text-[var(--dc-color-text-primary)]">
+          Choose Folder
+        </span>
       </div>
 
       {/* Breadcrumbs */}
       <div className="px-3 py-2 border-b border-gray-100 flex items-center gap-1 overflow-x-auto shrink-0">
         {breadcrumbs.map((crumb, i) => (
           <span key={crumb.id} className="flex items-center gap-1 shrink-0">
-            {i > 0 && <span className="text-gray-300 text-xs">/</span>}
+            {i > 0 && <span className="text-[var(--dc-color-border-strong)] text-xs">/</span>}
             <button
               onClick={() => navigateToBreadcrumb(i)}
               className={`text-xs min-h-[32px] px-1 rounded transition-colors ${
                 i === breadcrumbs.length - 1
-                  ? "font-medium text-gray-900"
+                  ? "font-medium text-[var(--dc-color-text-primary)]"
                   : "text-blue-600 hover:text-blue-700"
               }`}
             >
@@ -155,18 +157,22 @@ export function DriveFolderPicker({
       {/* Folder list */}
       <div className="flex-1 overflow-auto min-h-0">
         {isLoading ? (
-          <p className="px-3 py-6 text-center text-sm text-gray-500">Loading...</p>
+          <p className="px-3 py-6 text-center text-sm text-[var(--dc-color-text-muted)]">
+            Loading...
+          </p>
         ) : error ? (
           <p className="px-3 py-6 text-center text-sm text-red-600">{error}</p>
         ) : files.length === 0 ? (
-          <p className="px-3 py-6 text-center text-sm text-gray-400">No folders found</p>
+          <p className="px-3 py-6 text-center text-sm text-[var(--dc-color-text-placeholder)]">
+            No folders found
+          </p>
         ) : (
           <>
             {files.map((folder: DriveFile) => (
               <div
                 key={folder.id}
                 onClick={() => navigateToFolder(folder.id, folder.name)}
-                className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-50
+                className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-[var(--dc-color-surface-secondary)]
                            min-h-[44px] border-b border-gray-50"
               >
                 <svg
@@ -176,9 +182,11 @@ export function DriveFolderPicker({
                 >
                   <path d="M10 4H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V8a2 2 0 00-2-2h-8l-2-2z" />
                 </svg>
-                <span className="text-sm text-gray-900 truncate">{folder.name}</span>
+                <span className="text-sm text-[var(--dc-color-text-primary)] truncate">
+                  {folder.name}
+                </span>
                 <svg
-                  className="w-4 h-4 text-gray-400 shrink-0 ml-auto"
+                  className="w-4 h-4 text-[var(--dc-color-text-placeholder)] shrink-0 ml-auto"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -197,7 +205,7 @@ export function DriveFolderPicker({
               <button
                 onClick={loadMore}
                 disabled={isLoading}
-                className="w-full px-3 py-3 text-xs text-blue-600 hover:bg-gray-50
+                className="w-full px-3 py-3 text-xs text-blue-600 hover:bg-[var(--dc-color-surface-secondary)]
                            min-h-[44px] border-t border-gray-100"
               >
                 Load more
@@ -220,7 +228,7 @@ export function DriveFolderPicker({
                     if (e.key === "Escape") setShowCreateInput(false);
                   }}
                   placeholder="Folder name"
-                  className="flex-1 text-sm border border-gray-300 rounded-md px-2 py-1.5
+                  className="flex-1 text-sm border border-[var(--dc-color-border-strong)] rounded-md px-2 py-1.5
                              focus:outline-none focus:ring-2 focus:ring-blue-500 min-h-[36px]"
                   autoFocus
                 />
@@ -237,7 +245,7 @@ export function DriveFolderPicker({
                     setShowCreateInput(false);
                     setNewFolderName("");
                   }}
-                  className="text-xs text-gray-500 hover:text-gray-700 min-h-[36px] px-1"
+                  className="text-xs text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)] min-h-[36px] px-1"
                 >
                   Cancel
                 </button>

--- a/web/src/components/project/duplicate-project-dialog.tsx
+++ b/web/src/components/project/duplicate-project-dialog.tsx
@@ -46,18 +46,21 @@ export function DuplicateProjectDialog({
       aria-modal="true"
       aria-labelledby="duplicate-dialog-title"
     >
-      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
-        <h2 id="duplicate-dialog-title" className="text-lg font-semibold text-gray-900 mb-2">
+      <div className="bg-[var(--dc-color-surface-primary)] rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
+        <h2
+          id="duplicate-dialog-title"
+          className="text-lg font-semibold text-[var(--dc-color-text-primary)] mb-2"
+        >
           Duplicate Book
         </h2>
-        <p className="text-sm text-gray-600 mb-6">
+        <p className="text-sm text-[var(--dc-color-text-muted)] mb-6">
           Duplicate &ldquo;{projectTitle}&rdquo;? This creates a full copy of all chapters.
         </p>
         <div className="flex gap-3 justify-end">
           <button
             onClick={onCancel}
             disabled={isSubmitting}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg
+            className="px-4 py-2 text-sm font-medium text-[var(--dc-color-text-secondary)] bg-[var(--dc-color-surface-tertiary)] rounded-lg
                        hover:bg-gray-200 transition-colors min-h-[44px]
                        disabled:opacity-50 disabled:cursor-not-allowed"
           >

--- a/web/src/components/project/export-destination-picker.tsx
+++ b/web/src/components/project/export-destination-picker.tsx
@@ -109,7 +109,7 @@ export function ExportDestinationPicker({
     const folder = driveFolders[folderPickerOpen];
     return (
       <div className="fixed inset-0 bg-black/30 z-50 flex items-end justify-center">
-        <div className="bg-white rounded-t-2xl w-full max-w-lg max-h-[70vh] flex flex-col shadow-xl">
+        <div className="bg-[var(--dc-color-surface-primary)] rounded-t-2xl w-full max-w-lg max-h-[70vh] flex flex-col shadow-xl">
           <DriveFolderPicker
             connectionId={folderPickerOpen}
             initialFolderId={folder?.folderId}
@@ -126,14 +126,18 @@ export function ExportDestinationPicker({
 
   return (
     <div className="fixed inset-0 bg-black/30 z-50 flex items-end justify-center">
-      <div className="bg-white rounded-t-2xl w-full max-w-lg shadow-xl">
+      <div className="bg-[var(--dc-color-surface-primary)] rounded-t-2xl w-full max-w-lg shadow-xl">
         {/* Header */}
         <div className="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
           <div>
-            <h2 className="text-base font-semibold text-gray-900">
+            <h2 className="text-base font-semibold text-[var(--dc-color-text-primary)]">
               {editMode ? "Export Destination" : "Save Export"}
             </h2>
-            {!editMode && <p className="text-xs text-gray-500 truncate mt-0.5">{fileName}</p>}
+            {!editMode && (
+              <p className="text-xs text-[var(--dc-color-text-muted)] truncate mt-0.5">
+                {fileName}
+              </p>
+            )}
           </div>
           <button
             onClick={onDismiss}
@@ -141,7 +145,7 @@ export function ExportDestinationPicker({
             aria-label="Close"
           >
             <svg
-              className="w-5 h-5 text-gray-400"
+              className="w-5 h-5 text-[var(--dc-color-text-placeholder)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -164,12 +168,12 @@ export function ExportDestinationPicker({
             className={`w-full text-left p-3 rounded-lg border transition-colors min-h-[44px] ${
               selected.type === "device"
                 ? "border-blue-500 bg-blue-50"
-                : "border-gray-200 hover:border-gray-300"
+                : "border-gray-200 hover:border-[var(--dc-color-border-strong)]"
             }`}
           >
             <div className="flex items-center gap-3">
               <svg
-                className="w-5 h-5 text-gray-600 shrink-0"
+                className="w-5 h-5 text-[var(--dc-color-text-muted)] shrink-0"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -182,8 +186,12 @@ export function ExportDestinationPicker({
                 />
               </svg>
               <div>
-                <p className="text-sm font-medium text-gray-900">This Device</p>
-                <p className="text-xs text-gray-500">Save to your Downloads folder</p>
+                <p className="text-sm font-medium text-[var(--dc-color-text-primary)]">
+                  This Device
+                </p>
+                <p className="text-xs text-[var(--dc-color-text-muted)]">
+                  Save to your Downloads folder
+                </p>
               </div>
             </div>
           </button>
@@ -201,21 +209,25 @@ export function ExportDestinationPicker({
                 className={`w-full text-left p-3 rounded-lg border transition-colors min-h-[44px] ${
                   isSelected
                     ? "border-blue-500 bg-blue-50"
-                    : "border-gray-200 hover:border-gray-300"
+                    : "border-gray-200 hover:border-[var(--dc-color-border-strong)]"
                 }`}
               >
                 <div className="flex items-center gap-3">
                   <svg
-                    className="w-5 h-5 text-gray-600 shrink-0"
+                    className="w-5 h-5 text-[var(--dc-color-text-muted)] shrink-0"
                     viewBox="0 0 24 24"
                     fill="currentColor"
                   >
                     <path d="M7.71 3.5L1.15 15l3.43 5.99L11.01 9.5 7.71 3.5zm1.14 0l6.87 12H22.86l-3.43-6-6.87-12H8.85l-.01 0 .01-.01zm6.88 12.01H2.58l3.43 6h13.15l-3.43-6z" />
                   </svg>
                   <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium text-gray-900">Google Drive</p>
-                    <p className="text-xs text-gray-500 truncate">{connection.email}</p>
-                    <p className="text-xs text-gray-400 truncate">
+                    <p className="text-sm font-medium text-[var(--dc-color-text-primary)]">
+                      Google Drive
+                    </p>
+                    <p className="text-xs text-[var(--dc-color-text-muted)] truncate">
+                      {connection.email}
+                    </p>
+                    <p className="text-xs text-[var(--dc-color-text-placeholder)] truncate">
                       {folder?.folderPath || `${projectTitle} / _exports`}
                     </p>
                     {isSelected && (
@@ -243,9 +255,11 @@ export function ExportDestinationPicker({
               type="checkbox"
               checked={rememberDefault}
               onChange={(e) => setRememberDefault(e.target.checked)}
-              className="w-4 h-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              className="w-4 h-4 rounded border-[var(--dc-color-border-strong)] text-blue-600 focus:ring-blue-500"
             />
-            <span className="text-sm text-gray-700">Always save exports here</span>
+            <span className="text-sm text-[var(--dc-color-text-secondary)]">
+              Always save exports here
+            </span>
           </label>
         </div>
 

--- a/web/src/components/project/export-menu.tsx
+++ b/web/src/components/project/export-menu.tsx
@@ -453,18 +453,18 @@ export function ExportMenu({
       {/* Dropdown menu */}
       {isOpen && (
         <div
-          className="absolute right-0 top-full mt-1 w-56 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50"
+          className="absolute right-0 top-full mt-1 w-56 bg-[var(--dc-color-surface-primary)] rounded-lg shadow-lg border border-gray-200 py-1 z-50"
           role="menu"
           aria-label="Export options"
         >
           <button
             onClick={() => handleExport("book", "pdf")}
-            className="w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors
+            className="w-full text-left px-4 py-2.5 text-sm hover:bg-[var(--dc-color-surface-secondary)] transition-colors
                        min-h-[44px] flex items-center gap-2"
             role="menuitem"
           >
             <svg
-              className="w-4 h-4 text-gray-500 shrink-0"
+              className="w-4 h-4 text-[var(--dc-color-text-muted)] shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -481,12 +481,12 @@ export function ExportMenu({
 
           <button
             onClick={() => handleExport("book", "epub")}
-            className="w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors
+            className="w-full text-left px-4 py-2.5 text-sm hover:bg-[var(--dc-color-surface-secondary)] transition-colors
                        min-h-[44px] flex items-center gap-2"
             role="menuitem"
           >
             <svg
-              className="w-4 h-4 text-gray-500 shrink-0"
+              className="w-4 h-4 text-[var(--dc-color-text-muted)] shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -506,13 +506,13 @@ export function ExportMenu({
           <button
             onClick={() => handleExport("chapter", "pdf")}
             disabled={!activeChapterId}
-            className="w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors
+            className="w-full text-left px-4 py-2.5 text-sm hover:bg-[var(--dc-color-surface-secondary)] transition-colors
                        min-h-[44px] flex items-center gap-2
                        disabled:opacity-50 disabled:cursor-not-allowed"
             role="menuitem"
           >
             <svg
-              className="w-4 h-4 text-gray-500 shrink-0"
+              className="w-4 h-4 text-[var(--dc-color-text-muted)] shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -530,13 +530,13 @@ export function ExportMenu({
           <button
             onClick={() => handleExport("chapter", "epub")}
             disabled={!activeChapterId}
-            className="w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors
+            className="w-full text-left px-4 py-2.5 text-sm hover:bg-[var(--dc-color-surface-secondary)] transition-colors
                        min-h-[44px] flex items-center gap-2
                        disabled:opacity-50 disabled:cursor-not-allowed"
             role="menuitem"
           >
             <svg
-              className="w-4 h-4 text-gray-500 shrink-0"
+              className="w-4 h-4 text-[var(--dc-color-text-muted)] shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -559,12 +559,12 @@ export function ExportMenu({
               close();
               setDeliveryPhase("destination-settings");
             }}
-            className="w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors
+            className="w-full text-left px-4 py-2.5 text-sm hover:bg-[var(--dc-color-surface-secondary)] transition-colors
                        min-h-[44px] flex items-center gap-2"
             role="menuitem"
           >
             <svg
-              className="w-4 h-4 text-gray-500 shrink-0"
+              className="w-4 h-4 text-[var(--dc-color-text-muted)] shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -591,13 +591,13 @@ export function ExportMenu({
               downloadBackup(projectId);
             }}
             disabled={isDownloading}
-            className="w-full text-left px-4 py-2.5 text-sm hover:bg-gray-50 transition-colors
+            className="w-full text-left px-4 py-2.5 text-sm hover:bg-[var(--dc-color-surface-secondary)] transition-colors
                        min-h-[44px] flex items-center gap-2
                        disabled:opacity-50 disabled:cursor-not-allowed"
             role="menuitem"
           >
             <svg
-              className="w-4 h-4 text-gray-500 shrink-0"
+              className="w-4 h-4 text-[var(--dc-color-text-muted)] shrink-0"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"

--- a/web/src/components/project/project-switcher.tsx
+++ b/web/src/components/project/project-switcher.tsx
@@ -43,7 +43,7 @@ export function ProjectSwitcher({ currentProject, projects }: ProjectSwitcherPro
       {/* Trigger button */}
       <button
         onClick={toggle}
-        className="flex items-center gap-2 h-11 px-3 rounded-lg hover:bg-gray-100 transition-colors max-w-[280px]"
+        className="flex items-center gap-2 h-11 px-3 rounded-lg hover:bg-[var(--dc-color-surface-tertiary)] transition-colors max-w-[280px]"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
       >
@@ -61,7 +61,7 @@ export function ProjectSwitcher({ currentProject, projects }: ProjectSwitcherPro
       {/* Dropdown menu */}
       {isOpen && (
         <div
-          className="absolute top-full left-0 mt-1 w-64 bg-white border border-border rounded-lg shadow-lg z-50 py-1"
+          className="absolute top-full left-0 mt-1 w-64 bg-[var(--dc-color-surface-primary)] border border-border rounded-lg shadow-lg z-50 py-1"
           role="listbox"
         >
           {/* Project list */}
@@ -70,8 +70,8 @@ export function ProjectSwitcher({ currentProject, projects }: ProjectSwitcherPro
               key={project.id}
               onClick={() => handleProjectSelect(project.id)}
               className={`w-full px-4 py-3 text-left flex items-center justify-between min-h-[48px]
-                         hover:bg-gray-50 transition-colors
-                         ${project.id === currentProject.id ? "bg-blue-50" : ""}`}
+                         hover:bg-[var(--dc-color-surface-secondary)] transition-colors
+                         ${project.id === currentProject.id ? "bg-[var(--dc-color-interactive-primary-subtle)]" : ""}`}
               role="option"
               aria-selected={project.id === currentProject.id}
             >
@@ -109,7 +109,7 @@ export function ProjectSwitcher({ currentProject, projects }: ProjectSwitcherPro
             href="/setup"
             onClick={close}
             className="w-full px-4 py-3 text-left flex items-center gap-2 min-h-[48px]
-                       hover:bg-gray-50 transition-colors text-blue-600"
+                       hover:bg-[var(--dc-color-surface-secondary)] transition-colors text-blue-600"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path

--- a/web/src/components/project/rename-project-dialog.tsx
+++ b/web/src/components/project/rename-project-dialog.tsx
@@ -56,8 +56,11 @@ export function RenameProjectDialog({
       aria-modal="true"
       aria-labelledby="rename-dialog-title"
     >
-      <div className="bg-white rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
-        <h2 id="rename-dialog-title" className="text-lg font-semibold text-gray-900 mb-4">
+      <div className="bg-[var(--dc-color-surface-primary)] rounded-xl shadow-2xl max-w-md w-full mx-4 p-6">
+        <h2
+          id="rename-dialog-title"
+          className="text-lg font-semibold text-[var(--dc-color-text-primary)] mb-4"
+        >
           Rename Book
         </h2>
         <input
@@ -68,7 +71,7 @@ export function RenameProjectDialog({
             if (e.key === "Enter") handleSubmit();
             if (e.key === "Escape") onCancel();
           }}
-          className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm
+          className="w-full px-3 py-2 border border-[var(--dc-color-border-strong)] rounded-lg text-sm
                      focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           maxLength={500}
           autoFocus
@@ -77,7 +80,7 @@ export function RenameProjectDialog({
           <button
             onClick={onCancel}
             disabled={isSubmitting}
-            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg
+            className="px-4 py-2 text-sm font-medium text-[var(--dc-color-text-secondary)] bg-[var(--dc-color-surface-tertiary)] rounded-lg
                        hover:bg-gray-200 transition-colors min-h-[44px]
                        disabled:opacity-50 disabled:cursor-not-allowed"
           >

--- a/web/src/components/project/settings-menu.tsx
+++ b/web/src/components/project/settings-menu.tsx
@@ -74,14 +74,14 @@ export function SettingsMenu({
 
       {isOpen && (
         <div
-          className="absolute right-0 top-full mt-1 w-52 bg-white rounded-lg shadow-lg border border-gray-200 py-1 z-50"
+          className="absolute right-0 top-full mt-1 w-52 bg-[var(--dc-color-surface-primary)] rounded-lg shadow-lg border border-gray-200 py-1 z-50"
           role="menu"
           aria-label="Project settings"
         >
           {/* Rename Book */}
           <button
             onClick={() => handleMenuItem(onRenameBook)}
-            className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+            className="w-full text-left px-4 py-2.5 text-sm text-[var(--dc-color-text-secondary)] hover:bg-[var(--dc-color-surface-tertiary)]
                        transition-colors min-h-[44px] flex items-center gap-2"
             role="menuitem"
           >
@@ -100,7 +100,7 @@ export function SettingsMenu({
           <button
             onClick={() => handleMenuItem(onDuplicateBook)}
             disabled={isDuplicating}
-            className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+            className="w-full text-left px-4 py-2.5 text-sm text-[var(--dc-color-text-secondary)] hover:bg-[var(--dc-color-surface-tertiary)]
                        transition-colors min-h-[44px] flex items-center gap-2
                        disabled:opacity-50 disabled:cursor-not-allowed"
             role="menuitem"
@@ -139,7 +139,7 @@ export function SettingsMenu({
           <Link
             href="/help"
             onClick={close}
-            className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+            className="w-full text-left px-4 py-2.5 text-sm text-[var(--dc-color-text-secondary)] hover:bg-[var(--dc-color-surface-tertiary)]
                        transition-colors min-h-[44px] flex items-center gap-2"
             role="menuitem"
           >
@@ -161,7 +161,7 @@ export function SettingsMenu({
           <button
             onClick={() => handleMenuItem(onSignOut)}
             disabled={isSigningOut}
-            className="w-full text-left px-4 py-2.5 text-sm text-gray-700 hover:bg-gray-100
+            className="w-full text-left px-4 py-2.5 text-sm text-[var(--dc-color-text-secondary)] hover:bg-[var(--dc-color-surface-tertiary)]
                        transition-colors min-h-[44px] flex items-center gap-2
                        disabled:opacity-50 disabled:cursor-not-allowed"
             role="menuitem"

--- a/web/src/components/sources/desk-tab.tsx
+++ b/web/src/components/sources/desk-tab.tsx
@@ -185,7 +185,9 @@ export function DeskTab() {
       {/* Zone A: Instruction controls — fixed at top, capped at 50% */}
       <div className="shrink-0 max-h-[50%] overflow-y-auto border-b border-gray-200">
         <div className="px-4 pt-4">
-          <label className="text-xs font-medium text-gray-500 mb-1.5 block">Instruction</label>
+          <label className="text-xs font-medium text-[var(--dc-color-text-muted)] mb-1.5 block">
+            Instruction
+          </label>
 
           {/* Instruction list (replaces chips + saved picker) */}
           <div className="mb-3">
@@ -209,7 +211,7 @@ export function DeskTab() {
           <div className="pb-3">
             <label
               htmlFor="desk-instruction-textarea"
-              className="text-xs font-medium text-gray-500 mb-1.5 block"
+              className="text-xs font-medium text-[var(--dc-color-text-muted)] mb-1.5 block"
             >
               Or write your own
             </label>
@@ -233,12 +235,12 @@ export function DeskTab() {
       {/* Zone B: Document list + analysis results — flex-grows to fill remaining space */}
       <div className="flex-1 overflow-y-auto min-h-0">
         {/* Document list header */}
-        <div className="px-4 py-2 border-b border-gray-100 flex items-center gap-2 sticky top-0 bg-white z-10">
+        <div className="px-4 py-2 border-b border-gray-100 flex items-center gap-2 sticky top-0 bg-[var(--dc-color-surface-primary)] z-10">
           <button
             onClick={toggleSelectAll}
             role="checkbox"
             aria-checked={allSelected ? "true" : someSelected ? "mixed" : "false"}
-            className="flex items-center gap-2 text-xs text-gray-500 hover:text-gray-700
+            className="flex items-center gap-2 text-xs text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)]
                        transition-colors min-h-[32px]"
           >
             <span
@@ -247,7 +249,7 @@ export function DeskTab() {
                   ? "bg-blue-600 border-blue-600"
                   : someSelected
                     ? "bg-blue-600 border-blue-600"
-                    : "border-gray-300"
+                    : "border-[var(--dc-color-border-strong)]"
               }`}
             >
               {allSelected && (
@@ -278,7 +280,7 @@ export function DeskTab() {
             </span>
             {allSelected ? "Deselect all" : "Select all"}
           </button>
-          <span className="text-[10px] text-gray-400 ml-auto">
+          <span className="text-[10px] text-[var(--dc-color-text-placeholder)] ml-auto">
             {selectedIds.size > 0
               ? `${selectedIds.size} selected`
               : `${deskSources.length} on desk`}
@@ -299,7 +301,7 @@ export function DeskTab() {
             return (
               <div
                 key={source.id}
-                className="flex items-center w-full border-b border-gray-50 hover:bg-gray-50"
+                className="flex items-center w-full border-b border-gray-50 hover:bg-[var(--dc-color-surface-secondary)]"
               >
                 {/* Checkbox + title (tap to select) */}
                 <button
@@ -310,7 +312,9 @@ export function DeskTab() {
                 >
                   <span
                     className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 transition-colors ${
-                      isSelected ? "bg-blue-600 border-blue-600" : "border-gray-300"
+                      isSelected
+                        ? "bg-blue-600 border-blue-600"
+                        : "border-[var(--dc-color-border-strong)]"
                     }`}
                   >
                     {isSelected && (
@@ -342,7 +346,7 @@ export function DeskTab() {
                       d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                     />
                   </svg>
-                  <span className="text-sm text-gray-900 truncate flex-1 text-left">
+                  <span className="text-sm text-[var(--dc-color-text-primary)] truncate flex-1 text-left">
                     {source.title}
                   </span>
                 </button>
@@ -351,7 +355,7 @@ export function DeskTab() {
                 <button
                   onClick={() => handleUntag(source.id, source.title)}
                   className="p-2 mr-1 shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center
-                             text-blue-600 hover:text-gray-400 transition-colors"
+                             text-blue-600 hover:text-[var(--dc-color-text-placeholder)] transition-colors"
                   aria-label="Remove from desk"
                 >
                   <svg
@@ -376,7 +380,7 @@ export function DeskTab() {
         {/* Deep analysis progress */}
         {isDeepProcessing && deepAnalysis.totalBatches > 0 && (
           <div className="px-4 py-4 space-y-2">
-            <div className="flex items-center justify-between text-xs text-gray-500">
+            <div className="flex items-center justify-between text-xs text-[var(--dc-color-text-muted)]">
               <span>
                 Analyzing{" "}
                 {deepAnalysis.totalBatches > 1
@@ -402,9 +406,9 @@ export function DeskTab() {
         {/* Analysis result / streaming response */}
         {(effectiveText || isAnalyzing || effectiveError) && (
           <div ref={analysisRef} className="px-4 py-4 space-y-2">
-            <h3 className="text-xs font-medium text-gray-500">Analysis</h3>
+            <h3 className="text-xs font-medium text-[var(--dc-color-text-muted)]">Analysis</h3>
             <div
-              className="p-3 bg-gray-50 rounded-lg text-sm text-gray-900 leading-relaxed whitespace-pre-wrap min-h-[60px]"
+              className="p-3 bg-[var(--dc-color-surface-secondary)] rounded-lg text-sm text-[var(--dc-color-text-primary)] leading-relaxed whitespace-pre-wrap min-h-[60px]"
               aria-live={isAnyAnalyzing ? "off" : "polite"}
             >
               {effectiveText}
@@ -436,8 +440,8 @@ export function DeskTab() {
           <>
             <button
               onClick={handleCopy}
-              className="flex-1 h-10 rounded-lg border border-gray-300 text-sm font-medium text-gray-700
-                         hover:bg-gray-50 transition-colors min-h-[44px]"
+              className="flex-1 h-10 rounded-lg border border-[var(--dc-color-border-strong)] text-sm font-medium text-[var(--dc-color-text-secondary)]
+                         hover:bg-[var(--dc-color-surface-secondary)] transition-colors min-h-[44px]"
             >
               Copy
             </button>

--- a/web/src/components/sources/document-peek-view.tsx
+++ b/web/src/components/sources/document-peek-view.tsx
@@ -139,7 +139,7 @@ export function DocumentPeekView({
         <div className="flex items-center gap-2">
           <button
             onClick={onBack}
-            className="p-1 text-gray-400 hover:text-gray-600 min-h-[44px] min-w-[44px] flex items-center justify-center"
+            className="p-1 text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-muted)] min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Back to browser"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -152,9 +152,13 @@ export function DocumentPeekView({
             </svg>
           </button>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 truncate">{fileName}</h3>
+            <h3 className="text-sm font-medium text-[var(--dc-color-text-primary)] truncate">
+              {fileName}
+            </h3>
             {!isLoading && !error && (
-              <p className="text-xs text-gray-500">{wordCount.toLocaleString()} words</p>
+              <p className="text-xs text-[var(--dc-color-text-muted)]">
+                {wordCount.toLocaleString()} words
+              </p>
             )}
           </div>
         </div>
@@ -164,7 +168,7 @@ export function DocumentPeekView({
       <div className="flex-1 overflow-auto px-4 py-4">
         {isLoading ? (
           <div className="flex items-center justify-center py-12">
-            <p className="text-sm text-gray-500">Loading content...</p>
+            <p className="text-sm text-[var(--dc-color-text-muted)]">Loading content...</p>
           </div>
         ) : error ? (
           <div className="flex items-center justify-center py-12">
@@ -175,7 +179,9 @@ export function DocumentPeekView({
             {format === "html" ? (
               <div className="source-content" dangerouslySetInnerHTML={{ __html: content }} />
             ) : (
-              <pre className="whitespace-pre-wrap text-sm text-gray-800 font-sans">{content}</pre>
+              <pre className="whitespace-pre-wrap text-sm text-[var(--dc-color-text-primary)] font-sans">
+                {content}
+              </pre>
             )}
           </div>
         ) : null}
@@ -191,7 +197,7 @@ export function DocumentPeekView({
                        disabled:opacity-50 disabled:cursor-default ${
                          isOnDesk
                            ? "border-blue-300 text-blue-700 hover:bg-blue-50"
-                           : "border-gray-300 text-gray-700 hover:bg-gray-50"
+                           : "border-[var(--dc-color-border-strong)] text-[var(--dc-color-text-secondary)] hover:bg-[var(--dc-color-surface-secondary)]"
                        }`}
           >
             {isAdding

--- a/web/src/components/sources/drive-browser.tsx
+++ b/web/src/components/sources/drive-browser.tsx
@@ -105,12 +105,12 @@ export function DriveBrowser({
       <div className="px-3 py-2 border-b border-gray-100 flex items-center gap-1 overflow-x-auto shrink-0">
         {breadcrumbs.map((crumb, i) => (
           <span key={crumb.id} className="flex items-center gap-1 shrink-0">
-            {i > 0 && <span className="text-gray-300 text-xs">/</span>}
+            {i > 0 && <span className="text-[var(--dc-color-border-strong)] text-xs">/</span>}
             <button
               onClick={() => navigateToBreadcrumb(i)}
               className={`text-xs min-h-[32px] px-1 rounded transition-colors ${
                 i === breadcrumbs.length - 1
-                  ? "font-medium text-gray-900"
+                  ? "font-medium text-[var(--dc-color-text-primary)]"
                   : "text-blue-600 hover:text-blue-700"
               }`}
             >
@@ -123,7 +123,9 @@ export function DriveBrowser({
       {/* File list */}
       <div className="flex-1 overflow-auto min-h-0">
         {isLoading ? (
-          <p className="px-3 py-6 text-center text-sm text-gray-500">Loading...</p>
+          <p className="px-3 py-6 text-center text-sm text-[var(--dc-color-text-muted)]">
+            Loading...
+          </p>
         ) : error ? (
           <div className="px-3 py-6 text-center">
             <p className="text-sm text-red-600 mb-2">{error}</p>
@@ -153,8 +155,12 @@ export function DriveBrowser({
             const msg = getEmptyMessage();
             return (
               <div className="px-3 py-6 text-center">
-                <p className="text-sm text-gray-400">{msg.title}</p>
-                {msg.detail && <p className="text-xs text-gray-400 mt-1">{msg.detail}</p>}
+                <p className="text-sm text-[var(--dc-color-text-placeholder)]">{msg.title}</p>
+                {msg.detail && (
+                  <p className="text-xs text-[var(--dc-color-text-placeholder)] mt-1">
+                    {msg.detail}
+                  </p>
+                )}
               </div>
             );
           })()
@@ -166,7 +172,7 @@ export function DriveBrowser({
                 key={folder.id}
                 onClick={() => navigateToFolder(folder.id, folder.name)}
                 className="flex items-center gap-2 w-full px-3 min-h-[44px] border-b border-gray-50
-                           hover:bg-gray-50 cursor-pointer"
+                           hover:bg-[var(--dc-color-surface-secondary)] cursor-pointer"
               >
                 <svg
                   className="w-5 h-5 text-yellow-500 shrink-0"
@@ -175,11 +181,11 @@ export function DriveBrowser({
                 >
                   <path d="M10 4H4a2 2 0 00-2 2v12a2 2 0 002 2h16a2 2 0 002-2V8a2 2 0 00-2-2h-8l-2-2z" />
                 </svg>
-                <span className="text-sm text-gray-900 truncate flex-1 text-left">
+                <span className="text-sm text-[var(--dc-color-text-primary)] truncate flex-1 text-left">
                   {folder.name}
                 </span>
                 <svg
-                  className="w-4 h-4 text-gray-400 shrink-0"
+                  className="w-4 h-4 text-[var(--dc-color-text-placeholder)] shrink-0"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -200,7 +206,7 @@ export function DriveBrowser({
               return (
                 <div
                   key={doc.id}
-                  className="flex items-center w-full border-b border-gray-50 hover:bg-gray-50"
+                  className="flex items-center w-full border-b border-gray-50 hover:bg-[var(--dc-color-surface-secondary)]"
                 >
                   <button
                     onClick={() => onDocumentTap(doc)}
@@ -219,14 +225,14 @@ export function DriveBrowser({
                         d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
                       />
                     </svg>
-                    <span className="text-sm text-gray-900 truncate flex-1 text-left">
+                    <span className="text-sm text-[var(--dc-color-text-primary)] truncate flex-1 text-left">
                       {doc.name}
                     </span>
                   </button>
                   <button
                     onClick={() => (isTagged ? onUntag(doc) : onTag(doc))}
                     className={`p-2 mr-1 shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center
-                               transition-colors ${isTagged ? "text-blue-600" : "text-gray-300 hover:text-gray-500"}`}
+                               transition-colors ${isTagged ? "text-blue-600" : "text-[var(--dc-color-border-strong)] hover:text-[var(--dc-color-text-muted)]"}`}
                     aria-label={isTagged ? "Remove from desk" : "Add to desk"}
                   >
                     <svg
@@ -252,7 +258,7 @@ export function DriveBrowser({
               <button
                 onClick={loadMore}
                 disabled={isLoading}
-                className="w-full px-3 py-3 text-xs text-blue-600 hover:bg-gray-50
+                className="w-full px-3 py-3 text-xs text-blue-600 hover:bg-[var(--dc-color-surface-secondary)]
                            min-h-[44px] border-t border-gray-100"
               >
                 {isLoading ? "Loading..." : "Load more"}

--- a/web/src/components/sources/empty-state.tsx
+++ b/web/src/components/sources/empty-state.tsx
@@ -29,9 +29,13 @@ export function EmptyState({
 }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center px-6 py-12 text-center">
-      <div className="mb-4 text-gray-400">{icon}</div>
-      <p className="text-sm font-medium text-gray-700 mb-1">{message}</p>
-      {description && <p className="text-xs text-gray-500 mb-4 max-w-[240px]">{description}</p>}
+      <div className="mb-4 text-[var(--dc-color-text-placeholder)]">{icon}</div>
+      <p className="text-sm font-medium text-[var(--dc-color-text-secondary)] mb-1">{message}</p>
+      {description && (
+        <p className="text-xs text-[var(--dc-color-text-muted)] mb-4 max-w-[240px]">
+          {description}
+        </p>
+      )}
       {(action || secondaryAction) && (
         <div className="flex flex-col items-center gap-2">
           {action && (
@@ -46,7 +50,7 @@ export function EmptyState({
           {secondaryAction && (
             <button
               onClick={secondaryAction.onClick}
-              className="text-xs text-gray-500 hover:text-gray-700 transition-colors min-h-[44px]"
+              className="text-xs text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)] transition-colors min-h-[44px]"
             >
               {secondaryAction.label}
             </button>

--- a/web/src/components/sources/library-tab.tsx
+++ b/web/src/components/sources/library-tab.tsx
@@ -244,7 +244,7 @@ export function LibraryTab() {
   if (isLoadingSources) {
     return (
       <div className="px-3 py-8 text-center">
-        <p className="text-sm text-gray-500">Loading...</p>
+        <p className="text-sm text-[var(--dc-color-text-muted)]">Loading...</p>
       </div>
     );
   }
@@ -292,7 +292,9 @@ export function LibraryTab() {
           </svg>
 
           {connections.length === 1 ? (
-            <span className="text-xs text-gray-700 truncate flex-1">{activeAccountEmail}</span>
+            <span className="text-xs text-[var(--dc-color-text-secondary)] truncate flex-1">
+              {activeAccountEmail}
+            </span>
           ) : (
             <>
               <label htmlFor="browse-account-picker" className="sr-only">
@@ -302,7 +304,7 @@ export function LibraryTab() {
                 id="browse-account-picker"
                 value={safeIndex}
                 onChange={(e) => setSelectedConnectionIndex(Number(e.target.value))}
-                className="text-xs text-gray-700 bg-white border border-gray-200 rounded-md
+                className="text-xs text-[var(--dc-color-text-secondary)] bg-white border border-gray-200 rounded-md
                            px-2 py-1.5 min-h-[32px] flex-1 truncate"
               >
                 {connections.map((connection, i) => (

--- a/web/src/components/sources/project-source-list.tsx
+++ b/web/src/components/sources/project-source-list.tsx
@@ -64,7 +64,7 @@ export function ProjectSourceList() {
   if (isLoadingSources) {
     return (
       <div className="px-3 py-6 text-center">
-        <p className="text-sm text-gray-500">Loading sources...</p>
+        <p className="text-sm text-[var(--dc-color-text-muted)]">Loading sources...</p>
       </div>
     );
   }
@@ -76,7 +76,7 @@ export function ProjectSourceList() {
         <div className="px-3 pb-2">
           <div className="relative">
             <svg
-              className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400"
+              className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-[var(--dc-color-text-placeholder)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -99,7 +99,7 @@ export function ProjectSourceList() {
             {searchQuery && (
               <button
                 onClick={() => handleSearch("")}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-muted)]
                            min-h-[32px] min-w-[32px] flex items-center justify-center"
                 aria-label="Clear search"
               >
@@ -114,7 +114,11 @@ export function ProjectSourceList() {
               </button>
             )}
           </div>
-          {isSearching && <p className="text-xs text-gray-400 mt-1 px-1">Searching...</p>}
+          {isSearching && (
+            <p className="text-xs text-[var(--dc-color-text-placeholder)] mt-1 px-1">
+              Searching...
+            </p>
+          )}
         </div>
       )}
 
@@ -148,7 +152,7 @@ export function ProjectSourceList() {
                 <>
                   <button
                     onClick={() => openSourceAnalysis(source.id)}
-                    className="p-1.5 text-gray-400 hover:text-blue-600 transition-colors
+                    className="p-1.5 text-[var(--dc-color-text-placeholder)] hover:text-blue-600 transition-colors
                                min-h-[44px] min-w-[44px] flex items-center justify-center"
                     aria-label={`Analyze ${source.title}`}
                     title="Analyze with AI"
@@ -164,7 +168,7 @@ export function ProjectSourceList() {
                   </button>
                   <button
                     onClick={() => handleRemove(source.id, source.title)}
-                    className="p-1.5 text-gray-400 hover:text-red-600 transition-colors
+                    className="p-1.5 text-[var(--dc-color-text-placeholder)] hover:text-red-600 transition-colors
                                min-h-[44px] min-w-[44px] flex items-center justify-center"
                     aria-label={`Remove ${source.title}`}
                     title="Remove source"

--- a/web/src/components/sources/review-tab.tsx
+++ b/web/src/components/sources/review-tab.tsx
@@ -164,7 +164,7 @@ export function SourceDetailView({ onBack }: SourceDetailViewProps) {
         <div className="flex items-center gap-2">
           <button
             onClick={onBack}
-            className="p-1 text-gray-400 hover:text-gray-600 min-h-[44px] min-w-[44px] flex items-center justify-center"
+            className="p-1 text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-muted)] min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Back to Library"
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -177,9 +177,13 @@ export function SourceDetailView({ onBack }: SourceDetailViewProps) {
             </svg>
           </button>
           <div className="flex-1 min-w-0">
-            <h3 className="text-sm font-medium text-gray-900 truncate">{source.title}</h3>
+            <h3 className="text-sm font-medium text-[var(--dc-color-text-primary)] truncate">
+              {source.title}
+            </h3>
             {content && (
-              <p className="text-xs text-gray-500">{content.wordCount.toLocaleString()} words</p>
+              <p className="text-xs text-[var(--dc-color-text-muted)]">
+                {content.wordCount.toLocaleString()} words
+              </p>
             )}
           </div>
         </div>
@@ -189,7 +193,7 @@ export function SourceDetailView({ onBack }: SourceDetailViewProps) {
       <div className="flex-1 overflow-auto px-4 py-4 relative">
         {isLoading ? (
           <div className="flex items-center justify-center py-12">
-            <p className="text-sm text-gray-500">Loading content...</p>
+            <p className="text-sm text-[var(--dc-color-text-muted)]">Loading content...</p>
           </div>
         ) : error ? (
           <div className="flex items-center justify-center py-12">

--- a/web/src/components/sources/source-item.tsx
+++ b/web/src/components/sources/source-item.tsx
@@ -31,7 +31,11 @@ function SourceIcon({ mimeType }: { mimeType: string }) {
   }
   // Text / Markdown / default
   return (
-    <svg className="w-5 h-5 text-gray-500 shrink-0" viewBox="0 0 24 24" fill="currentColor">
+    <svg
+      className="w-5 h-5 text-[var(--dc-color-text-muted)] shrink-0"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+    >
       <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8l-6-6zm-1 2l5 5h-5V4zM8 13h8v2H8v-2zm0 4h5v2H8v-2z" />
     </svg>
   );
@@ -52,7 +56,7 @@ export function SourceItem({
   return (
     <div
       className={`flex items-center gap-3 px-3 py-2 rounded-lg transition-colors min-h-[44px]
-                  ${onClick ? "cursor-pointer hover:bg-gray-50 active:bg-gray-100" : ""}
+                  ${onClick ? "cursor-pointer hover:bg-[var(--dc-color-surface-secondary)] active:bg-[var(--dc-color-surface-tertiary)]" : ""}
                   ${selected ? "bg-blue-50 ring-1 ring-blue-200" : ""}`}
       onClick={onClick}
       role={onClick ? "button" : undefined}
@@ -70,9 +74,13 @@ export function SourceItem({
     >
       <SourceIcon mimeType={mimeType} />
       <div className="flex-1 min-w-0">
-        <p className="text-sm font-medium text-gray-900 truncate leading-tight">{title}</p>
+        <p className="text-sm font-medium text-[var(--dc-color-text-primary)] truncate leading-tight">
+          {title}
+        </p>
         {wordCount > 0 && (
-          <p className="text-xs text-gray-500">{wordCount.toLocaleString()} words</p>
+          <p className="text-xs text-[var(--dc-color-text-muted)]">
+            {wordCount.toLocaleString()} words
+          </p>
         )}
       </div>
       {actions && (

--- a/web/src/components/sources/source-picker.tsx
+++ b/web/src/components/sources/source-picker.tsx
@@ -55,7 +55,7 @@ export function SourcePicker({
           aria-label="Go back"
         >
           <svg
-            className="w-5 h-5 text-gray-500"
+            className="w-5 h-5 text-[var(--dc-color-text-muted)]"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -68,18 +68,20 @@ export function SourcePicker({
             />
           </svg>
         </button>
-        <h3 className="text-sm font-medium text-gray-900">Add Source</h3>
+        <h3 className="text-sm font-medium text-[var(--dc-color-text-primary)]">Add Source</h3>
       </div>
 
       {/* Trust message */}
-      <p className="text-xs text-gray-400 mb-4 px-1">Your originals are never changed.</p>
+      <p className="text-xs text-[var(--dc-color-text-placeholder)] mb-4 px-1">
+        Your originals are never changed.
+      </p>
 
       {/* Source type rows */}
       <div className="flex flex-col gap-1">
         {/* Google Drive */}
         <button
           onClick={handleDriveClick}
-          className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+          className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-[var(--dc-color-surface-secondary)]
                      transition-colors min-h-[56px] w-full text-left"
         >
           <div className="w-9 h-9 rounded-lg bg-blue-50 flex items-center justify-center shrink-0">
@@ -91,13 +93,15 @@ export function SourcePicker({
             </svg>
           </div>
           <div className="flex-1 min-w-0">
-            <span className="text-sm font-medium text-gray-900 block">Google Drive</span>
-            <span className="text-xs text-gray-500 block">
+            <span className="text-sm font-medium text-[var(--dc-color-text-primary)] block">
+              Google Drive
+            </span>
+            <span className="text-xs text-[var(--dc-color-text-muted)] block">
               Browse and add documents from your Drive
             </span>
           </div>
           <svg
-            className={`w-4 h-4 text-gray-400 shrink-0 transition-transform ${expanded && connections.length >= 1 ? "rotate-90" : ""}`}
+            className={`w-4 h-4 text-[var(--dc-color-text-placeholder)] shrink-0 transition-transform ${expanded && connections.length >= 1 ? "rotate-90" : ""}`}
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -108,12 +112,12 @@ export function SourcePicker({
 
         {/* Inline account list: browse existing or connect another */}
         {expanded && connections.length >= 1 && (
-          <div className="ml-6 bg-gray-50 rounded-lg overflow-hidden">
+          <div className="ml-6 bg-[var(--dc-color-surface-secondary)] rounded-lg overflow-hidden">
             {connections.map((connection) => (
               <button
                 key={connection.driveConnectionId}
                 onClick={() => onSelectConnection(connection)}
-                className="flex items-center gap-3 px-3 py-2.5 hover:bg-gray-100
+                className="flex items-center gap-3 px-3 py-2.5 hover:bg-[var(--dc-color-surface-tertiary)]
                            transition-colors min-h-[44px] w-full text-left"
               >
                 <svg className="w-4 h-4 shrink-0" viewBox="0 0 24 24" fill="currentColor">
@@ -122,9 +126,11 @@ export function SourcePicker({
                     className="text-blue-500"
                   />
                 </svg>
-                <span className="text-sm text-gray-700 truncate flex-1">{connection.email}</span>
+                <span className="text-sm text-[var(--dc-color-text-secondary)] truncate flex-1">
+                  {connection.email}
+                </span>
                 <svg
-                  className="w-4 h-4 text-gray-400 shrink-0"
+                  className="w-4 h-4 text-[var(--dc-color-text-placeholder)] shrink-0"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -140,11 +146,11 @@ export function SourcePicker({
             ))}
             <button
               onClick={onConnectDrive}
-              className="flex items-center gap-3 px-3 py-2.5 hover:bg-gray-100
+              className="flex items-center gap-3 px-3 py-2.5 hover:bg-[var(--dc-color-surface-tertiary)]
                          transition-colors min-h-[44px] w-full text-left border-t border-gray-200"
             >
               <svg
-                className="w-4 h-4 shrink-0 text-gray-400"
+                className="w-4 h-4 shrink-0 text-[var(--dc-color-text-placeholder)]"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -156,7 +162,9 @@ export function SourcePicker({
                   d="M12 4v16m8-8H4"
                 />
               </svg>
-              <span className="text-sm text-gray-500">Connect another account</span>
+              <span className="text-sm text-[var(--dc-color-text-muted)]">
+                Connect another account
+              </span>
             </button>
           </div>
         )}
@@ -164,12 +172,12 @@ export function SourcePicker({
         {/* Local Files */}
         <button
           onClick={onUploadLocal}
-          className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-gray-50
+          className="flex items-center gap-3 px-3 py-2.5 rounded-lg hover:bg-[var(--dc-color-surface-secondary)]
                      transition-colors min-h-[56px] w-full text-left"
         >
-          <div className="w-9 h-9 rounded-lg bg-gray-50 flex items-center justify-center shrink-0">
+          <div className="w-9 h-9 rounded-lg bg-[var(--dc-color-surface-secondary)] flex items-center justify-center shrink-0">
             <svg
-              className="w-5 h-5 text-gray-500"
+              className="w-5 h-5 text-[var(--dc-color-text-muted)]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -183,11 +191,15 @@ export function SourcePicker({
             </svg>
           </div>
           <div className="flex-1 min-w-0">
-            <span className="text-sm font-medium text-gray-900 block">Local Files</span>
-            <span className="text-xs text-gray-500 block">Upload documents from this device</span>
+            <span className="text-sm font-medium text-[var(--dc-color-text-primary)] block">
+              Local Files
+            </span>
+            <span className="text-xs text-[var(--dc-color-text-muted)] block">
+              Upload documents from this device
+            </span>
           </div>
           <svg
-            className="w-4 h-4 text-gray-400 shrink-0"
+            className="w-4 h-4 text-[var(--dc-color-text-placeholder)] shrink-0"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -201,7 +213,7 @@ export function SourcePicker({
       <div className="mt-auto pt-4">
         <button
           onClick={onCancel}
-          className="text-sm text-gray-500 hover:text-gray-700 transition-colors min-h-[44px] px-3"
+          className="text-sm text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)] transition-colors min-h-[44px] px-3"
         >
           Cancel
         </button>

--- a/web/src/components/sources/sources-panel-overlay.tsx
+++ b/web/src/components/sources/sources-panel-overlay.tsx
@@ -52,8 +52,8 @@ export function SourcesPanelOverlay() {
                 className={`h-8 px-3 text-xs font-medium rounded-md transition-colors min-h-[32px]
                            ${
                              activeTab === tab.id
-                               ? "bg-blue-50 text-blue-700"
-                               : "text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+                               ? "bg-[var(--dc-color-interactive-primary-subtle)] text-[var(--dc-color-interactive-primary-on-subtle)]"
+                               : "text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-primary)] hover:bg-[var(--dc-color-surface-secondary)]"
                            }`}
                 aria-selected={activeTab === tab.id}
                 role="tab"
@@ -64,7 +64,7 @@ export function SourcesPanelOverlay() {
           </div>
           <button
             onClick={closePanel}
-            className="p-1.5 text-gray-400 hover:text-gray-600 transition-colors
+            className="p-1.5 text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-muted)] transition-colors
                        min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Close library panel"
           >

--- a/web/src/components/sources/sources-panel.tsx
+++ b/web/src/components/sources/sources-panel.tsx
@@ -38,8 +38,8 @@ export function SourcesPanel() {
               className={`h-8 px-3 text-xs font-medium rounded-md transition-colors min-h-[32px]
                          ${
                            activeTab === tab.id
-                             ? "bg-blue-50 text-blue-700"
-                             : "text-gray-600 hover:text-gray-900 hover:bg-gray-50"
+                             ? "bg-[var(--dc-color-interactive-primary-subtle)] text-[var(--dc-color-interactive-primary-on-subtle)]"
+                             : "text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-primary)] hover:bg-[var(--dc-color-surface-secondary)]"
                          }`}
               aria-selected={activeTab === tab.id}
               role="tab"
@@ -50,7 +50,7 @@ export function SourcesPanel() {
         </div>
         <button
           onClick={closePanel}
-          className="p-1.5 text-gray-400 hover:text-gray-600 transition-colors
+          className="p-1.5 text-[var(--dc-color-text-placeholder)] hover:text-[var(--dc-color-text-muted)] transition-colors
                      min-h-[44px] min-w-[44px] flex items-center justify-center"
           aria-label="Close library panel"
         >

--- a/web/src/components/sources/sources-section.tsx
+++ b/web/src/components/sources/sources-section.tsx
@@ -49,7 +49,7 @@ export function SourcesSection({ onBrowseConnection, onAddSource }: SourcesSecti
       <div className="flex items-center gap-2 min-h-[32px] mb-1">
         <div className="flex-1 flex items-center gap-2">
           <div className="h-px bg-gray-200 flex-1" />
-          <span className="text-[10px] font-semibold tracking-wider text-gray-400 uppercase shrink-0">
+          <span className="text-[10px] font-semibold tracking-wider text-[var(--dc-color-text-placeholder)] uppercase shrink-0">
             Connections
           </span>
           <div className="h-px bg-gray-200 flex-1" />
@@ -59,7 +59,9 @@ export function SourcesSection({ onBrowseConnection, onAddSource }: SourcesSecti
       {/* Connection rows */}
       <div className="flex flex-col gap-1">
         {connections.length === 0 ? (
-          <p className="text-xs text-gray-400 py-2 px-1">No sources connected.</p>
+          <p className="text-xs text-[var(--dc-color-text-placeholder)] py-2 px-1">
+            No sources connected.
+          </p>
         ) : (
           connections.map((connection) => (
             <div key={connection.id}>
@@ -72,9 +74,11 @@ export function SourcesSection({ onBrowseConnection, onAddSource }: SourcesSecti
                   />
                 </svg>
                 <div className="flex-1 min-w-0">
-                  <span className="text-xs text-gray-700 truncate block">{connection.email}</span>
+                  <span className="text-xs text-[var(--dc-color-text-secondary)] truncate block">
+                    {connection.email}
+                  </span>
                   {connection.documentCount > 0 && (
-                    <span className="text-[10px] text-gray-400">
+                    <span className="text-[10px] text-[var(--dc-color-text-placeholder)]">
                       {connection.documentCount} document{connection.documentCount !== 1 ? "s" : ""}
                     </span>
                   )}
@@ -93,7 +97,7 @@ export function SourcesSection({ onBrowseConnection, onAddSource }: SourcesSecti
                 {confirmingId !== connection.id && (
                   <button
                     onClick={() => setConfirmingId(connection.id)}
-                    className="text-xs text-gray-400 hover:text-red-600 transition-colors
+                    className="text-xs text-[var(--dc-color-text-placeholder)] hover:text-red-600 transition-colors
                                  min-h-[44px] flex items-center shrink-0"
                   >
                     Remove
@@ -103,8 +107,8 @@ export function SourcesSection({ onBrowseConnection, onAddSource }: SourcesSecti
 
               {/* Inline confirmation */}
               {confirmingId === connection.id && (
-                <div className="px-1 py-2 bg-gray-50 rounded-lg mx-1 mb-1">
-                  <p className="text-xs text-gray-600 mb-2">
+                <div className="px-1 py-2 bg-[var(--dc-color-surface-secondary)] rounded-lg mx-1 mb-1">
+                  <p className="text-xs text-[var(--dc-color-text-muted)] mb-2">
                     Remove {connection.email} from this book? Documents from this source will be
                     archived.
                   </p>
@@ -120,7 +124,7 @@ export function SourcesSection({ onBrowseConnection, onAddSource }: SourcesSecti
                     <button
                       onClick={() => setConfirmingId(null)}
                       disabled={isUnlinking}
-                      className="text-xs text-gray-500 hover:text-gray-700
+                      className="text-xs text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)]
                                    min-h-[36px] px-2 disabled:opacity-50"
                     >
                       Cancel


### PR DESCRIPTION
## Summary

Closes #370.

Migrates raw Tailwind color utility classes to `--dc-color-*` semantic CSS custom properties across **42 files** (components, pages, and CSS stylesheets). This is the first step toward full theme-ability and dark mode support.

### What was migrated

| Hardcoded class | Semantic token |
|---|---|
| `text-gray-900` | `--dc-color-text-primary` |
| `text-gray-800` | `--dc-color-text-primary` |
| `text-gray-700` | `--dc-color-text-secondary` |
| `text-gray-600` | `--dc-color-text-muted` |
| `text-gray-500` | `--dc-color-text-muted` |
| `text-gray-400` | `--dc-color-text-placeholder` |
| `bg-white` | `--dc-color-surface-primary` |
| `bg-gray-50` | `--dc-color-surface-secondary` |
| `bg-gray-100` | `--dc-color-surface-tertiary` |
| `hover:bg-gray-50` | `--dc-color-surface-secondary` |
| `hover:bg-gray-100` | `--dc-color-surface-tertiary` |
| `border-gray-300` | `--dc-color-border-strong` |
| `text-blue-600` | `--dc-color-interactive-primary` |
| `bg-blue-50` | `--dc-color-interactive-primary-subtle` |
| CSS hex colors | Corresponding `var()` tokens |

### What was intentionally NOT migrated

- **`border-gray-200`** / **`border-gray-100`** / **`border-gray-50`**: No `--dc-color-border-default` token exists yet (deferred to #371)
- **`bg-gray-900`** / **`hover:bg-gray-800`**: Primary button background — no token exists
- **Clerk `appearance.elements` strings**: Third-party component API; CSS custom properties may not resolve reliably
- **`text-red-*`**, **`text-green-*`**, **`text-yellow-*`**: Semantic/status colors — no tokens defined yet

### Files changed: 42

**CSS (3):** `editor.css`, `sources.css`, `workspace.css`
**Pages (8):** dashboard, help, layout, landing, privacy, terms, sign-in, sign-up
**Editor components (5):** crash-recovery-dialog, editor-writing-area, floating-action-bar, onboarding-tooltips, text-editor
**Project components (9):** accounts-sheet, delete-chapter-dialog, delete-project-dialog, drive-folder-picker, duplicate-project-dialog, export-destination-picker, export-menu, project-switcher, rename-project-dialog, settings-menu
**Sources components (10):** desk-tab, document-peek-view, drive-browser, empty-state, library-tab, project-source-list, review-tab, source-item, source-picker, sources-panel, sources-panel-overlay, sources-section
**Other (2):** feedback-sheet, accordion-section, instruction-list, sidebar

## Test plan

- [ ] Visual regression: spot-check dashboard, editor, sources panel, export menu, landing page, terms, privacy, sign-in, sign-up
- [ ] Verify no color changes visible (tokens resolve to same values as hardcoded classes)
- [ ] Check iPad Safari rendering (primary target)
- [ ] Confirm lint, typecheck, and format checks pass in CI

---
Generated with [Claude Code](https://claude.com/claude-code)