### PR TITLE
feat: auto-context collection for feedback (#373)

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,5 +1,11 @@
 import type { NextConfig } from "next";
 import { withSerwist } from "@serwist/turbopack";
+import { createRequire } from "module";
+
+// Read version from package.json at build time for NEXT_PUBLIC_APP_VERSION.
+// createRequire is used because next.config.ts is processed as ESM by Next.js.
+const require = createRequire(import.meta.url);
+const pkg = require("./package.json") as { version: string };
 
 /**
  * Security headers applied to all routes.
@@ -52,6 +58,9 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+  },
   images: {
     remotePatterns: [
       {

--- a/web/src/app/(protected)/drive/success/page.tsx
+++ b/web/src/app/(protected)/drive/success/page.tsx
@@ -106,6 +106,12 @@ export default function DriveSuccessPage() {
         // sessionStorage unavailable — URL param fallback below handles this
       }
     }
+    // Record Drive connection status for feedback context (#373)
+    try {
+      sessionStorage.setItem("dc_drive_connected", "true");
+    } catch {
+      // Non-critical
+    }
     // Append URL param as iPad Safari fallback (sessionStorage can be lost on tab suspension)
     const destination = sourceLinkProjectId ? `${base}?sources=open` : base;
     router.push(destination);

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useEffect } from "react";
 import { ClerkProvider } from "@clerk/nextjs";
+import { initErrorStore } from "@/lib/error-store";
 
 interface ProvidersProps {
   children: React.ReactNode;
@@ -16,8 +18,18 @@ interface ProvidersProps {
  *   (Settings > Sessions > Session lifetime = 30 days, Inactivity timeout = 30 days).
  * - Sliding window renewal is handled automatically by Clerk's token refresh.
  * - afterSignInUrl/afterSignUpUrl direct authenticated users to the writing environment.
+ *
+ * Error capture (#373):
+ * - initErrorStore() installs global window.onerror and unhandledrejection
+ *   listeners. Captured errors feed into useFeedbackContext for auto-context.
  */
 export function Providers({ children }: ProvidersProps) {
+  // Install global error listeners once on mount.
+  // initErrorStore is idempotent so multiple calls are harmless.
+  useEffect(() => {
+    initErrorStore();
+  }, []);
+
   return (
     <ClerkProvider
       signInUrl="/sign-in"

--- a/web/src/hooks/use-feedback-context.ts
+++ b/web/src/hooks/use-feedback-context.ts
@@ -2,24 +2,98 @@
 
 import { usePathname, useParams } from "next/navigation";
 import { useCallback } from "react";
+import { getRecentErrors, type CapturedError } from "@/lib/error-store";
 
 /**
- * Auto-captured context sent alongside feedback submissions (#342).
+ * Auto-captured context sent alongside feedback submissions (#373).
  *
- * Five actionable fields. Collected at submission time (not on mount)
- * to capture the state at the moment the user reports an issue.
+ * 14 fields collected automatically at submission time (not on mount)
+ * so the snapshot reflects the user's state at the moment they report.
+ * None of these fields are user-editable.
  */
 export interface FeedbackContext {
+  /** Full user-agent string */
   userAgent: string;
-  currentRoute: string;
-  projectId: string | null;
-  chapterId: string | null;
+  /** Viewport width in CSS pixels */
+  viewportWidth: number;
+  /** Viewport height in CSS pixels */
+  viewportHeight: number;
+  /** Device pixel ratio (1 = standard, 2 = Retina, etc.) */
+  devicePixelRatio: number;
+  /** Whether a virtual keyboard is likely visible (viewport shrank significantly) */
+  keyboardVisible: boolean;
+  /** Whether the device supports touch input */
+  touchSupport: boolean;
+  /** Whether the browser reports being online */
   onlineStatus: boolean;
+  /** Current Next.js route pathname */
+  currentRoute: string;
+  /** Active project ID from route params, or null */
+  projectId: string | null;
+  /** Active chapter ID from route params, or null */
+  chapterId: string | null;
+  /** Drive connection status: "connected", "disconnected", or "unknown" */
+  driveConnectionStatus: "connected" | "disconnected" | "unknown";
+  /** App version from package.json, exposed via NEXT_PUBLIC_APP_VERSION */
+  appVersion: string;
+  /** Ring buffer of the last 5 client-side errors */
+  recentErrors: CapturedError[];
+  /** ISO 8601 timestamp of when the feedback was submitted */
+  submittedAt: string;
 }
 
 /**
- * Returns a function that collects feedback context on demand.
- * Call `collectContext()` at submission time.
+ * Detect whether a virtual keyboard is likely open.
+ *
+ * Uses the VirtualKeyboard API if available (Chromium), otherwise falls back
+ * to comparing the visual viewport height against the layout viewport.
+ * A >25% reduction in visual height is a strong signal on iPad/mobile.
+ */
+function detectKeyboardVisible(): boolean {
+  if (typeof window === "undefined") return false;
+
+  // VirtualKeyboard API (Chromium-based browsers)
+  if ("virtualKeyboard" in navigator) {
+    const vk = (navigator as { virtualKeyboard?: { boundingRect?: DOMRect } }).virtualKeyboard;
+    if (vk?.boundingRect && vk.boundingRect.height > 0) {
+      return true;
+    }
+  }
+
+  // Visual viewport heuristic: if visual viewport is significantly shorter
+  // than the layout viewport, a keyboard is likely open.
+  if (window.visualViewport) {
+    const ratio = window.visualViewport.height / window.innerHeight;
+    return ratio < 0.75;
+  }
+
+  return false;
+}
+
+/**
+ * Detect Drive connection status from local cues without making an API call.
+ *
+ * Checks sessionStorage for the OAuth success signal that the Drive callback
+ * page sets. This is a best-effort heuristic — accurate when the user has
+ * connected Drive during this browser session.
+ */
+function detectDriveStatus(): "connected" | "disconnected" | "unknown" {
+  if (typeof window === "undefined") return "unknown";
+  try {
+    // The drive success page sets this flag in sessionStorage
+    const flag = sessionStorage.getItem("dc_drive_connected");
+    if (flag === "true") return "connected";
+    if (flag === "false") return "disconnected";
+  } catch {
+    // sessionStorage unavailable (e.g., private mode restrictions)
+  }
+  return "unknown";
+}
+
+/**
+ * Returns a function that collects all 14 feedback context fields on demand.
+ * Call `collectContext()` at submission time — not on mount — so the snapshot
+ * reflects the user's state at the moment they report.
  */
 export function useFeedbackContext() {
   const pathname = usePathname();
@@ -28,10 +102,19 @@ export function useFeedbackContext() {
   const collectContext = useCallback((): FeedbackContext => {
     return {
       userAgent: navigator.userAgent,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      devicePixelRatio: window.devicePixelRatio ?? 1,
+      keyboardVisible: detectKeyboardVisible(),
+      touchSupport: "ontouchstart" in window || navigator.maxTouchPoints > 0,
+      onlineStatus: navigator.onLine,
       currentRoute: pathname,
       projectId: (params?.projectId as string) ?? null,
       chapterId: (params?.chapterId as string) ?? null,
-      onlineStatus: navigator.onLine,
+      driveConnectionStatus: detectDriveStatus(),
+      appVersion: process.env.NEXT_PUBLIC_APP_VERSION ?? "0.1.0",
+      recentErrors: getRecentErrors(),
+      submittedAt: new Date().toISOString(),
     };
   }, [pathname, params]);
 

--- a/web/src/lib/error-store.ts
+++ b/web/src/lib/error-store.ts
@@ -1,0 +1,97 @@
+/**
+ * Global error store — ring buffer of the last 5 client-side errors.
+ *
+ * Captures unhandled errors (window.onerror) and unhandled promise rejections
+ * (unhandledrejection). Used by useFeedbackContext to auto-attach recent
+ * errors to feedback submissions so users never have to describe stack traces.
+ *
+ * The store is a plain module singleton (no React state) to ensure errors
+ * are captured regardless of which component tree is mounted.
+ *
+ * @module error-store
+ * @see {@link ../hooks/use-feedback-context.ts}
+ */
+
+const MAX_ERRORS = 5;
+
+export interface CapturedError {
+  /** Error message */
+  message: string;
+  /** Source file (if available from onerror) */
+  source?: string;
+  /** Line number (if available from onerror) */
+  line?: number;
+  /** Column number (if available from onerror) */
+  column?: number;
+  /** ISO 8601 timestamp of when the error was captured */
+  timestamp: string;
+}
+
+/** Ring buffer of recent errors, newest last. */
+const errors: CapturedError[] = [];
+
+/** Whether listeners have been installed. */
+let initialized = false;
+
+/**
+ * Push an error into the ring buffer.
+ * Oldest entries are evicted when the buffer exceeds MAX_ERRORS.
+ */
+function pushError(entry: CapturedError): void {
+  errors.push(entry);
+  if (errors.length > MAX_ERRORS) {
+    errors.shift();
+  }
+}
+
+/**
+ * Return a snapshot (shallow copy) of the current error buffer.
+ * Safe to serialize — no circular references.
+ */
+export function getRecentErrors(): CapturedError[] {
+  return [...errors];
+}
+
+/**
+ * Install global error listeners (window.onerror + unhandledrejection).
+ * Safe to call multiple times — listeners are only installed once.
+ * Must be called in a browser environment (guards against SSR).
+ */
+export function initErrorStore(): void {
+  if (initialized) return;
+  if (typeof window === "undefined") return;
+
+  initialized = true;
+
+  window.addEventListener("error", (event: ErrorEvent) => {
+    pushError({
+      message: event.message || "Unknown error",
+      source: event.filename || undefined,
+      line: event.lineno || undefined,
+      column: event.colno || undefined,
+      timestamp: new Date().toISOString(),
+    });
+  });
+
+  window.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) => {
+    const reason = event.reason;
+    let message = "Unhandled promise rejection";
+
+    if (reason instanceof Error) {
+      message = reason.message;
+    } else if (typeof reason === "string") {
+      message = reason;
+    } else if (reason != null) {
+      try {
+        message = String(reason);
+      } catch {
+        // Keep the default message
+      }
+    }
+
+    pushError({
+      message,
+      timestamp: new Date().toISOString(),
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Expand `useFeedbackContext` hook from 5 to 14 auto-captured fields: userAgent, viewport width/height, devicePixelRatio, virtual keyboard visibility, touch support, online status, current route, projectId, chapterId, Drive connection status, app version, recent errors (last 5), and submission timestamp
- Add `web/src/lib/error-store.ts` — a global ring buffer (max 5 entries) that captures `window.onerror` and `unhandledrejection` events as a module singleton, initialized via `initErrorStore()` in the Providers component
- Expose `NEXT_PUBLIC_APP_VERSION` from `package.json` via `next.config.ts` env config
- Set `dc_drive_connected` sessionStorage flag on Drive OAuth success for lightweight Drive status detection without API calls

## Test plan
- [ ] Open the feedback sheet (Help > Report a Problem) and submit feedback — verify the API receives all 14 context fields in the `context` payload
- [ ] Trigger a JS error in the console (`throw new Error("test")`) and then submit feedback — verify the error appears in `recentErrors`
- [ ] Test on iPad Safari: confirm `touchSupport: true`, viewport dimensions match, and keyboard visibility detects the on-screen keyboard
- [ ] Test with and without Google Drive connected — verify `driveConnectionStatus` reflects the correct state
- [ ] Verify `appVersion` matches the version in `web/package.json`
- [ ] Confirm the app loads without errors (no regressions from error store initialization)

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)