### PR TITLE
feat: add skip link and focus management audit (#330)

### DIFF
--- a/web/src/app/styles/components.css
+++ b/web/src/app/styles/components.css
@@ -178,6 +178,56 @@
   animation: backdrop-fade-out 200ms ease-in forwards;
 }
 
+/* ------------------------------------------------------------------
+ * Skip Link (#330)
+ *
+ * Visually hidden link that appears on focus for keyboard users.
+ * Positioned fixed at top-center, slides down when focused.
+ * Uses --dc-color-interactive-primary for visual identity.
+ * ------------------------------------------------------------------ */
+
+.skip-link {
+  position: fixed;
+  top: -100%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10000;
+  padding: 12px 24px;
+  background: var(--dc-color-interactive-primary);
+  color: var(--dc-color-text-inverse);
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: var(--dc-radius-md);
+  box-shadow: var(--dc-shadow-lg);
+  text-decoration: none;
+  transition: top var(--dc-motion-fast) var(--dc-motion-ease-out);
+  white-space: nowrap;
+}
+
+.skip-link:focus {
+  top: 12px;
+  outline: 2px solid var(--dc-color-interactive-primary);
+  outline-offset: 2px;
+}
+
+/* ------------------------------------------------------------------
+ * Global Focus-Visible Styles (#330)
+ *
+ * Consistent focus ring using the --dc-color-interactive-primary
+ * design token. Applied to all focusable elements when focused
+ * via keyboard (focus-visible).
+ * ------------------------------------------------------------------ */
+
+:focus-visible {
+  outline: 2px solid var(--dc-color-interactive-primary);
+  outline-offset: 2px;
+}
+
+/* Remove default focus outline — only show on focus-visible */
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
 /* Respect prefers-reduced-motion */
 @media (prefers-reduced-motion: reduce) {
   .toast-fade-in {

--- a/web/src/components/editor/editor-writing-area.tsx
+++ b/web/src/components/editor/editor-writing-area.tsx
@@ -56,7 +56,12 @@ export function EditorWritingArea({
   onBlur,
 }: EditorWritingAreaProps) {
   return (
-    <div className="flex-1 overflow-auto">
+    <div
+      className="flex-1 overflow-auto"
+      id="writing-area"
+      tabIndex={-1}
+      style={{ outline: "none" }}
+    >
       <div className="max-w-[700px] mx-auto px-6 py-8">
         {/* Chapter title - editable at top of editor (US-011) */}
         {editingTitle ? (

--- a/web/src/components/editor/skip-link.tsx
+++ b/web/src/components/editor/skip-link.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * SkipLink - Visually hidden link that appears on focus for keyboard users.
+ *
+ * Provides a "Skip to writing area" link at the top of the editor page
+ * that jumps directly to the Tiptap editor, bypassing the sidebar,
+ * toolbar, and panel navigation.
+ *
+ * Per WCAG 2.4.1 (Bypass Blocks): A mechanism is available to bypass
+ * blocks of content that are repeated on multiple pages.
+ *
+ * The link is visually hidden until focused via keyboard (Tab key),
+ * at which point it appears as a prominent blue banner at the top
+ * of the viewport. Uses the --dc-color-interactive-primary design token
+ * for the focus ring and visual styling.
+ */
+export function SkipLink() {
+  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    e.preventDefault();
+    const target = document.getElementById("writing-area");
+    if (target) {
+      target.focus({ preventScroll: false });
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  };
+
+  return (
+    <a href="#writing-area" onClick={handleClick} className="skip-link">
+      Skip to writing area
+    </a>
+  );
+}

--- a/web/src/components/sources/sources-panel-overlay.tsx
+++ b/web/src/components/sources/sources-panel-overlay.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { useSourcesContext } from "@/contexts/sources-context";
 import { useDelayedUnmount } from "@/hooks/use-delayed-unmount";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
 import { LibraryTab } from "./library-tab";
 import { DeskTab } from "./desk-tab";
 import type { SourcesTab } from "@/hooks/use-sources-panel";
@@ -14,6 +15,7 @@ import type { SourcesTab } from "@/hooks/use-sources-panel";
 export function SourcesPanelOverlay() {
   const { activeTab, setActiveTab, isPanelOpen, closePanel, sources } = useSourcesContext();
   const { shouldRender, isClosing } = useDelayedUnmount(isPanelOpen, 200);
+  const panelRef = useFocusTrap({ isOpen: isPanelOpen, onEscape: closePanel });
 
   const deskCount = useMemo(() => sources.filter((s) => s.status === "active").length, [sources]);
 
@@ -38,6 +40,7 @@ export function SourcesPanelOverlay() {
 
       {/* Panel */}
       <div
+        ref={panelRef}
         className={`sources-panel-overlay fixed inset-y-0 right-0 z-50 w-full max-w-[380px]
                    bg-background shadow-xl flex flex-col lg:hidden ${isClosing ? "sources-panel-slide-out" : "sources-panel-slide-in"}`}
         role="dialog"

--- a/web/src/components/sources/sources-panel.tsx
+++ b/web/src/components/sources/sources-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { useSourcesContext } from "@/contexts/sources-context";
 import { LibraryTab } from "./library-tab";
 import { DeskTab } from "./desk-tab";
@@ -13,6 +13,24 @@ import type { SourcesTab } from "@/hooks/use-sources-panel";
  */
 export function SourcesPanel() {
   const { activeTab, setActiveTab, closePanel, isPanelOpen, sources } = useSourcesContext();
+  const triggerRef = useRef<Element | null>(null);
+  const prevIsOpenRef = useRef(false);
+
+  // Focus management: capture trigger on open, restore on close (#330)
+  useEffect(() => {
+    const wasOpen = prevIsOpenRef.current;
+    prevIsOpenRef.current = isPanelOpen;
+
+    if (isPanelOpen && !wasOpen) {
+      triggerRef.current = document.activeElement;
+    } else if (!isPanelOpen && wasOpen) {
+      const trigger = triggerRef.current;
+      triggerRef.current = null;
+      if (trigger instanceof HTMLElement) {
+        trigger.focus();
+      }
+    }
+  }, [isPanelOpen]);
 
   const deskCount = useMemo(() => sources.filter((s) => s.status === "active").length, [sources]);
 


### PR DESCRIPTION
## Summary

- Adds a "Skip to writing area" link at the top of the editor page (WCAG 2.4.1) that appears on keyboard Tab and focuses the Tiptap editor
- Adds focus trapping to `SourcesPanelOverlay` (portrait mode) via the existing `useFocusTrap` hook from #375
- Adds focus restoration to all panels (`EditorPanel`, `EditorPanelOverlay`, `SourcesPanel`, `SourcesPanelOverlay`) so focus returns to the trigger element when panels close
- Adds Escape key handling to `EditorPanelOverlay` for keyboard dismissal
- Adds `aria-live` region for screen reader announcements when panels open/close (editor panel, library panel, sidebar overlay)
- Adds global `focus-visible` styles using `--dc-color-interactive-primary` design token for consistent focus rings across the workspace

## Files Changed

| File | Change |
|------|--------|
| `web/src/components/editor/skip-link.tsx` | New skip link component |
| `web/src/app/styles/components.css` | Skip link CSS + global focus-visible styles |
| `web/src/components/editor/editor-writing-area.tsx` | Add `id="writing-area"` target + `tabIndex={-1}` |
| `web/src/app/(protected)/editor/[projectId]/page.tsx` | Wire SkipLink, aria-live announcements, panel announce callbacks |
| `web/src/components/editor/editor-panel.tsx` | Focus restore on close, Escape key, ref for overlay |
| `web/src/components/sources/sources-panel.tsx` | Focus restore on close |
| `web/src/components/sources/sources-panel-overlay.tsx` | Focus trap via `useFocusTrap`, Escape key |

## Test plan

- [ ] Tab on page load shows "Skip to writing area" link; pressing Enter focuses the writing area
- [ ] Opening/closing the editor panel (both desktop and portrait overlay) restores focus to the toggle button
- [ ] Opening/closing the library panel (both desktop and portrait overlay) restores focus to the toggle button
- [ ] In portrait mode, sources panel overlay traps focus (Tab cycles within panel)
- [ ] In portrait mode, sidebar overlay traps focus (Tab cycles within overlay)
- [ ] Escape key closes EditorPanelOverlay and SourcesPanelOverlay
- [ ] Screen reader announces "Editor panel opened/closed", "Library panel opened/closed", "Chapter navigation opened/closed"
- [ ] Focus rings use the blue design token (`--dc-color-interactive-primary`) consistently
- [ ] No regressions in toolbar keyboard shortcuts (Cmd+Shift+E, Cmd+Shift+L, Cmd+Shift+B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)