### PR TITLE
fix: remove auto-focus that prevents text selection when editor panel is open

### DIFF
--- a/web/src/components/editor/chapter-editor-panel.tsx
+++ b/web/src/components/editor/chapter-editor-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef } from "react";
 import type { AIRewriteResult, SheetState } from "@/hooks/use-ai-rewrite";
 import { StreamingResponse } from "./streaming-response";
 import { useSourcesContext } from "@/contexts/sources-context";
@@ -74,7 +74,6 @@ export function ChapterEditorPanel({
 
   const isStreaming = sheetState === "streaming";
   const isComplete = sheetState === "complete";
-  const isIdle = sheetState === "idle";
   const hasResult = result !== null;
   const hasSelectedText = selectedText.length > 0;
 
@@ -159,13 +158,6 @@ export function ChapterEditorPanel({
   const handleGoDeeper = useCallback(() => {
     if (result && onGoDeeper) onGoDeeper(result);
   }, [result, onGoDeeper]);
-
-  // Focus instruction field when panel becomes idle with selected text
-  useEffect(() => {
-    if (isIdle && hasSelectedText && instructionRef.current) {
-      instructionRef.current.focus();
-    }
-  }, [isIdle, hasSelectedText]);
 
   return (
     <div className="flex flex-col h-full">


### PR DESCRIPTION
## Summary
- Removed a `useEffect` in `ChapterEditorPanel` that auto-focused the instruction textarea whenever `hasSelectedText` became true
- This effect was stealing focus from the Tiptap editor mid-drag, making it impossible to select text while the Chapter Editor panel was open
- Cleaned up unused `isIdle` variable and `useEffect` import

## Test plan
- [ ] Open the Chapter Editor panel
- [ ] Click and drag to select text in the writing area — selection should work normally
- [ ] Verify the instruction textarea is still clickable/focusable manually
- [ ] Verify AI rewrite flow still works: select text, click instruction chip or type instruction, submit

🤖 Generated with [Claude Code](https://claude.com/claude-code)