### PR TITLE
chore: sync calendar-sync skills for block-based session history

### DIFF
--- a/.agents/skills/calendar-sync/SKILL.md
+++ b/.agents/skills/calendar-sync/SKILL.md
@@ -5,7 +5,7 @@ description: Calendar Sync
 
 # /calendar-sync - Calendar Sync
 
-Transform planned calendar events into actuals using real session data from D1. Replaces future-looking planned events with past-looking actual work blocks.
+Create actual session events on Google Calendar from D1 session history. Planned events are never modified or deleted — they represent the work plan and coexist with actuals.
 
 ## Usage
 
@@ -17,7 +17,7 @@ Transform planned calendar events into actuals using real session data from D1. 
 
 ### Step 1: Fetch Session History
 
-Call `crane_schedule(action: "session-history", days: 7)` to get ended sessions aggregated by venture and date.
+Call `crane_schedule(action: "session-history", days: 7)` to get ended sessions aggregated by venture and date, with sessions merged into contiguous blocks (gaps > 30 min create separate blocks).
 
 This returns entries like:
 
@@ -25,43 +25,48 @@ This returns entries like:
 {
   "venture": "vc",
   "work_date": "2026-03-21",
-  "earliest_start": "2026-03-21T13:30:00Z",
-  "latest_end": "2026-03-21T21:00:00Z",
-  "session_count": 2
+  "blocks": [
+    {
+      "start": "2026-03-21T13:30:00Z",
+      "end": "2026-03-21T16:00:00Z",
+      "session_count": 2,
+      "hosts": ["m16.local"],
+      "repos": ["crane-console"],
+      "branches": ["main"],
+      "issues": []
+    },
+    {
+      "start": "2026-03-21T19:00:00Z",
+      "end": "2026-03-21T21:00:00Z",
+      "session_count": 1,
+      "hosts": ["m16.local"],
+      "repos": ["crane-console"],
+      "branches": ["main"],
+      "issues": [347]
+    }
+  ],
+  "total_sessions": 3
 }
 ```
 
 Only `status = 'ended'` sessions are included. Abandoned sessions are excluded (heartbeat data is unreliable).
 
-### Step 2: Sync Each Work Day
+### Step 2: Create/Update Actual Events
 
-For each venture/day entry from session history:
+For each venture/day entry from session history, each **block** becomes a separate calendar event:
 
-1. Query planned events: `crane_schedule(action: "planned-events", from: "{work_date}", to: "{work_date}", type: "planned")`
+1. Query existing actual events: `crane_schedule(action: "planned-events", from: "{work_date}", to: "{work_date}", type: "actual")`
 
-2. **If a planned event exists and venture matches**:
-   - Update the Google Calendar event times to actual start/end
-   - Update the D1 record: `crane_schedule(action: "planned-event-update", id: "{id}", type: "actual", start_time: "{actual_start}", end_time: "{actual_end}", sync_status: "synced")`
+2. **Reconcile blocks against existing actual events:**
+   - Match blocks to existing events by time proximity (closest start time)
+   - **Matched event, times differ**: Update the Google Calendar event times and the D1 record: `crane_schedule(action: "planned-event-update", id: "{id}", start_time: "{block.start}", end_time: "{block.end}", sync_status: "synced")`
+   - **Matched event, times match**: Skip (already synced)
+   - **Unmatched block (no existing event)**: Create a new Google Calendar event with the block's venture and times, then create a D1 record: `crane_schedule(action: "planned-event-create", ...)` with type='actual'
+   - **Orphaned actual event (no matching block)**: Delete the Google Calendar event and update the D1 record to type='cancelled'
 
-3. **If a planned event exists but a different venture was worked**:
-   - Delete the planned Google Calendar event
-   - Create a new Google Calendar event with the actual venture and times
-   - Update the D1 record with the new gcal_event_id, type='actual', actual times
+**IMPORTANT: Never modify, replace, or delete planned events.** Planned events are the work schedule set by `/work-plan`. They stay on the calendar regardless of what actually happened. The calendar shows both planned blocks and actual session blocks side by side.
 
-4. **If no planned event exists (unplanned work)**:
-   - Create a new Google Calendar event with actual venture and times
-   - Create a D1 record: `crane_schedule(action: "planned-event-create", ...)` with type='actual'
-
-### Step 3: Clean Up Unworked Planned Events
-
-Query planned events for dates in the past (before today) that have no matching session:
-
-1. Get planned events: `crane_schedule(action: "planned-events", from: "{week_ago}", to: "{yesterday}", type: "planned")`
-2. For each with a `gcal_event_id`:
-   - Delete the Google Calendar event (try/catch, log failures)
-3. Update D1 records: set `type = 'cancelled'`
-
-### Step 4: Display Summary
+### Step 3: Display Summary
 
 Show a table of synced sessions:
 
@@ -70,20 +75,21 @@ Show a table of synced sessions:
 
 | Date | Venture | Start | End | Sessions | Action |
 |------|---------|-------|-----|----------|--------|
-| 2026-03-21 | VC | 6:30am | 2:00pm | 2 | updated |
-| 2026-03-20 | VC | 7:00am | 5:00pm | 3 | created |
-| 2026-03-19 | - | - | - | 0 | cancelled |
+| 2026-03-21 | VC | 6:30am | 9:00am | 2 | updated |
+| 2026-03-21 | VC | 12:00pm | 2:00pm | 1 | created |
+| 2026-03-20 | VC | 7:00am | 5:00pm | 3 | already synced |
 
-Synced: 2 days, Cancelled: 1 planned event
+Synced: 2 blocks, Already synced: 1 block
 ```
 
 ## Calendar Result
 
 After sync, Google Calendar should show:
 
-- **Past days**: Actual work blocks per venture (real session times)
-- **Future days**: Planned blocks (from /work-plan)
-- **No overlap**: Each day has at most one event per venture
+- **Past days**: Both planned blocks (from /work-plan) AND actual session blocks (from D1)
+- **Future days**: Planned blocks only (from /work-plan)
+- Planned and actual events coexist — they are not mutually exclusive
+- Multiple actual events per venture per day are expected when work sessions have gaps > 30 minutes
 
 ## Timezone
 

--- a/.claude/commands/calendar-sync.md
+++ b/.claude/commands/calendar-sync.md
@@ -1,6 +1,6 @@
 # /calendar-sync - Calendar Sync
 
-Transform planned calendar events into actuals using real session data from D1. Replaces future-looking planned events with past-looking actual work blocks.
+Create actual session events on Google Calendar from D1 session history. Planned events are never modified or deleted — they represent the work plan and coexist with actuals.
 
 ## Usage
 
@@ -12,7 +12,7 @@ Transform planned calendar events into actuals using real session data from D1. 
 
 ### Step 1: Fetch Session History
 
-Call `crane_schedule(action: "session-history", days: 7)` to get ended sessions aggregated by venture and date.
+Call `crane_schedule(action: "session-history", days: 7)` to get ended sessions aggregated by venture and date, with sessions merged into contiguous blocks (gaps > 30 min create separate blocks).
 
 This returns entries like:
 
@@ -20,43 +20,48 @@ This returns entries like:
 {
   "venture": "vc",
   "work_date": "2026-03-21",
-  "earliest_start": "2026-03-21T13:30:00Z",
-  "latest_end": "2026-03-21T21:00:00Z",
-  "session_count": 2
+  "blocks": [
+    {
+      "start": "2026-03-21T13:30:00Z",
+      "end": "2026-03-21T16:00:00Z",
+      "session_count": 2,
+      "hosts": ["m16.local"],
+      "repos": ["crane-console"],
+      "branches": ["main"],
+      "issues": []
+    },
+    {
+      "start": "2026-03-21T19:00:00Z",
+      "end": "2026-03-21T21:00:00Z",
+      "session_count": 1,
+      "hosts": ["m16.local"],
+      "repos": ["crane-console"],
+      "branches": ["main"],
+      "issues": [347]
+    }
+  ],
+  "total_sessions": 3
 }
 ```
 
 Only `status = 'ended'` sessions are included. Abandoned sessions are excluded (heartbeat data is unreliable).
 
-### Step 2: Sync Each Work Day
+### Step 2: Create/Update Actual Events
 
-For each venture/day entry from session history:
+For each venture/day entry from session history, each **block** becomes a separate calendar event:
 
-1. Query planned events: `crane_schedule(action: "planned-events", from: "{work_date}", to: "{work_date}", type: "planned")`
+1. Query existing actual events: `crane_schedule(action: "planned-events", from: "{work_date}", to: "{work_date}", type: "actual")`
 
-2. **If a planned event exists and venture matches**:
-   - Update the Google Calendar event times to actual start/end
-   - Update the D1 record: `crane_schedule(action: "planned-event-update", id: "{id}", type: "actual", start_time: "{actual_start}", end_time: "{actual_end}", sync_status: "synced")`
+2. **Reconcile blocks against existing actual events:**
+   - Match blocks to existing events by time proximity (closest start time)
+   - **Matched event, times differ**: Update the Google Calendar event times and the D1 record: `crane_schedule(action: "planned-event-update", id: "{id}", start_time: "{block.start}", end_time: "{block.end}", sync_status: "synced")`
+   - **Matched event, times match**: Skip (already synced)
+   - **Unmatched block (no existing event)**: Create a new Google Calendar event with the block's venture and times, then create a D1 record: `crane_schedule(action: "planned-event-create", ...)` with type='actual'
+   - **Orphaned actual event (no matching block)**: Delete the Google Calendar event and update the D1 record to type='cancelled'
 
-3. **If a planned event exists but a different venture was worked**:
-   - Delete the planned Google Calendar event
-   - Create a new Google Calendar event with the actual venture and times
-   - Update the D1 record with the new gcal_event_id, type='actual', actual times
+**IMPORTANT: Never modify, replace, or delete planned events.** Planned events are the work schedule set by `/work-plan`. They stay on the calendar regardless of what actually happened. The calendar shows both planned blocks and actual session blocks side by side.
 
-4. **If no planned event exists (unplanned work)**:
-   - Create a new Google Calendar event with actual venture and times
-   - Create a D1 record: `crane_schedule(action: "planned-event-create", ...)` with type='actual'
-
-### Step 3: Clean Up Unworked Planned Events
-
-Query planned events for dates in the past (before today) that have no matching session:
-
-1. Get planned events: `crane_schedule(action: "planned-events", from: "{week_ago}", to: "{yesterday}", type: "planned")`
-2. For each with a `gcal_event_id`:
-   - Delete the Google Calendar event (try/catch, log failures)
-3. Update D1 records: set `type = 'cancelled'`
-
-### Step 4: Display Summary
+### Step 3: Display Summary
 
 Show a table of synced sessions:
 
@@ -65,20 +70,21 @@ Show a table of synced sessions:
 
 | Date | Venture | Start | End | Sessions | Action |
 |------|---------|-------|-----|----------|--------|
-| 2026-03-21 | VC | 6:30am | 2:00pm | 2 | updated |
-| 2026-03-20 | VC | 7:00am | 5:00pm | 3 | created |
-| 2026-03-19 | - | - | - | 0 | cancelled |
+| 2026-03-21 | VC | 6:30am | 9:00am | 2 | updated |
+| 2026-03-21 | VC | 12:00pm | 2:00pm | 1 | created |
+| 2026-03-20 | VC | 7:00am | 5:00pm | 3 | already synced |
 
-Synced: 2 days, Cancelled: 1 planned event
+Synced: 2 blocks, Already synced: 1 block
 ```
 
 ## Calendar Result
 
 After sync, Google Calendar should show:
 
-- **Past days**: Actual work blocks per venture (real session times)
-- **Future days**: Planned blocks (from /work-plan)
-- **No overlap**: Each day has at most one event per venture
+- **Past days**: Both planned blocks (from /work-plan) AND actual session blocks (from D1)
+- **Future days**: Planned blocks only (from /work-plan)
+- Planned and actual events coexist — they are not mutually exclusive
+- Multiple actual events per venture per day are expected when work sessions have gaps > 30 minutes
 
 ## Timezone
 

--- a/.gemini/commands/calendar-sync.toml
+++ b/.gemini/commands/calendar-sync.toml
@@ -2,7 +2,7 @@ description = "Calendar Sync"
 
 prompt = """
 
-Transform planned calendar events into actuals using real session data from D1. Replaces future-looking planned events with past-looking actual work blocks.
+Create actual session events on Google Calendar from D1 session history. Planned events are never modified or deleted — they represent the work plan and coexist with actuals.
 
 ## Usage
 
@@ -14,7 +14,7 @@ Transform planned calendar events into actuals using real session data from D1. 
 
 ### Step 1: Fetch Session History
 
-Call `crane_schedule(action: "session-history", days: 7)` to get ended sessions aggregated by venture and date.
+Call `crane_schedule(action: "session-history", days: 7)` to get ended sessions aggregated by venture and date, with sessions merged into contiguous blocks (gaps > 30 min create separate blocks).
 
 This returns entries like:
 
@@ -22,43 +22,48 @@ This returns entries like:
 {
   "venture": "vc",
   "work_date": "2026-03-21",
-  "earliest_start": "2026-03-21T13:30:00Z",
-  "latest_end": "2026-03-21T21:00:00Z",
-  "session_count": 2
+  "blocks": [
+    {
+      "start": "2026-03-21T13:30:00Z",
+      "end": "2026-03-21T16:00:00Z",
+      "session_count": 2,
+      "hosts": ["m16.local"],
+      "repos": ["crane-console"],
+      "branches": ["main"],
+      "issues": []
+    },
+    {
+      "start": "2026-03-21T19:00:00Z",
+      "end": "2026-03-21T21:00:00Z",
+      "session_count": 1,
+      "hosts": ["m16.local"],
+      "repos": ["crane-console"],
+      "branches": ["main"],
+      "issues": [347]
+    }
+  ],
+  "total_sessions": 3
 }
 ```
 
 Only `status = 'ended'` sessions are included. Abandoned sessions are excluded (heartbeat data is unreliable).
 
-### Step 2: Sync Each Work Day
+### Step 2: Create/Update Actual Events
 
-For each venture/day entry from session history:
+For each venture/day entry from session history, each **block** becomes a separate calendar event:
 
-1. Query planned events: `crane_schedule(action: "planned-events", from: "{work_date}", to: "{work_date}", type: "planned")`
+1. Query existing actual events: `crane_schedule(action: "planned-events", from: "{work_date}", to: "{work_date}", type: "actual")`
 
-2. **If a planned event exists and venture matches**:
-   - Update the Google Calendar event times to actual start/end
-   - Update the D1 record: `crane_schedule(action: "planned-event-update", id: "{id}", type: "actual", start_time: "{actual_start}", end_time: "{actual_end}", sync_status: "synced")`
+2. **Reconcile blocks against existing actual events:**
+   - Match blocks to existing events by time proximity (closest start time)
+   - **Matched event, times differ**: Update the Google Calendar event times and the D1 record: `crane_schedule(action: "planned-event-update", id: "{id}", start_time: "{block.start}", end_time: "{block.end}", sync_status: "synced")`
+   - **Matched event, times match**: Skip (already synced)
+   - **Unmatched block (no existing event)**: Create a new Google Calendar event with the block's venture and times, then create a D1 record: `crane_schedule(action: "planned-event-create", ...)` with type='actual'
+   - **Orphaned actual event (no matching block)**: Delete the Google Calendar event and update the D1 record to type='cancelled'
 
-3. **If a planned event exists but a different venture was worked**:
-   - Delete the planned Google Calendar event
-   - Create a new Google Calendar event with the actual venture and times
-   - Update the D1 record with the new gcal_event_id, type='actual', actual times
+**IMPORTANT: Never modify, replace, or delete planned events.** Planned events are the work schedule set by `/work-plan`. They stay on the calendar regardless of what actually happened. The calendar shows both planned blocks and actual session blocks side by side.
 
-4. **If no planned event exists (unplanned work)**:
-   - Create a new Google Calendar event with actual venture and times
-   - Create a D1 record: `crane_schedule(action: "planned-event-create", ...)` with type='actual'
-
-### Step 3: Clean Up Unworked Planned Events
-
-Query planned events for dates in the past (before today) that have no matching session:
-
-1. Get planned events: `crane_schedule(action: "planned-events", from: "{week_ago}", to: "{yesterday}", type: "planned")`
-2. For each with a `gcal_event_id`:
-   - Delete the Google Calendar event (try/catch, log failures)
-3. Update D1 records: set `type = 'cancelled'`
-
-### Step 4: Display Summary
+### Step 3: Display Summary
 
 Show a table of synced sessions:
 
@@ -67,20 +72,21 @@ Show a table of synced sessions:
 
 | Date | Venture | Start | End | Sessions | Action |
 |------|---------|-------|-----|----------|--------|
-| 2026-03-21 | VC | 6:30am | 2:00pm | 2 | updated |
-| 2026-03-20 | VC | 7:00am | 5:00pm | 3 | created |
-| 2026-03-19 | - | - | - | 0 | cancelled |
+| 2026-03-21 | VC | 6:30am | 9:00am | 2 | updated |
+| 2026-03-21 | VC | 12:00pm | 2:00pm | 1 | created |
+| 2026-03-20 | VC | 7:00am | 5:00pm | 3 | already synced |
 
-Synced: 2 days, Cancelled: 1 planned event
+Synced: 2 blocks, Already synced: 1 block
 ```
 
 ## Calendar Result
 
 After sync, Google Calendar should show:
 
-- **Past days**: Actual work blocks per venture (real session times)
-- **Future days**: Planned blocks (from /work-plan)
-- **No overlap**: Each day has at most one event per venture
+- **Past days**: Both planned blocks (from /work-plan) AND actual session blocks (from D1)
+- **Future days**: Planned blocks only (from /work-plan)
+- Planned and actual events coexist — they are not mutually exclusive
+- Multiple actual events per venture per day are expected when work sessions have gaps > 30 minutes
 
 ## Timezone
 


### PR DESCRIPTION
## Summary

- Updates all 3 calendar-sync skill definitions (`.claude/commands/`, `.gemini/commands/`, `.agents/skills/`) to use the new `blocks[]` response shape from venturecrane/crane-console#347
- Each block becomes a separate calendar event instead of one event per venture per day
- Adds block reconciliation strategy: match by time proximity, create/update/delete actuals
- Removes destructive Step 3 from Gemini variant that was deleting planned events and cancelling D1 records

## Test plan

- [x] Full pre-push verification (typecheck + format + lint + 730 tests) passes
- [ ] Run `/calendar-sync` after crane-context worker is deployed and verify separate events per block

Depends on: venturecrane/crane-console#347

🤖 Generated with [Claude Code](https://claude.com/claude-code)