### PR TITLE
fix: skip husky prepare script on Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "oauth:check": "bash scripts/oauth-readiness.sh",
     "pdf:check": "bash scripts/browser-rendering-readiness.sh",
     "verify": "npm run typecheck && npm run format:check && npm run lint && npm run test",
-    "prepare": "node -e \"if(process.env.CI)process.exit(0)\" && husky"
+    "prepare": "node -e \"if(process.env.CI||process.env.VERCEL)process.exit(0)\" && husky"
   },
   "devDependencies": {
     "docx": "^9.5.3",


### PR DESCRIPTION
## Summary
- Add `process.env.VERCEL` check to the `prepare` script so husky is skipped on Vercel
- Vercel does not set `CI=true`, causing `npm install` to fail with exit code 127 when husky is not found
- This has been blocking all production deployments since c7a7a96 (#455)
- Reverts Vercel CLI auto-injected CLAUDE.md boilerplate

## Test plan
- [x] `npm run verify` passes (531 tests, lint, typecheck, format)
- [ ] Vercel preview build succeeds (this is the actual test)
- [ ] Production deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)