### PR TITLE
fix: correct husky prepare script shell logic for Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "oauth:check": "bash scripts/oauth-readiness.sh",
     "pdf:check": "bash scripts/browser-rendering-readiness.sh",
     "verify": "npm run typecheck && npm run format:check && npm run lint && npm run test",
-    "prepare": "node -e \"if(process.env.CI||process.env.VERCEL)process.exit(0)\" && husky"
+    "prepare": "node -e \"process.exit(process.env.CI||process.env.VERCEL?0:1)\" || husky"
   },
   "devDependencies": {
     "docx": "^9.5.3",


### PR DESCRIPTION
## Summary
- The `prepare` script used `process.exit(0) && husky` — exit code 0 means success in shell, so `&&` **always** ran husky regardless of the env check
- Changed to `process.exit(0/1) || husky` — now husky only runs when the node check fails (local dev), and is correctly skipped in CI/Vercel
- This is the actual root cause of all Vercel production deployment failures since c7a7a96

## Root cause
Vercel runs `npm install` at the repo root. The `prepare` lifecycle script fires, and since husky isn't available in Vercel's build environment, `npm install` exits with code 127. The `process.exit(0)` check was supposed to short-circuit but `&&` continues on exit code 0.

## Test plan
- [x] `npm run verify` passes (531 tests)
- [ ] Vercel production deployment succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)