### PR TITLE
fix: auto-open editor panel when switching to Book view

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -156,6 +156,19 @@ function EditorPageInner() {
     })
   }, [announcePanel])
 
+  // Wrap setViewMode to auto-open editor panel when switching to Book mode
+  const handleViewModeChange = useCallback(
+    (mode: 'chapter' | 'book') => {
+      setViewMode(mode)
+      if (mode === 'book') {
+        setEditorPanelOpen(true)
+        setSidebarCollapsed(true)
+        announcePanel('Book editor opened')
+      }
+    },
+    [setViewMode, announcePanel]
+  )
+
   // --- Chapter management ---
   const {
     chapterToDelete,
@@ -370,7 +383,7 @@ function EditorPageInner() {
               saveStatus={saveStatus}
               onSaveRetry={saveNow}
               viewMode={viewMode}
-              onViewModeChange={setViewMode}
+              onViewModeChange={handleViewModeChange}
               isEditorPanelOpen={editorPanelOpen}
               onToggleEditorPanel={handleToggleEditorPanel}
               projectId={projectId}


### PR DESCRIPTION
## Summary
- Clicking the "Book" toggle updated `viewMode` but never opened the `EditorPanel`, making the entire `BookEditorPanel` invisible to users
- Wrap `setViewMode` in `handleViewModeChange` that also opens the panel and collapses the chapter sidebar
- This is the root cause of the panel redesign (#455) appearing to have no visible effect

## Root cause
`EditorPanel` is controlled by `editorPanelOpen` state (defaults to `false`). The Book toggle only called `setViewMode` — it never set `editorPanelOpen` to `true`. The BookEditorPanel was rendering correctly inside a closed panel.

## Test plan
- [x] `npm run verify` passes (531 tests)
- [ ] Click "Book" toggle → editor panel opens showing BookEditorPanel with instruction list
- [ ] Click "Chapter" toggle → stays on editor panel with ChapterEditorPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)