### PR TITLE
fix: replace hardcoded Tailwind colors with design tokens

### DIFF
--- a/web/src/components/editor/crash-recovery-dialog.tsx
+++ b/web/src/components/editor/crash-recovery-dialog.tsx
@@ -48,8 +48,8 @@ export function CrashRecoveryDialog({ recovery, onAccept, onDismiss }: CrashReco
           </button>
           <button
             onClick={onAccept}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg
-                       hover:bg-blue-700 transition-colors min-h-[44px]"
+            className="px-4 py-2 text-sm font-medium text-white bg-[var(--dc-color-interactive-primary)] rounded-lg
+                       hover:bg-[var(--dc-color-interactive-primary-hover)] transition-colors min-h-[44px]"
             autoFocus
           >
             Restore Changes

--- a/web/src/components/editor/editor-writing-area.tsx
+++ b/web/src/components/editor/editor-writing-area.tsx
@@ -75,14 +75,14 @@ export function EditorWritingArea({
               if (e.key === 'Escape') onTitleEditCancel()
             }}
             className="text-3xl font-semibold text-foreground mb-6 outline-none w-full
-                       border-b-2 border-blue-500 bg-transparent"
+                       border-b-2 border-[var(--dc-color-interactive-primary)] bg-transparent"
             autoFocus
             maxLength={200}
           />
         ) : (
           <h1
             className="text-3xl font-semibold text-foreground mb-6 outline-none cursor-text
-                       hover:bg-[var(--dc-color-surface-secondary)] focus:bg-[var(--dc-color-surface-secondary)] focus:ring-2 focus:ring-blue-500
+                       hover:bg-[var(--dc-color-surface-secondary)] focus:bg-[var(--dc-color-surface-secondary)] focus:ring-2 focus:ring-[var(--dc-color-border-focus)]
                        rounded px-1 -mx-1 transition-colors"
             onClick={onTitleEdit}
             onKeyDown={(e) => {

--- a/web/src/components/editor/floating-action-bar.tsx
+++ b/web/src/components/editor/floating-action-bar.tsx
@@ -41,7 +41,7 @@ export function FloatingActionBar({ selection, onRewrite }: FloatingActionBarPro
     <div
       role="toolbar"
       aria-label="AI text actions"
-      className="absolute z-50 flex items-center gap-2 bg-[var(--dc-color-surface-primary)] border border-gray-200
+      className="absolute z-50 flex items-center gap-2 bg-[var(--dc-color-surface-primary)] border border-[var(--dc-color-border-default)]
                  rounded-xl shadow-lg px-2 py-1 select-none
                  transform -translate-x-1/2"
       style={{
@@ -53,15 +53,18 @@ export function FloatingActionBar({ selection, onRewrite }: FloatingActionBarPro
       onTouchStart={(e) => e.stopPropagation()}
     >
       {selection.exceedsLimit ? (
-        <span className="text-sm text-amber-700 px-3 py-2 whitespace-nowrap" role="alert">
+        <span
+          className="text-sm text-[var(--dc-color-status-warning)] px-3 py-2 whitespace-nowrap"
+          role="alert"
+        >
           Select up to 2,000 words
         </span>
       ) : (
         <button
           onClick={handleRewriteClick}
           className="flex items-center gap-2 px-4 py-2 min-w-[48px] min-h-[48px]
-                     text-sm font-medium text-white bg-blue-600 rounded-lg
-                     hover:bg-blue-700 active:bg-blue-800
+                     text-sm font-medium text-white bg-[var(--dc-color-interactive-primary)] rounded-lg
+                     hover:bg-[var(--dc-color-interactive-primary-hover)] active:bg-[var(--dc-color-interactive-primary-active)]
                      transition-colors whitespace-nowrap
                      touch-manipulation"
           aria-label="AI Rewrite selected text"

--- a/web/src/components/editor/onboarding-tooltips.tsx
+++ b/web/src/components/editor/onboarding-tooltips.tsx
@@ -185,7 +185,9 @@ export function OnboardingTooltips() {
               <div
                 key={i}
                 className={`h-1.5 rounded-full transition-all duration-200 ${
-                  i === currentStep ? 'w-6 bg-blue-600' : 'w-1.5 bg-[var(--dc-color-border-strong)]'
+                  i === currentStep
+                    ? 'w-6 bg-[var(--dc-color-onboarding-dot-active)]'
+                    : 'w-1.5 bg-[var(--dc-color-border-strong)]'
                 }`}
                 aria-hidden="true"
               />
@@ -208,7 +210,7 @@ export function OnboardingTooltips() {
 
             <button
               onClick={handleNext}
-              className="min-h-[44px] min-w-[80px] rounded-lg bg-gray-900 px-4 text-sm font-medium text-white transition-colors hover:bg-gray-800 active:bg-gray-950"
+              className="min-h-[44px] min-w-[80px] rounded-lg bg-[var(--dc-color-text-primary)] px-4 text-sm font-medium text-white transition-colors hover:bg-[var(--dc-color-text-secondary)] active:bg-[var(--dc-color-text-primary)]"
             >
               {isLastStep ? 'Done' : 'Next'}
             </button>

--- a/web/src/components/editor/save-indicator.tsx
+++ b/web/src/components/editor/save-indicator.tsx
@@ -44,7 +44,7 @@ function getStatusDisplay(status: SaveStatus): { text: string; className: string
       return { text: '', className: 'text-muted-foreground' }
 
     case 'saving':
-      return { text: 'Saving\u2026', className: 'text-blue-600' }
+      return { text: 'Saving\u2026', className: 'text-[var(--dc-color-interactive-primary)]' }
 
     case 'saved': {
       const timeStr = formatTime(status.at)

--- a/web/src/components/editor/workspace-toggle.tsx
+++ b/web/src/components/editor/workspace-toggle.tsx
@@ -109,7 +109,7 @@ function ToggleOption({ label, value, isSelected, onSelect }: ToggleOptionProps)
       onClick={onSelect}
       className={`relative z-10 flex items-center justify-center px-3 h-10 min-w-[72px]
                  text-sm font-medium rounded-md transition-colors duration-200
-                 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1
+                 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--dc-color-border-focus)] focus-visible:ring-offset-1
                  ${isSelected ? 'text-foreground' : 'text-[var(--dc-color-text-secondary)] hover:text-foreground'}`}
       aria-label={`${label} view${isSelected ? ' (selected)' : ''}`}
       data-view={value}

--- a/web/src/components/sources/desk-tab.tsx
+++ b/web/src/components/sources/desk-tab.tsx
@@ -243,7 +243,7 @@ export function DeskTab() {
             role="checkbox"
             aria-checked={allSelected ? 'true' : someSelected ? 'mixed' : 'false'}
             className="flex items-center gap-2 text-xs text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)]
-                       transition-colors min-h-[32px]"
+                       transition-colors min-h-[var(--dc-touch-target-min)]"
           >
             <span
               className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 transition-colors ${


### PR DESCRIPTION
## Summary
- Replace hardcoded `blue-*/gray-*` Tailwind classes with `--dc-color-*` CSS custom property tokens across 7 components (workspace-toggle, floating-action-bar, editor-writing-area, crash-recovery-dialog, save-indicator, onboarding-tooltips, desk-tab)
- Fix WCAG 2.5.8 touch-target violation in desk-tab.tsx (32px → 44px via `--dc-touch-target-min`)
- All tokens reference existing definitions in `globals.css` — no new tokens added

## Test plan
- [x] `npm run verify` passes (typecheck, format, lint, tests)
- [ ] Visual regression check: components render identically (token values match previous hardcoded values)
- [ ] Touch targets on desk-tab meet 44px minimum on iPad Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)