### PR TITLE
feat: implement Book Outline Mode in center area

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -10,6 +10,8 @@ import { CrashRecoveryDialog } from '@/components/editor/crash-recovery-dialog'
 import { EditorSidebar } from '@/components/editor/editor-sidebar'
 import { EditorToolbar } from '@/components/editor/editor-toolbar'
 import { EditorWritingArea } from '@/components/editor/editor-writing-area'
+import { BookOutline } from '@/components/book/book-outline'
+import type { ChapterCardData } from '@/components/book/chapter-card'
 import { EditorDialogs } from '@/components/editor/editor-dialogs'
 import { EditorPanel, EditorPanelOverlay } from '@/components/editor/editor-panel'
 import { ChapterEditorPanel } from '@/components/editor/chapter-editor-panel'
@@ -79,7 +81,7 @@ function EditorPageInner() {
     content: currentContent,
     setContent,
   } = useAutoSave({
-    chapterId: activeChapterId,
+    chapterId: viewMode === 'book' ? null : activeChapterId,
     version: activeChapter?.version ?? 1,
     getToken: getToken as () => Promise<string | null>,
     apiUrl: API_URL,
@@ -275,6 +277,15 @@ function EditorPageInner() {
       sortOrder: ch.sortOrder,
     })) ?? []
 
+  const outlineChapters: ChapterCardData[] =
+    projectData?.chapters.map((ch) => ({
+      id: ch.id,
+      title: ch.title,
+      wordCount: ch.wordCount,
+      sortOrder: ch.sortOrder,
+      status: ch.status,
+    })) ?? []
+
   // --- Loading / Error states ---
   if (isLoading) {
     return (
@@ -399,23 +410,32 @@ function EditorPageInner() {
             />
           )}
 
-          <EditorWritingArea
-            editorRef={editorRef}
-            currentContent={currentContent}
-            onContentChange={handleContentChange}
-            onSelectionWordCountChange={handleSelectionWordCountChange}
-            onSelectionUpdate={handleEditorSelectionUpdate}
-            onBlur={handleEditorBlur}
-            activeChapter={activeChapter}
-            editingTitle={editingTitle}
-            titleValue={titleValue}
-            onTitleValueChange={setTitleValue}
-            onTitleEdit={handleTitleEdit}
-            onTitleSave={handleTitleSave}
-            onTitleEditCancel={() => setEditingTitle(false)}
-            currentWordCount={currentWordCount}
-            selectionWordCount={selectionWordCount}
-          />
+          {viewMode === 'book' ? (
+            <BookOutline
+              chapters={outlineChapters}
+              onChapterReorder={handleChapterReorder}
+              onChapterSelect={handleChapterSelect}
+              onViewModeChange={setViewMode}
+            />
+          ) : (
+            <EditorWritingArea
+              editorRef={editorRef}
+              currentContent={currentContent}
+              onContentChange={handleContentChange}
+              onSelectionWordCountChange={handleSelectionWordCountChange}
+              onSelectionUpdate={handleEditorSelectionUpdate}
+              onBlur={handleEditorBlur}
+              activeChapter={activeChapter}
+              editingTitle={editingTitle}
+              titleValue={titleValue}
+              onTitleValueChange={setTitleValue}
+              onTitleEdit={handleTitleEdit}
+              onTitleSave={handleTitleSave}
+              onTitleEditCancel={() => setEditingTitle(false)}
+              currentWordCount={currentWordCount}
+              selectionWordCount={selectionWordCount}
+            />
+          )}
         </div>
 
         <SourcesPanel />

--- a/web/src/components/book/book-outline.tsx
+++ b/web/src/components/book/book-outline.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  TouchSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  DragOverlay,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable'
+import { SortableChapterCard, ChapterCard, type ChapterCardData } from './chapter-card'
+
+interface BookOutlineProps {
+  chapters: ChapterCardData[]
+  onChapterReorder: (chapterIds: string[]) => void
+  onChapterSelect: (chapterId: string) => void
+  onViewModeChange: (mode: 'chapter' | 'book') => void
+}
+
+/**
+ * BookOutline - Full chapter list rendered in the center area when viewMode === 'book'.
+ *
+ * Uses @dnd-kit for drag-to-reorder following the same pattern as the sidebar.
+ * Sensors: PointerSensor (distance:8), TouchSensor (delay:250), KeyboardSensor.
+ * On card click, switches to chapter view and selects that chapter.
+ */
+export function BookOutline({
+  chapters,
+  onChapterReorder,
+  onChapterSelect,
+  onViewModeChange,
+}: BookOutlineProps) {
+  const sortedChapters = [...chapters].sort((a, b) => a.sortOrder - b.sortOrder)
+  const [dragActiveId, setDragActiveId] = useState<string | null>(null)
+
+  // DnD sensors — same config as sidebar
+  const pointerSensor = useSensor(PointerSensor, {
+    activationConstraint: { distance: 8 },
+  })
+  const touchSensor = useSensor(TouchSensor, {
+    activationConstraint: { delay: 250, tolerance: 5 },
+  })
+  const keyboardSensor = useSensor(KeyboardSensor, {
+    coordinateGetter: sortableKeyboardCoordinates,
+  })
+  const sensors = useSensors(pointerSensor, touchSensor, keyboardSensor)
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setDragActiveId(event.active.id as string)
+  }, [])
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      setDragActiveId(null)
+      const { active, over } = event
+      if (!over || active.id === over.id) return
+
+      const oldIndex = sortedChapters.findIndex((ch) => ch.id === active.id)
+      const newIndex = sortedChapters.findIndex((ch) => ch.id === over.id)
+      if (oldIndex === -1 || newIndex === -1) return
+
+      const reordered = [...sortedChapters]
+      const [moved] = reordered.splice(oldIndex, 1)
+      reordered.splice(newIndex, 0, moved)
+
+      onChapterReorder(reordered.map((ch) => ch.id))
+    },
+    [sortedChapters, onChapterReorder]
+  )
+
+  const handleDragCancel = useCallback(() => {
+    setDragActiveId(null)
+  }, [])
+
+  const handleCardSelect = useCallback(
+    (chapterId: string) => {
+      onViewModeChange('chapter')
+      onChapterSelect(chapterId)
+    },
+    [onViewModeChange, onChapterSelect]
+  )
+
+  const draggedChapter = dragActiveId ? sortedChapters.find((ch) => ch.id === dragActiveId) : null
+
+  return (
+    <div
+      className="flex-1 overflow-auto"
+      id="writing-area"
+      tabIndex={-1}
+      style={{ outline: 'none' }}
+    >
+      <div className="max-w-[700px] mx-auto px-6 py-8">
+        <h2 className="font-[var(--dc-font-serif)] text-[var(--dc-text-2xl)] font-semibold text-[var(--dc-color-text-primary)] mb-6">
+          Book Outline
+        </h2>
+
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onDragCancel={handleDragCancel}
+        >
+          <SortableContext
+            items={sortedChapters.map((ch) => ch.id)}
+            strategy={verticalListSortingStrategy}
+          >
+            <div role="listbox" aria-label="Chapter list" className="flex flex-col gap-3">
+              {sortedChapters.map((chapter) => (
+                <SortableChapterCard
+                  key={chapter.id}
+                  chapter={chapter}
+                  onSelect={() => handleCardSelect(chapter.id)}
+                />
+              ))}
+            </div>
+          </SortableContext>
+
+          <DragOverlay>
+            {draggedChapter ? (
+              <ChapterCard chapter={draggedChapter} onSelect={() => {}} isDragOverlay />
+            ) : null}
+          </DragOverlay>
+        </DndContext>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/book/chapter-card.tsx
+++ b/web/src/components/book/chapter-card.tsx
@@ -1,0 +1,136 @@
+'use client'
+
+import type { DraggableSyntheticListeners } from '@dnd-kit/core'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+
+export interface ChapterCardData {
+  id: string
+  title: string
+  wordCount: number
+  sortOrder: number
+  status: string
+}
+
+interface ChapterCardProps {
+  chapter: ChapterCardData
+  onSelect: () => void
+  isDragOverlay?: boolean
+  dragListeners?: DraggableSyntheticListeners
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  draft: 'bg-amber-400',
+  review: 'bg-blue-400',
+  complete: 'bg-emerald-400',
+  'needs-work': 'bg-red-400',
+}
+
+/**
+ * ChapterCard - Individual card in the Book Outline view.
+ *
+ * Displays chapter title (Lora serif, 20px, weight 600), word count
+ * with tabular-nums, and a status dot. Cards are 88px min-height
+ * and use design tokens from globals.css.
+ */
+function ChapterCard({
+  chapter,
+  onSelect,
+  isDragOverlay = false,
+  dragListeners,
+}: ChapterCardProps) {
+  const statusColor = STATUS_COLORS[chapter.status] ?? STATUS_COLORS.draft
+
+  return (
+    <div
+      className={`group flex items-stretch min-h-[88px] rounded-lg border
+                 transition-shadow
+                 ${isDragOverlay ? 'shadow-lg border-[var(--dc-color-interactive-primary-border)] bg-[var(--dc-color-surface-primary)]' : 'border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-primary)] hover:shadow-[var(--dc-shadow-md)]'}`}
+      role="option"
+      aria-selected={false}
+      aria-label={`${chapter.title || 'Untitled Chapter'}, ${chapter.wordCount.toLocaleString()} words, ${chapter.status}`}
+    >
+      {/* Drag handle */}
+      <button
+        className="flex items-center justify-center w-10 shrink-0 cursor-grab
+                   text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-secondary)]
+                   transition-colors touch-none select-none rounded-l-lg"
+        aria-label={`Drag to reorder ${chapter.title || 'Untitled Chapter'}`}
+        tabIndex={-1}
+        {...dragListeners}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <circle cx="9" cy="5" r="2" />
+          <circle cx="15" cy="5" r="2" />
+          <circle cx="9" cy="12" r="2" />
+          <circle cx="15" cy="12" r="2" />
+          <circle cx="9" cy="19" r="2" />
+          <circle cx="15" cy="19" r="2" />
+        </svg>
+      </button>
+
+      {/* Card content — clickable to navigate */}
+      <button
+        onClick={onSelect}
+        className="flex-1 min-w-0 px-4 py-3 text-left
+                   focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--dc-color-border-focus)] focus-visible:ring-inset
+                   rounded-r-lg"
+      >
+        <div className="flex items-start justify-between gap-3">
+          <h3
+            className="font-[var(--dc-font-serif)] text-[var(--dc-text-xl)] font-semibold leading-[var(--dc-leading-snug)]
+                       text-[var(--dc-color-text-primary)] truncate"
+          >
+            {chapter.title || 'Untitled Chapter'}
+          </h3>
+
+          {/* Status dot */}
+          <span
+            className={`mt-1.5 w-2.5 h-2.5 rounded-full shrink-0 ${statusColor}`}
+            aria-label={`Status: ${chapter.status}`}
+          />
+        </div>
+
+        <div className="mt-1 text-[var(--dc-text-sm)] text-[var(--dc-color-text-muted)] tabular-nums">
+          {chapter.wordCount.toLocaleString()} words
+        </div>
+      </button>
+    </div>
+  )
+}
+
+/**
+ * SortableChapterCard — wraps ChapterCard with @dnd-kit/sortable for drag-to-reorder.
+ */
+export function SortableChapterCard({
+  chapter,
+  onSelect,
+}: {
+  chapter: ChapterCardData
+  onSelect: () => void
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: chapter.id,
+  })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} {...attributes}>
+      <ChapterCard chapter={chapter} onSelect={onSelect} dragListeners={listeners} />
+    </div>
+  )
+}
+
+export { ChapterCard }

--- a/web/src/components/editor/editor-toolbar.tsx
+++ b/web/src/components/editor/editor-toolbar.tsx
@@ -154,7 +154,7 @@ export function EditorToolbar({
 
       {/* Right: Actions */}
       <div className="flex items-center gap-2 shrink-0">
-        <SaveIndicator status={saveStatus} onRetry={onSaveRetry} />
+        {viewMode !== 'book' && <SaveIndicator status={saveStatus} onRetry={onSaveRetry} />}
 
         {/* Editor Panel toggle (#317, #389) */}
         {onToggleEditorPanel && (
@@ -193,14 +193,16 @@ export function EditorToolbar({
           zone="library"
         />
 
-        <ExportMenu
-          projectId={projectId}
-          projectTitle={projectData.title}
-          activeChapterId={activeChapterId}
-          getToken={getToken}
-          apiUrl={apiUrl}
-          connections={connections}
-        />
+        {viewMode !== 'book' && (
+          <ExportMenu
+            projectId={projectId}
+            projectTitle={projectData.title}
+            activeChapterId={activeChapterId}
+            getToken={getToken}
+            apiUrl={apiUrl}
+            connections={connections}
+          />
+        )}
 
         <SettingsMenu
           onRenameBook={onRenameBook}


### PR DESCRIPTION
## Summary
- New `BookOutline` and `ChapterCard` components render draggable chapter cards when viewMode is "book" — replacing the Tiptap editor in the center area
- Cards show Lora serif title, word count, status dot (draft=amber, review=blue, complete=emerald, needs-work=red), with @dnd-kit drag-to-reorder
- Toolbar hides save status and export controls in book mode; auto-save disabled via `chapterId: null` guard
- ARIA: `role="listbox"`/`role="option"` for flat chapter list, proper keyboard navigation

## Test plan
- [x] `npm run verify` passes (typecheck, format, lint, 730 tests)
- [ ] Toggle to Book view: center area shows chapter cards (not Tiptap editor)
- [ ] Toggle back to Chapter view: Tiptap editor returns, auto-save resumes
- [ ] Drag-to-reorder works on chapter cards (same as sidebar)
- [ ] Click card: switches to Chapter view and selects that chapter
- [ ] Toolbar: no save indicator or export menu in book mode
- [ ] iPad Safari: touch drag works (250ms delay activation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)