### PR TITLE
fix: remove PRAGMA statements from migration 0028

### DIFF
--- a/workers/dc-api/migrations/0028_chapter_status_update.sql
+++ b/workers/dc-api/migrations/0028_chapter_status_update.sql
@@ -3,8 +3,6 @@
 -- Maps existing 'final' rows to 'complete'
 -- Also drops unused drive_file_id column (NULLed in 0021, unused in code)
 
-PRAGMA foreign_keys=OFF;
-
 -- 1. Create new table with updated status constraint (no drive_file_id)
 CREATE TABLE chapters_new (
   id TEXT PRIMARY KEY,
@@ -33,5 +31,3 @@ ALTER TABLE chapters_new RENAME TO chapters;
 -- 4. Recreate indexes
 CREATE UNIQUE INDEX idx_chapters_sort ON chapters(project_id, sort_order);
 CREATE INDEX idx_chapters_project_id ON chapters(project_id);
-
-PRAGMA foreign_keys=ON;


### PR DESCRIPTION
## Summary
- Remove `PRAGMA foreign_keys=OFF/ON` from migration 0028 — D1 runs migrations as batched transactions where PRAGMA doesn't behave as expected
- The `PRAGMA foreign_keys=ON` triggered a FK integrity check that failed on child tables referencing the recreated chapters table
- Matches the pattern used in migration 0027 (which also does table recreation without PRAGMA)

## Test plan
- [x] `npm run verify` passes
- [ ] `npx wrangler d1 migrations apply dc-main --remote` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)