### PR TITLE
feat: standardize 3 AI Assist panels with shared components

### DIFF
--- a/web/src/components/editor/book-editor-panel.tsx
+++ b/web/src/components/editor/book-editor-panel.tsx
@@ -3,8 +3,12 @@
 import { useState, useCallback, useRef, useEffect } from 'react'
 import { StreamingResponse } from './streaming-response'
 import { PanelActionBar, PanelButton } from './panel-action-bar'
+import { PanelStatusHeader } from './panel-status-header'
+import { Spinner } from './spinner'
+import { InstructionInput } from './instruction-input'
 import { useSourcesContext } from '@/contexts/sources-context'
 import { InstructionList } from '@/components/instruction-list'
+import { useToast } from '@/components/toast'
 import type { BookAnalysisState, BookAnalysisResult } from '@/hooks/use-book-ai'
 
 interface BookEditorPanelProps {
@@ -55,6 +59,7 @@ export function BookEditorPanel({
     touchInstructionLastUsed,
   } = useSourcesContext()
 
+  const { showToast } = useToast()
   const [instruction, setInstruction] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -81,24 +86,15 @@ export function BookEditorPanel({
     onAnalyze(trimmed)
   }, [instruction, onAnalyze])
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault()
-        handleSubmit()
-      }
-    },
-    [handleSubmit]
-  )
-
   const handleCopy = useCallback(async () => {
     if (!result?.text) return
     try {
       await navigator.clipboard.writeText(result.text)
+      showToast('Copied to clipboard')
     } catch {
-      // Clipboard API may fail on some devices
+      showToast('Failed to copy')
     }
-  }, [result])
+  }, [result, showToast])
 
   const handleStartOver = useCallback(() => {
     setInstruction('')
@@ -117,6 +113,13 @@ export function BookEditorPanel({
     totalWordCount >= 1000
       ? `${(totalWordCount / 1000).toFixed(1)}k words`
       : `${totalWordCount} words`
+
+  // Status header label
+  const statusLabel = isStreaming
+    ? 'Analyzing...'
+    : hasError
+      ? 'Could not finish the analysis.'
+      : 'Analysis complete.'
 
   return (
     <div className="flex flex-col h-full">
@@ -164,91 +167,34 @@ export function BookEditorPanel({
               />
             </div>
 
-            <div>
-              <label
-                htmlFor="book-panel-instruction"
-                className="text-xs font-medium text-[var(--dc-color-text-muted)] mb-1.5 block"
-              >
-                Or write your own
-              </label>
-              <div className="flex gap-2">
-                <textarea
-                  id="book-panel-instruction"
-                  ref={textareaRef}
-                  value={instruction}
-                  onChange={(e) => setInstruction(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  disabled={isStreaming}
-                  className="flex-1 p-2.5 text-sm border border-[var(--dc-color-border-strong)] rounded-[var(--dc-radius-md)] resize-none
-                             focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-interactive-escalation)] focus:border-transparent
-                             disabled:opacity-50 disabled:cursor-not-allowed
-                             placeholder:text-[var(--dc-color-text-placeholder)]"
-                  rows={2}
-                  placeholder="Type an instruction..."
-                />
-                <button
-                  type="button"
-                  onClick={handleSubmit}
-                  disabled={isStreaming || !instruction.trim()}
-                  className="self-end shrink-0 flex items-center justify-center rounded-[var(--dc-radius-md)]
-                             bg-[var(--dc-color-interactive-escalation)] text-[var(--dc-color-text-inverse)]
-                             hover:bg-[var(--dc-color-interactive-escalation-hover)]
-                             disabled:opacity-50 disabled:cursor-not-allowed
-                             transition-colors min-h-[44px] min-w-[44px]"
-                  aria-label="Send instruction"
-                >
-                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M14 5l7 7m0 0l-7 7m7-7H3"
-                    />
-                  </svg>
-                </button>
-              </div>
-            </div>
+            <InstructionInput
+              id="book-panel-instruction"
+              value={instruction}
+              onChange={setInstruction}
+              onSubmit={handleSubmit}
+              disabled={isStreaming}
+              variant="escalation"
+              textareaRef={textareaRef}
+            />
           </>
         )}
 
         {/* Streaming / complete: status header + response */}
         {result && (isStreaming || isComplete) && (
           <div>
-            <div className="flex items-center justify-between mb-2">
-              <h3
-                className={`text-xs font-medium ${
-                  hasError
-                    ? 'text-[var(--dc-color-status-error)]'
-                    : 'text-[var(--dc-color-interactive-escalation)]'
-                }`}
-              >
-                {isStreaming
-                  ? 'Analyzing...'
-                  : hasError
-                    ? 'Could not finish the analysis.'
-                    : 'Analysis complete.'}
-              </h3>
-              {isStreaming && (
-                <span className="text-xs text-[var(--dc-color-interactive-escalation)] flex items-center gap-1">
-                  <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                    />
-                  </svg>
-                  Writing...
-                </span>
-              )}
-            </div>
+            <PanelStatusHeader
+              label={statusLabel}
+              isError={hasError}
+              variant="escalation"
+              right={
+                isStreaming ? (
+                  <span className="text-xs text-[var(--dc-color-interactive-escalation)] flex items-center gap-1">
+                    <Spinner size="sm" />
+                    Writing...
+                  </span>
+                ) : undefined
+              }
+            />
             <StreamingResponse
               text={result.text}
               isStreaming={isStreaming}
@@ -285,42 +231,55 @@ export function BookEditorPanel({
             </p>
           </div>
         )}
+
+        {/* SR-only status announcement */}
+        <div className="sr-only" aria-live="polite" role="status">
+          {isStreaming
+            ? 'Analysis in progress.'
+            : isComplete && !hasError
+              ? 'Analysis complete.'
+              : hasError
+                ? 'Analysis failed.'
+                : null}
+        </div>
       </div>
 
-      {/* Action bar - pinned to bottom */}
-      {isComplete && hasResult && !hasError && (
+      {/* Action bar - pinned to bottom, consolidated into one block */}
+      {(isStreaming || (isComplete && hasResult)) && (
         <PanelActionBar>
-          <PanelButton tier="ghost" onClick={handleStartOver}>
-            Start Over
-          </PanelButton>
-          <PanelButton tier="primary" variant="escalation" onClick={handleCopy}>
-            Copy
-          </PanelButton>
-        </PanelActionBar>
-      )}
-
-      {/* Streaming: Cancel button */}
-      {isStreaming && (
-        <PanelActionBar>
-          <PanelButton tier="ghost" onClick={onReset}>
-            Cancel
-          </PanelButton>
-        </PanelActionBar>
-      )}
-
-      {/* Error: Start Over + Retry */}
-      {isComplete && hasError && (
-        <PanelActionBar>
-          <PanelButton tier="ghost" onClick={handleStartOver}>
-            Start Over
-          </PanelButton>
-          <PanelButton
-            tier="primary"
-            variant="escalation"
-            onClick={() => result && onAnalyze(result.instruction)}
-          >
-            Try Again
-          </PanelButton>
+          {isStreaming ? (
+            <PanelButton tier="ghost" onClick={onReset} aria-label="Cancel analysis">
+              Cancel
+            </PanelButton>
+          ) : hasError ? (
+            <>
+              <PanelButton tier="ghost" onClick={handleStartOver} aria-label="Start over">
+                Start Over
+              </PanelButton>
+              <PanelButton
+                tier="primary"
+                variant="escalation"
+                onClick={() => result && onAnalyze(result.instruction)}
+                aria-label="Try again"
+              >
+                Try Again
+              </PanelButton>
+            </>
+          ) : (
+            <>
+              <PanelButton tier="ghost" onClick={handleStartOver} aria-label="Start over">
+                Start Over
+              </PanelButton>
+              <PanelButton
+                tier="primary"
+                variant="escalation"
+                onClick={handleCopy}
+                aria-label="Copy analysis to clipboard"
+              >
+                Copy
+              </PanelButton>
+            </>
+          )}
         </PanelActionBar>
       )}
     </div>

--- a/web/src/components/editor/chapter-editor-panel.tsx
+++ b/web/src/components/editor/chapter-editor-panel.tsx
@@ -4,6 +4,9 @@ import { useState, useCallback, useRef, useEffect } from 'react'
 import type { AIRewriteResult, SheetState } from '@/hooks/use-ai-rewrite'
 import { StreamingResponse } from './streaming-response'
 import { PanelActionBar, PanelButton } from './panel-action-bar'
+import { PanelStatusHeader } from './panel-status-header'
+import { Spinner } from './spinner'
+import { InstructionInput } from './instruction-input'
 import { useSourcesContext } from '@/contexts/sources-context'
 import { InstructionList } from '@/components/instruction-list'
 
@@ -134,15 +137,10 @@ export function ChapterEditorPanel({
     }
   }, [editedInstruction, hasResult, result, onRetry, onRewriteWithInstruction])
 
-  const handleInstructionKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault()
-        handleInstructionSubmit()
-      }
-    },
-    [handleInstructionSubmit]
-  )
+  const handleInstructionChange = useCallback((value: string) => {
+    setEditedInstruction(value)
+    setHasUserEdited(true)
+  }, [])
 
   const handleAccept = useCallback(() => {
     if (result) onAccept(result)
@@ -170,6 +168,16 @@ export function ChapterEditorPanel({
     }
   }, [isIdle, hasSelectedText])
 
+  // Status header label
+  const statusLabel =
+    panelState === 'streaming'
+      ? 'Rewriting...'
+      : panelState === 'error'
+        ? 'Could not finish the rewrite.'
+        : result && result.attemptNumber > 1
+          ? 'Here is another take.'
+          : 'Here is a rewrite.'
+
   // Shared instruction controls block (used in Ready and Complete states)
   const instructionControls = showInstructions ? (
     <>
@@ -188,53 +196,15 @@ export function ChapterEditorPanel({
         />
       </div>
 
-      <div>
-        <label
-          htmlFor="editor-panel-instruction"
-          className="text-xs font-medium text-[var(--dc-color-text-muted)] mb-1.5 block"
-        >
-          Or write your own
-        </label>
-        <div className="flex gap-2">
-          <textarea
-            id="editor-panel-instruction"
-            ref={instructionRef}
-            value={editedInstruction || (result?.instruction ?? '')}
-            onChange={(e) => {
-              setEditedInstruction(e.target.value)
-              setHasUserEdited(true)
-            }}
-            onKeyDown={handleInstructionKeyDown}
-            disabled={isStreaming}
-            className="flex-1 p-2.5 text-sm border border-[var(--dc-color-border-strong)] rounded-[var(--dc-radius-md)] resize-none
-                       focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-interactive-escalation)] focus:border-transparent
-                       disabled:opacity-50 disabled:cursor-not-allowed
-                       placeholder:text-[var(--dc-color-text-placeholder)]"
-            rows={2}
-            placeholder="Type an instruction..."
-          />
-          <button
-            type="button"
-            onClick={handleInstructionSubmit}
-            disabled={isStreaming || !editedInstruction.trim()}
-            className="self-end shrink-0 flex items-center justify-center rounded-[var(--dc-radius-md)]
-                       bg-[var(--dc-color-interactive-escalation)] text-[var(--dc-color-text-inverse)]
-                       hover:bg-[var(--dc-color-interactive-escalation-hover)]
-                       disabled:opacity-50 disabled:cursor-not-allowed
-                       transition-colors min-h-[44px] min-w-[44px]"
-            aria-label="Send instruction"
-          >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M14 5l7 7m0 0l-7 7m7-7H3"
-              />
-            </svg>
-          </button>
-        </div>
-      </div>
+      <InstructionInput
+        id="editor-panel-instruction"
+        value={editedInstruction || (result?.instruction ?? '')}
+        onChange={handleInstructionChange}
+        onSubmit={handleInstructionSubmit}
+        disabled={isStreaming}
+        variant="escalation"
+        textareaRef={instructionRef}
+      />
     </>
   ) : null
 
@@ -309,48 +279,26 @@ export function ChapterEditorPanel({
         {/* Streaming response area */}
         {hasResult && (
           <div>
-            <div className="flex items-center justify-between mb-2">
-              <h3
-                className={`text-xs font-medium ${
-                  panelState === 'error'
-                    ? 'text-[var(--dc-color-status-error)]'
-                    : 'text-[var(--dc-color-interactive-escalation)]'
-                }`}
-              >
-                {panelState === 'streaming'
-                  ? 'Rewriting...'
-                  : panelState === 'error'
-                    ? 'Could not finish the rewrite.'
-                    : result.attemptNumber > 1
-                      ? 'Here is another take.'
-                      : 'Here is a rewrite.'}
-              </h3>
-              {isStreaming && (
-                <span className="text-xs text-[var(--dc-color-interactive-escalation)] flex items-center gap-1">
-                  <svg className="animate-spin h-3 w-3" viewBox="0 0 24 24" fill="none">
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                    />
-                  </svg>
-                  Writing...
-                </span>
-              )}
-              {isComplete && result.attemptNumber > 0 && (
-                <span className="text-xs text-[var(--dc-color-text-muted)]">
-                  Attempt {result.attemptNumber}
-                </span>
-              )}
-            </div>
+            <PanelStatusHeader
+              label={statusLabel}
+              isError={panelState === 'error'}
+              variant="escalation"
+              right={
+                <>
+                  {isStreaming && (
+                    <span className="text-xs text-[var(--dc-color-interactive-escalation)] flex items-center gap-1">
+                      <Spinner size="sm" />
+                      Writing...
+                    </span>
+                  )}
+                  {isComplete && result.attemptNumber > 0 && (
+                    <span className="text-xs text-[var(--dc-color-text-muted)]">
+                      Attempt {result.attemptNumber}
+                    </span>
+                  )}
+                </>
+              }
+            />
             <StreamingResponse
               text={result.rewriteText}
               isStreaming={isStreaming}
@@ -360,6 +308,17 @@ export function ChapterEditorPanel({
             />
           </div>
         )}
+
+        {/* SR-only status announcement */}
+        <div className="sr-only" aria-live="polite" role="status">
+          {isStreaming
+            ? 'Rewrite in progress.'
+            : panelState === 'complete'
+              ? 'Rewrite complete.'
+              : panelState === 'error'
+                ? 'Rewrite failed.'
+                : null}
+        </div>
 
         {/* Complete state: instruction controls appear below response (for retry) */}
         {panelState === 'complete' && instructionControls}

--- a/web/src/components/editor/instruction-input.tsx
+++ b/web/src/components/editor/instruction-input.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useCallback, type RefObject } from 'react'
+
+type InputVariant = 'escalation' | 'primary'
+
+interface InstructionInputProps {
+  /** HTML id for the textarea (links to external label) */
+  id: string
+  /** Current instruction text */
+  value: string
+  /** Called when the user types */
+  onChange: (value: string) => void
+  /** Called when the user submits (Enter key or send button) */
+  onSubmit: () => void
+  /** Disable interaction during streaming */
+  disabled?: boolean
+  /** Accent color variant */
+  variant?: InputVariant
+  /** Placeholder text */
+  placeholder?: string
+  /** Number of visible rows */
+  rows?: number
+  /** Label text shown above the input */
+  label?: string
+  /** Ref forwarded to the underlying textarea */
+  textareaRef?: RefObject<HTMLTextAreaElement | null>
+}
+
+const ringColors: Record<InputVariant, string> = {
+  escalation: 'focus:ring-[var(--dc-color-interactive-escalation)]',
+  primary: 'focus:ring-[var(--dc-color-interactive-primary)]',
+}
+
+const buttonColors: Record<InputVariant, string> = {
+  escalation:
+    'bg-[var(--dc-color-interactive-escalation)] hover:bg-[var(--dc-color-interactive-escalation-hover)]',
+  primary:
+    'bg-[var(--dc-color-interactive-primary)] hover:bg-[var(--dc-color-interactive-primary-hover)]',
+}
+
+/**
+ * InstructionInput — Shared textarea + arrow-send-button for AI Assist panels.
+ *
+ * Used by Chapter Editor and Book Editor panels where Enter submits
+ * (Shift+Enter inserts newline). The send button provides a 44px touch
+ * target for iPad interaction.
+ *
+ * **Not for Desk Tab.** Desk Tab uses a decoupled instruction/action pattern:
+ * its textarea allows multiline input without Enter-to-submit, and the submit
+ * action is a separate "Analyze" button in the action bar.
+ */
+export function InstructionInput({
+  id,
+  value,
+  onChange,
+  onSubmit,
+  disabled = false,
+  variant = 'escalation',
+  placeholder = 'Type an instruction...',
+  rows = 2,
+  label = 'Or write your own',
+  textareaRef,
+}: InstructionInputProps) {
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault()
+        onSubmit()
+      }
+    },
+    [onSubmit]
+  )
+
+  return (
+    <div>
+      <label
+        htmlFor={id}
+        className="text-xs font-medium text-[var(--dc-color-text-muted)] mb-1.5 block"
+      >
+        {label}
+      </label>
+      <div className="flex gap-2">
+        <textarea
+          id={id}
+          ref={textareaRef}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={disabled}
+          className={`flex-1 p-2.5 text-sm border border-[var(--dc-color-border-strong)] rounded-[var(--dc-radius-md)] resize-none
+                     focus:outline-none focus:ring-2 ${ringColors[variant]} focus:border-transparent
+                     disabled:opacity-50 disabled:cursor-not-allowed
+                     placeholder:text-[var(--dc-color-text-placeholder)]`}
+          rows={rows}
+          placeholder={placeholder}
+        />
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={disabled || !value.trim()}
+          className={`self-end shrink-0 flex items-center justify-center rounded-[var(--dc-radius-md)]
+                     ${buttonColors[variant]} text-[var(--dc-color-text-inverse)]
+                     disabled:opacity-50 disabled:cursor-not-allowed
+                     transition-colors min-h-[44px] min-w-[44px]`}
+          aria-label="Send instruction"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M14 5l7 7m0 0l-7 7m7-7H3"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/editor/panel-status-header.tsx
+++ b/web/src/components/editor/panel-status-header.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+
+type StatusVariant = 'escalation' | 'primary'
+
+interface PanelStatusHeaderProps {
+  /** Pre-computed label (e.g. "Rewriting...", "Analysis complete.") */
+  label: string
+  /** Show error styling (red text) instead of variant color */
+  isError?: boolean
+  /** Accent color variant */
+  variant: StatusVariant
+  /** Optional right-side content (spinner during streaming, attempt counter, etc.) */
+  right?: ReactNode
+}
+
+const variantColors: Record<StatusVariant, string> = {
+  escalation: 'text-[var(--dc-color-interactive-escalation)]',
+  primary: 'text-[var(--dc-color-interactive-primary)]',
+}
+
+/**
+ * PanelStatusHeader — Shared status header for AI Assist streaming/complete/error states.
+ *
+ * Layout: label on left, optional content on right. Consumer owns all label
+ * logic (attempt-aware text, contextual messages). This component is a
+ * layout primitive, not a state machine.
+ */
+export function PanelStatusHeader({
+  label,
+  isError = false,
+  variant,
+  right,
+}: PanelStatusHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-2">
+      <h3
+        className={`text-xs font-medium ${
+          isError ? 'text-[var(--dc-color-status-error)]' : variantColors[variant]
+        }`}
+      >
+        {label}
+      </h3>
+      {right}
+    </div>
+  )
+}

--- a/web/src/components/editor/spinner.tsx
+++ b/web/src/components/editor/spinner.tsx
@@ -1,0 +1,34 @@
+/**
+ * Spinner — Shared animated loading indicator for AI Assist panels.
+ *
+ * Renders a spinning circle SVG with reduced-motion support.
+ * Used in status headers during streaming state.
+ */
+
+const sizeClasses = {
+  sm: 'h-3 w-3',
+  md: 'h-4 w-4',
+} as const
+
+interface SpinnerProps {
+  size?: 'sm' | 'md'
+  className?: string
+}
+
+export function Spinner({ size = 'sm', className = '' }: SpinnerProps) {
+  return (
+    <svg
+      className={`animate-spin motion-reduce:animate-none ${sizeClasses[size]} ${className}`}
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  )
+}

--- a/web/src/components/sources/desk-tab.tsx
+++ b/web/src/components/sources/desk-tab.tsx
@@ -5,6 +5,8 @@ import { useSourcesContext } from '@/contexts/sources-context'
 import { InstructionList } from '@/components/instruction-list'
 import { StreamingResponse } from '@/components/editor/streaming-response'
 import { PanelActionBar, PanelButton } from '@/components/editor/panel-action-bar'
+import { PanelStatusHeader } from '@/components/editor/panel-status-header'
+import { Spinner } from '@/components/editor/spinner'
 import { EmptyState } from './empty-state'
 import { useToast } from '@/components/toast'
 
@@ -29,6 +31,7 @@ export function DeskTab() {
     isAnalysisComplete,
     analysisError,
     resetAnalysis,
+    abortAnalysis,
     deskInstructions,
     isLoadingInstructions,
     createInstruction,
@@ -48,6 +51,8 @@ export function DeskTab() {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const analysisRef = useRef<HTMLDivElement>(null)
   const hasScrolledToResults = useRef(false)
+  // Store the instruction at analysis time so retry uses the correct value
+  const lastAnalysisInstruction = useRef('')
 
   // Merge inline + deep analysis state
   const isDeepProcessing = deepAnalysis.status === 'pending' || deepAnalysis.status === 'processing'
@@ -121,14 +126,31 @@ export function DeskTab() {
   const handleAnalyze = useCallback(() => {
     const ids = Array.from(selectedIds)
     if (ids.length === 0 || !instruction.trim()) return
+    lastAnalysisInstruction.current = instruction.trim()
     analyze(projectId, ids, instruction)
   }, [selectedIds, instruction, projectId, analyze])
+
+  const handleCancel = useCallback(() => {
+    abortAnalysis()
+    deepAnalysis.reset()
+  }, [abortAnalysis, deepAnalysis])
+
+  const handleStartOver = useCallback(() => {
+    // Clears analysis results only — preserves instruction text and document selections
+    resetAnalysis()
+    deepAnalysis.reset()
+  }, [resetAnalysis, deepAnalysis])
 
   const handleRetry = useCallback(() => {
     resetAnalysis()
     deepAnalysis.reset()
-    handleAnalyze()
-  }, [resetAnalysis, deepAnalysis, handleAnalyze])
+    // Use the instruction captured at analysis time, not current textarea state
+    const retryInstruction = lastAnalysisInstruction.current
+    if (!retryInstruction) return
+    const ids = Array.from(selectedIds)
+    if (ids.length === 0) return
+    analyze(projectId, ids, retryInstruction)
+  }, [resetAnalysis, deepAnalysis, selectedIds, projectId, analyze])
 
   const handleCopy = useCallback(async () => {
     if (!effectiveText) return
@@ -161,6 +183,15 @@ export function DeskTab() {
       closePanel()
     }
   }, [effectiveText, editorRef, showToast, isPanelOpen, closePanel])
+
+  const hasAnalysisContent = !!effectiveText
+
+  // Status header label
+  const statusLabel = isAnyAnalyzing
+    ? 'Analyzing...'
+    : effectiveError
+      ? 'Could not finish the analysis.'
+      : 'Analysis complete.'
 
   // Empty desk
   if (deskSources.length === 0) {
@@ -208,7 +239,7 @@ export function DeskTab() {
             />
           </div>
 
-          {/* Freeform instruction textarea */}
+          {/* Freeform instruction textarea (no Enter-to-submit — decoupled from Analyze button) */}
           <div className="pb-3">
             <label
               htmlFor="desk-instruction-textarea"
@@ -406,7 +437,19 @@ export function DeskTab() {
         {/* Analysis result / streaming response */}
         {(effectiveText || isAnalyzing || effectiveError) && (
           <div ref={analysisRef} className="px-4 py-4 space-y-2">
-            <h3 className="text-xs font-medium text-[var(--dc-color-text-muted)]">Analysis</h3>
+            <PanelStatusHeader
+              label={statusLabel}
+              isError={!!effectiveError}
+              variant="primary"
+              right={
+                isAnyAnalyzing ? (
+                  <span className="text-xs text-[var(--dc-color-interactive-primary)] flex items-center gap-1">
+                    <Spinner size="sm" />
+                    Writing...
+                  </span>
+                ) : undefined
+              }
+            />
             <StreamingResponse
               text={effectiveText}
               isStreaming={isAnalyzing}
@@ -417,51 +460,75 @@ export function DeskTab() {
             />
           </div>
         )}
+
+        {/* SR-only status announcement for analysis */}
+        <div className="sr-only" aria-live="polite" role="status">
+          {isAnyAnalyzing
+            ? 'Analysis in progress.'
+            : effectiveComplete && !effectiveError
+              ? 'Analysis complete.'
+              : effectiveError
+                ? 'Analysis failed.'
+                : null}
+        </div>
       </div>
 
-      {/* Zone C: Action bar - pinned at bottom */}
+      {/* Zone C: Action bar - pinned at bottom, 4 branches */}
       <PanelActionBar>
-        {effectiveComplete && effectiveText && !effectiveError ? (
+        {isAnyAnalyzing ? (
+          /* Streaming → Cancel */
+          <PanelButton tier="ghost" onClick={handleCancel} aria-label="Cancel analysis">
+            Cancel
+          </PanelButton>
+        ) : effectiveError ? (
+          /* Error → Start Over + Try Again */
           <>
-            <PanelButton tier="ghost" onClick={handleCopy}>
+            <PanelButton tier="ghost" onClick={handleStartOver} aria-label="Start over">
+              Start Over
+            </PanelButton>
+            <PanelButton
+              tier="primary"
+              variant="primary"
+              onClick={handleRetry}
+              aria-label="Try again"
+            >
+              Try Again
+            </PanelButton>
+          </>
+        ) : effectiveComplete && hasAnalysisContent ? (
+          /* Complete → Start Over + Copy + Insert */
+          <>
+            <PanelButton tier="ghost" onClick={handleStartOver} aria-label="Start over">
+              Start Over
+            </PanelButton>
+            <PanelButton tier="ghost" onClick={handleCopy} aria-label="Copy analysis to clipboard">
               Copy
             </PanelButton>
-            <PanelButton tier="primary" variant="primary" onClick={handleInsert}>
+            <PanelButton
+              tier="primary"
+              variant="primary"
+              onClick={handleInsert}
+              aria-label="Insert analysis into chapter"
+            >
               Insert into Chapter
             </PanelButton>
           </>
         ) : (
+          /* Idle → Analyze button */
           <PanelButton
             tier="primary"
             variant="primary"
             onClick={handleAnalyze}
-            disabled={selectedIds.size === 0 || !instruction.trim() || isAnyAnalyzing}
-            aria-busy={isAnyAnalyzing}
+            disabled={selectedIds.size === 0 || !instruction.trim()}
+            aria-label={
+              selectedIds.size === 0
+                ? 'Select documents to analyze'
+                : `Analyze ${selectedIds.size} document${selectedIds.size !== 1 ? 's' : ''}`
+            }
           >
-            {isAnyAnalyzing ? (
-              <>
-                <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="10"
-                    stroke="currentColor"
-                    strokeWidth="4"
-                  />
-                  <path
-                    className="opacity-75"
-                    fill="currentColor"
-                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                  />
-                </svg>
-                Analyzing...
-              </>
-            ) : selectedIds.size === 0 ? (
-              'Select documents to analyze'
-            ) : (
-              `Analyze ${selectedIds.size} document${selectedIds.size !== 1 ? 's' : ''}`
-            )}
+            {selectedIds.size === 0
+              ? 'Select documents to analyze'
+              : `Analyze ${selectedIds.size} document${selectedIds.size !== 1 ? 's' : ''}`}
           </PanelButton>
         )}
       </PanelActionBar>


### PR DESCRIPTION
## Summary

Closes #466

- **Extracted 3 shared components** from duplicated code across Chapter Editor, Book Editor, and Desk Tab panels:
  - `Spinner` — animated loading indicator with `motion-reduce:animate-none`
  - `InstructionInput` — textarea + arrow send button (Chapter + Book only; Desk Tab intentionally uses decoupled instruction/action pattern)
  - `PanelStatusHeader` — status header layout primitive (label left, optional right content)
- **Chapter Editor Panel** — swapped inline textarea/spinner/header for shared components; added `sr-only` status announcements
- **Book Editor Panel** — consolidated 3 separate `<PanelActionBar>` blocks into 1 conditional block; added toast feedback on Copy (was silently failing); added `aria-label` on all action buttons; added `sr-only` status announcements
- **Desk Tab** — added Cancel button during streaming (calls both `abortAnalysis()` and `deepAnalysis.reset()`); added error recovery actions (Start Over + Try Again); added Start Over to complete state; replaced static "Analysis" text with `PanelStatusHeader`; fixed retry to use stored instruction ref (`lastAnalysisInstruction`) instead of current textarea state; consolidated action bar into 4 branches (idle/streaming/complete/error); added `aria-label` on all action buttons

Net: **+441 / -256 lines** (185 net new) — most of the additions are the 3 new shared components; the panel files themselves shrink.

## Test plan

- [ ] `npm run verify` passes (typecheck + format + lint + test — 730 tests green)
- [ ] Chapter panel: select text → pick instruction → stream → Use This replaces text
- [ ] Book panel: pick instruction → stream → Copy shows toast → Start Over resets
- [ ] Desk tab: check documents → write instruction → Analyze → Cancel aborts mid-stream → error shows Start Over + Try Again → Try Again re-runs with original instruction → Insert works
- [ ] All panels: action bars show correct buttons for each state, ARIA labels present, 44px touch targets
- [ ] Screen reader: `sr-only` announcements fire on streaming start/complete/error

**QA Grade: B** — Behavioral changes (cancel, error recovery, retry-with-stored-instruction) need manual verification on iPad Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)