### PR TITLE
feat: polish AI Assist panels with gradient buttons, status icons, and card rows

### DIFF
--- a/web/src/components/editor/panel-action-bar.tsx
+++ b/web/src/components/editor/panel-action-bar.tsx
@@ -34,9 +34,9 @@ export function PanelActionBar({ children, className = '' }: PanelActionBarProps
 
 const primaryStyles: Record<ActionVariant, string> = {
   escalation:
-    'bg-[var(--dc-color-interactive-escalation)] hover:bg-[var(--dc-color-interactive-escalation-hover)] text-[var(--dc-color-text-inverse)] border-none',
+    'bg-gradient-to-r from-[var(--dc-color-interactive-escalation)] to-[var(--dc-color-interactive-escalation-hover)] hover:from-[var(--dc-color-interactive-escalation-hover)] hover:to-[var(--dc-color-interactive-escalation-hover)] text-[var(--dc-color-text-inverse)] border-none shadow-sm',
   primary:
-    'bg-[var(--dc-color-interactive-primary)] hover:bg-[var(--dc-color-interactive-primary-hover)] text-[var(--dc-color-text-inverse)] border-none',
+    'bg-gradient-to-r from-[var(--dc-color-interactive-primary)] to-[var(--dc-color-interactive-primary-active)] hover:from-[var(--dc-color-interactive-primary-hover)] hover:to-[var(--dc-color-interactive-primary-active)] text-[var(--dc-color-text-inverse)] border-none shadow-sm',
 }
 
 const secondaryStyles: Record<ActionVariant, string> = {

--- a/web/src/components/editor/panel-status-header.tsx
+++ b/web/src/components/editor/panel-status-header.tsx
@@ -3,8 +3,8 @@ import type { ReactNode } from 'react'
 type StatusVariant = 'escalation' | 'primary'
 
 interface PanelStatusHeaderProps {
-  /** Pre-computed label (e.g. "Rewriting...", "Analysis complete.") */
-  label: string
+  /** Pre-computed label — string or JSX with inline icons */
+  label: ReactNode
   /** Show error styling (red text) instead of variant color */
   isError?: boolean
   /** Accent color variant */

--- a/web/src/components/editor/streaming-response.tsx
+++ b/web/src/components/editor/streaming-response.tsx
@@ -84,14 +84,30 @@ export function StreamingResponse({
       aria-live="polite"
     >
       {showErrorOnly ? (
-        <div>
-          <span className="text-[var(--dc-color-status-error)] text-xs">{errorMessage}</span>
+        <div className="bg-[var(--dc-color-error-bg)] border border-[var(--dc-color-status-error)]/20 rounded-[var(--dc-radius-md)] p-3 -m-0.5">
+          <span className="text-[var(--dc-color-status-error)] text-xs leading-relaxed">
+            {errorMessage}
+          </span>
           {onRetry && (
             <button
               type="button"
               onClick={onRetry}
-              className={`block mt-1 text-xs ${styles.retry}`}
+              className={`mt-2 text-xs font-medium ${styles.retry} flex items-center gap-1 min-h-[32px]`}
             >
+              <svg
+                className="w-3 h-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                />
+              </svg>
               Tap to retry
             </button>
           )}
@@ -107,14 +123,30 @@ export function StreamingResponse({
             />
           )}
           {showErrorInline && (
-            <div className="mt-3">
-              <span className="text-[var(--dc-color-status-error)] text-xs">{errorMessage}</span>
+            <div className="mt-3 bg-[var(--dc-color-error-bg)] border border-[var(--dc-color-status-error)]/20 rounded-[var(--dc-radius-md)] p-3">
+              <span className="text-[var(--dc-color-status-error)] text-xs leading-relaxed">
+                {errorMessage}
+              </span>
               {onRetry && (
                 <button
                   type="button"
                   onClick={onRetry}
-                  className={`block mt-1 text-xs ${styles.retry}`}
+                  className={`mt-2 text-xs font-medium ${styles.retry} flex items-center gap-1 min-h-[32px]`}
                 >
+                  <svg
+                    className="w-3 h-3"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                    />
+                  </svg>
                   Tap to retry
                 </button>
               )}

--- a/web/src/components/sources/desk-tab.tsx
+++ b/web/src/components/sources/desk-tab.tsx
@@ -186,12 +186,29 @@ export function DeskTab() {
 
   const hasAnalysisContent = !!effectiveText
 
-  // Status header label
-  const statusLabel = isAnyAnalyzing
-    ? 'Analyzing...'
-    : effectiveError
-      ? 'Could not finish the analysis.'
-      : 'Analysis complete.'
+  // Status header label with inline icons
+  const statusLabel = isAnyAnalyzing ? (
+    'Analyzing...'
+  ) : effectiveError ? (
+    <span className="flex items-center gap-1">
+      <svg className="w-3 h-3 shrink-0" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
+        <path
+          fillRule="evenodd"
+          d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7 4a1 1 0 11-2 0 1 1 0 012 0zm-1-9a1 1 0 00-1 1v4a1 1 0 102 0V6a1 1 0 00-1-1z"
+          clipRule="evenodd"
+        />
+      </svg>
+      Could not finish the analysis.
+    </span>
+  ) : (
+    <span className="flex items-center gap-1">
+      <span className="relative flex h-2 w-2 shrink-0">
+        <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-[var(--dc-color-status-success)] opacity-75" />
+        <span className="relative inline-flex rounded-full h-2 w-2 bg-[var(--dc-color-status-success)]" />
+      </span>
+      Analysis complete.
+    </span>
+  )
 
   // Empty desk
   if (deskSources.length === 0) {
@@ -326,13 +343,17 @@ export function DeskTab() {
         </div>
 
         {/* Document rows */}
-        <div>
+        <div className="px-2 py-1 space-y-1">
           {deskSources.map((source) => {
             const isSelected = selectedIds.has(source.id)
             return (
               <div
                 key={source.id}
-                className="flex items-center w-full border-b border-[var(--dc-color-border-subtle)] hover:bg-[var(--dc-color-surface-secondary)]"
+                className={`flex items-center w-full rounded-lg transition-colors ${
+                  isSelected
+                    ? 'bg-[var(--dc-color-interactive-primary-subtle)] border border-[var(--dc-color-interactive-primary-border)]'
+                    : 'hover:bg-[var(--dc-color-surface-secondary)] border border-transparent'
+                }`}
               >
                 {/* Checkbox + title (tap to select) */}
                 <button


### PR DESCRIPTION
## Summary
- **Gradient buttons**: Primary-tier `PanelButton` uses subtle gradient fill (`from-primary to-primary-active`) with `shadow-sm` across all 3 AI panels
- **Status icons**: Desk Tab shows animated green ping dot on "Analysis complete" and filled error circle on failure state
- **Card-style document rows**: Selected documents on the Desk Tab render with blue-tinted background and blue border instead of flat divider rows
- **Error card styling**: `StreamingResponse` error state renders in a red-tinted card (`#fef2f2`) with refresh icon on retry button
- **ReactNode labels**: `PanelStatusHeader` now accepts `ReactNode` for inline icon support (backward-compatible)

Design improvements adopted from Stitch screen generation (project: DC AI Assist Panels, 4 screens: initial-selected, streaming, complete, error).

## Test plan
- [x] `npm run verify` passes (531 tests, typecheck, lint, format)
- [ ] Visual: Primary buttons show subtle gradient on all 3 panels (Chapter Editor, Book Editor, Desk Tab)
- [ ] Visual: Desk Tab checked document rows have blue card styling
- [ ] Visual: "Analysis complete" shows green pinging dot
- [ ] Visual: Error state shows red-tinted card with retry icon
- [ ] iPad Safari: Touch targets remain 44px minimum

🤖 Generated with [Claude Code](https://claude.com/claude-code)