### PR TITLE
fix: remove floating Ch pill — breadcrumb nav handles chapter switching

### DIFF
--- a/web/src/components/editor/editor-sidebar.tsx
+++ b/web/src/components/editor/editor-sidebar.tsx
@@ -26,7 +26,7 @@ interface EditorSidebarProps {
  *
  * Handles the desktop persistent sidebar and the mobile overlay pattern
  * per PRD Section 14 (iPad-First Design):
- * - Sidebar persistent in landscape (240-280pt), hidden in portrait with "Ch X" pill
+ * - Sidebar persistent in landscape (240-280pt), hidden in portrait (breadcrumb nav handles chapter switching)
  * - Touch targets 44x44pt minimum
  */
 export function EditorSidebar({

--- a/web/src/components/layout/index.ts
+++ b/web/src/components/layout/index.ts
@@ -17,7 +17,6 @@ export {
   WorkspaceCenter,
   WorkspaceLibraryPanel,
   OverlayPanel,
-  SidebarPill,
   StandaloneWorkspaceShell,
   useWorkspaceShell,
 } from './workspace-shell'

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -77,7 +77,7 @@ export interface SidebarProps {
  *
  * Per PRD Section 9 (Sidebar Responsive Behavior):
  * - iPad Landscape (1024pt+): Persistent, 240-280pt wide, collapsible
- * - iPad Portrait (768pt): Hidden by default with "Ch X" pill indicator
+ * - iPad Portrait (768pt): Hidden by default (breadcrumb nav handles chapter switching)
  * - Desktop (1200pt+): Persistent
  *
  * Per PRD US-013 (Rename Chapter):
@@ -220,22 +220,9 @@ export function Sidebar({
   }, [onChapterReorder, activeChapterId, sortedChapters])
 
   if (collapsed) {
-    // Collapsed state - show only a pill indicator
-    const activeChapter = sortedChapters.find((ch) => ch.id === activeChapterId)
-    const activeIndex = activeChapter ? sortedChapters.indexOf(activeChapter) + 1 : 1
-
-    return (
-      <button
-        onClick={onToggleCollapsed}
-        className="fixed left-2 top-1/2 -translate-y-1/2 z-40
-                   px-3 py-2 rounded-full bg-blue-600 text-white text-sm font-medium
-                   shadow-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500
-                   transition-colors min-w-[44px] min-h-[44px] flex items-center justify-center"
-        aria-label={`Chapter ${activeIndex}. Tap to open chapter list.`}
-      >
-        Ch {activeIndex}
-      </button>
-    )
+    // Breadcrumb nav in the toolbar now handles chapter indication and switching.
+    // No pill needed — return nothing when collapsed.
+    return null
   }
 
   // Find the dragged chapter for overlay rendering

--- a/web/src/components/layout/workspace-shell.tsx
+++ b/web/src/components/layout/workspace-shell.tsx
@@ -169,7 +169,7 @@ export function WorkspaceShell({ children, className = '' }: WorkspaceShellProps
  * WorkspaceSidebar - Sidebar grid area for chapter navigation
  *
  * Behavior by breakpoint:
- * - Portrait: collapsed to pill (not rendered in grid, use SidebarPill)
+ * - Portrait: collapsed (breadcrumb nav handles chapter switching)
  * - Landscape: persistent, collapsible (240-280px)
  * - Desktop: always persistent (260px)
  */
@@ -295,33 +295,6 @@ export function OverlayPanel({
         {children}
       </div>
     </div>
-  )
-}
-
-// -----------------------------------------------------------------------------
-// Collapsed Sidebar Pill
-// -----------------------------------------------------------------------------
-
-interface SidebarPillProps {
-  label: string
-  onClick: () => void
-}
-
-/**
- * SidebarPill - Collapsed sidebar indicator
- *
- * Shows "Ch X" pill when sidebar is collapsed in portrait mode.
- * Tapping opens the sidebar overlay.
- */
-export function SidebarPill({ label, onClick }: SidebarPillProps) {
-  return (
-    <button
-      onClick={onClick}
-      className="workspace-sidebar-pill"
-      aria-label={`${label}. Tap to open chapter list.`}
-    >
-      {label}
-    </button>
   )
 }
 


### PR DESCRIPTION
## Summary
- Remove the floating blue "Ch X" pill from the bottom-left corner — it's redundant now that the breadcrumb nav shows the current chapter and provides a chapter list popover
- Remove the `SidebarPill` component and its export from workspace-shell
- Update doc comments to reference breadcrumb nav instead of pill

## Test plan
- [x] `npm run verify` passes (531 tests)
- [ ] iPad portrait: No floating pill visible when sidebar is collapsed
- [ ] Chapter switching still works via breadcrumb popover in toolbar
- [ ] Desktop sidebar collapse/expand still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)