### PR TITLE
fix: editor content area blank after logo bar removal

### DIFF
--- a/web/src/app/(protected)/(editor)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/(editor)/editor/[projectId]/page.tsx
@@ -289,7 +289,7 @@ function EditorPageInner() {
   // --- Loading / Error states ---
   if (isLoading) {
     return (
-      <div className="flex h-[calc(100dvh-3.5rem)] items-center justify-center">
+      <div className="flex h-dvh items-center justify-center">
         <div className="text-muted-foreground">Loading project...</div>
       </div>
     )
@@ -297,7 +297,7 @@ function EditorPageInner() {
 
   if (error) {
     return (
-      <div className="flex h-[calc(100dvh-3.5rem)] items-center justify-center p-4">
+      <div className="flex h-dvh items-center justify-center p-4">
         <div className="text-center">
           <p className="text-red-600 mb-4">{error}</p>
           <button
@@ -314,7 +314,7 @@ function EditorPageInner() {
   return (
     <SourcesProvider projectId={projectId} editorRef={editorRef}>
       <SkipLink />
-      <div className="flex h-[calc(100dvh-3.5rem)]">
+      <div className="flex h-dvh">
         <OnboardingTooltips />
 
         {/* Screen reader announcements for panel state changes (#330) */}


### PR DESCRIPTION
## Summary
- Editor page used `h-[calc(100dvh-3.5rem)]` to subtract space for the DraftCrane header bar
- PR #471 removed that header bar but didn't update the height calc
- Content area rendered 56px shorter than the viewport, making the writing area invisible
- Fix: change to `h-dvh` (full viewport height, no subtraction)

## Test plan
- [x] `npm run verify` passes (531 tests)
- [ ] Editor page shows manuscript content below toolbar
- [ ] Writing area fills available space in both landscape and portrait

🤖 Generated with [Claude Code](https://claude.com/claude-code)