### PR TITLE
fix: add dedicated editor layout for proper full-viewport height

### DIFF
--- a/web/src/app/(protected)/(editor)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/(editor)/editor/[projectId]/page.tsx
@@ -289,7 +289,7 @@ function EditorPageInner() {
   // --- Loading / Error states ---
   if (isLoading) {
     return (
-      <div className="flex h-dvh items-center justify-center">
+      <div className="flex h-full items-center justify-center">
         <div className="text-muted-foreground">Loading project...</div>
       </div>
     )
@@ -297,7 +297,7 @@ function EditorPageInner() {
 
   if (error) {
     return (
-      <div className="flex h-dvh items-center justify-center p-4">
+      <div className="flex h-full items-center justify-center p-4">
         <div className="text-center">
           <p className="text-red-600 mb-4">{error}</p>
           <button
@@ -314,7 +314,7 @@ function EditorPageInner() {
   return (
     <SourcesProvider projectId={projectId} editorRef={editorRef}>
       <SkipLink />
-      <div className="flex h-dvh">
+      <div className="flex h-full">
         <OnboardingTooltips />
 
         {/* Screen reader announcements for panel state changes (#330) */}

--- a/web/src/app/(protected)/(editor)/layout.tsx
+++ b/web/src/app/(protected)/(editor)/layout.tsx
@@ -1,0 +1,14 @@
+interface EditorLayoutProps {
+  children: React.ReactNode
+}
+
+/**
+ * Editor layout — no header bar, full viewport height.
+ *
+ * The editor page manages its own toolbar and layout.
+ * This layout just ensures the content fills the viewport
+ * without the parent's flex/padding interfering.
+ */
+export default function EditorLayout({ children }: EditorLayoutProps) {
+  return <div className="h-dvh overflow-hidden">{children}</div>
+}


### PR DESCRIPTION
## Summary
- Previous fix (#472) changed `h-[calc(100dvh-3.5rem)]` → `h-dvh` but the content area remained blank
- Root cause: `h-dvh` inside the parent layout's `flex-1 main` with `pb-[env(safe-area-inset-bottom)]` creates a height conflict
- Fix: add `(editor)/layout.tsx` with `h-dvh overflow-hidden` as the proper viewport container, and change page to `h-full`

## Test plan
- [x] `npm run verify` passes (531 tests)
- [x] `next build` succeeds, `/editor/[projectId]` route resolves
- [ ] **CRITICAL: Visually verify editor content renders below toolbar**

🤖 Generated with [Claude Code](https://claude.com/claude-code)