### PR TITLE
feat: remove header from editor via conditional rendering

### DIFF
--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -289,7 +289,7 @@ function EditorPageInner() {
   // --- Loading / Error states ---
   if (isLoading) {
     return (
-      <div className="flex h-[calc(100dvh-3.5rem)] items-center justify-center">
+      <div className="flex h-dvh items-center justify-center">
         <div className="text-muted-foreground">Loading project...</div>
       </div>
     )
@@ -297,7 +297,7 @@ function EditorPageInner() {
 
   if (error) {
     return (
-      <div className="flex h-[calc(100dvh-3.5rem)] items-center justify-center p-4">
+      <div className="flex h-dvh items-center justify-center p-4">
         <div className="text-center">
           <p className="text-red-600 mb-4">{error}</p>
           <button
@@ -314,7 +314,7 @@ function EditorPageInner() {
   return (
     <SourcesProvider projectId={projectId} editorRef={editorRef}>
       <SkipLink />
-      <div className="flex h-[calc(100dvh-3.5rem)]">
+      <div className="flex h-dvh">
         <OnboardingTooltips />
 
         {/* Screen reader announcements for panel state changes (#330) */}
@@ -395,7 +395,6 @@ function EditorPageInner() {
               onSaveRetry={saveNow}
               viewMode={viewMode}
               onViewModeChange={handleViewModeChange}
-              isEditorPanelOpen={editorPanelOpen}
               onToggleEditorPanel={handleToggleEditorPanel}
               projectId={projectId}
               activeChapterId={activeChapterId}
@@ -408,6 +407,8 @@ function EditorPageInner() {
               onSignOut={handleSignOut}
               isSigningOut={isSigningOut}
               onChapterSelect={handleChapterSelect}
+              onToggleSidebar={() => setMobileOverlayOpen(!mobileOverlayOpen)}
+              isSidebarOpen={mobileOverlayOpen}
             />
           )}
 

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -1,7 +1,6 @@
 import { auth } from '@clerk/nextjs/server'
-import { UserButton } from '@clerk/nextjs'
 import { redirect } from 'next/navigation'
-import Link from 'next/link'
+import { AppHeader } from '@/components/layout/app-header'
 
 interface ProtectedLayoutProps {
   children: React.ReactNode
@@ -9,23 +8,10 @@ interface ProtectedLayoutProps {
 
 /**
  * Protected layout that requires authentication.
- * Per PRD Section 8:
- * - US-002: Returning user signs in and is taken directly to Writing Environment
- * - US-004: 30-day session lifetime (configured in Clerk Dashboard)
  *
- * Session expiry handling (US-004):
- * - When a session expires (after 30 days of inactivity), auth() returns no userId.
- * - This layout redirects to /sign-in cleanly with no error page or stale state.
- * - Returning users within the 30-day window are served directly without re-auth
- *   because the Clerk middleware refreshes the session token automatically.
- *
- * This layout wraps all authenticated routes and redirects to sign-in if not authenticated.
- * Includes a simple header with DraftCrane logo/title and user button for sign out.
- *
- * Design constraints:
- * - iPad Safari is primary target - use 100dvh not 100vh
- * - Touch targets minimum 44x44pt
- * - Account for safe-area-inset for Safari toolbar
+ * The AppHeader is a client component that conditionally renders
+ * based on pathname — hidden on /editor/* routes where the editor
+ * has its own toolbar, visible everywhere else.
  */
 export default async function ProtectedLayout({ children }: ProtectedLayoutProps) {
   const { userId } = await auth()
@@ -36,51 +22,7 @@ export default async function ProtectedLayout({ children }: ProtectedLayoutProps
 
   return (
     <div className="flex min-h-dvh flex-col bg-background">
-      {/* Header with safe area padding for iPad Safari */}
-      <header className="flex h-14 shrink-0 items-center justify-between border-b border-gray-200 px-4 pt-[env(safe-area-inset-top)]">
-        {/* Logo/Title - links to dashboard */}
-        <Link
-          href="/dashboard"
-          className="flex h-11 items-center font-serif text-xl font-semibold text-[var(--dc-color-text-primary)]"
-        >
-          DraftCrane
-        </Link>
-
-        {/* Right-side actions: help + user */}
-        <div className="flex items-center gap-2">
-          <Link
-            href="/help"
-            className="flex h-11 w-11 items-center justify-center rounded-lg hover:bg-[var(--dc-color-surface-tertiary)] transition-colors"
-            aria-label="Help"
-          >
-            <svg
-              className="h-5 w-5 text-[var(--dc-color-text-muted)]"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-          </Link>
-          <div className="flex h-11 w-11 items-center justify-center">
-            <UserButton
-              appearance={{
-                elements: {
-                  avatarBox: 'h-9 w-9',
-                  userButtonTrigger: 'h-11 w-11 flex items-center justify-center',
-                },
-              }}
-            />
-          </div>
-        </div>
-      </header>
-
-      {/* Main content area */}
+      <AppHeader />
       <main className="flex-1 pb-[env(safe-area-inset-bottom)]">{children}</main>
     </div>
   )

--- a/web/src/components/editor/breadcrumb-nav.tsx
+++ b/web/src/components/editor/breadcrumb-nav.tsx
@@ -77,7 +77,7 @@ export function BreadcrumbNav({
 
   return (
     <div className="relative flex items-center min-w-0" ref={dropdownRef}>
-      {/* Breadcrumb trigger */}
+      {/* Breadcrumb trigger — book title with chevron */}
       <button
         onClick={toggle}
         className="flex items-center gap-1.5 h-11 px-2 rounded-lg hover:bg-[var(--dc-color-surface-tertiary)] transition-colors min-w-0"
@@ -85,22 +85,6 @@ export function BreadcrumbNav({
         aria-haspopup="true"
         aria-label="Book navigation"
       >
-        {/* Outline icon */}
-        <svg
-          className="w-4 h-4 text-[var(--dc-color-text-muted)] shrink-0"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M4 6h16M4 12h16M4 18h16"
-          />
-        </svg>
-
         {/* Book title */}
         <span className="text-sm font-semibold text-[var(--dc-color-text-primary)] truncate max-w-[200px]">
           {currentProject.title}

--- a/web/src/components/editor/editor-toolbar.tsx
+++ b/web/src/components/editor/editor-toolbar.tsx
@@ -21,12 +21,11 @@ interface EditorToolbarProps {
   saveStatus: SaveStatus
   onSaveRetry: () => void
 
-  // View mode (#318)
+  // View mode
   viewMode: ViewMode
   onViewModeChange: (mode: ViewMode) => void
 
-  // Editor Panel (#317)
-  isEditorPanelOpen?: boolean
+  // Editor Panel (keyboard shortcut only — toggle lives in sidebar)
   onToggleEditorPanel?: () => void
 
   // Export
@@ -45,16 +44,20 @@ interface EditorToolbarProps {
 
   // Chapter navigation (for breadcrumb)
   onChapterSelect?: (chapterId: string) => void
+
+  // Sidebar
+  onToggleSidebar?: () => void
+  isSidebarOpen?: boolean
 }
 
 /**
- * EditorToolbar — Minimal top toolbar with spatial panel toggles and breadcrumb nav.
+ * EditorToolbar — Minimal toolbar per approved Stitch design.
  *
- * Layout: [✏️ Editor] — [≡ Book Title ▾ / Chapter] — [SaveIndicator] [⚙️] [📚 Library]
+ * Layout: [Logomark] [Book Title ▾ > Chapter] ... [Saved] [Export] [⚙️] [📚]
  *
- * The Editor toggle sits far-left, Library far-right, reinforcing the
- * spatial metaphor: left = AI editor, right = research library.
- * The breadcrumb replaces both the ProjectSwitcher and the Chapter/Book toggle.
+ * The logomark opens the sidebar overlay (navigation hub with chapters,
+ * AI Editor, Library access). The Library icon stays in the toolbar
+ * for quick access. Editor toggle is in the sidebar, not the toolbar.
  */
 export function EditorToolbar({
   projectData,
@@ -64,7 +67,6 @@ export function EditorToolbar({
   onSaveRetry,
   viewMode,
   onViewModeChange,
-  isEditorPanelOpen = false,
   onToggleEditorPanel,
   projectId,
   activeChapterId,
@@ -77,6 +79,8 @@ export function EditorToolbar({
   onSignOut,
   isSigningOut,
   onChapterSelect,
+  onToggleSidebar,
+  isSidebarOpen = false,
 }: EditorToolbarProps) {
   const { isPanelOpen, togglePanel, connections } = useSourcesContext()
   const [announcement, setAnnouncement] = useState('')
@@ -107,16 +111,10 @@ export function EditorToolbar({
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [onToggleEditorPanel, togglePanel, viewMode, onViewModeChange])
 
-  // aria-live announcements (#393)
   const announce = useCallback((msg: string) => {
     setAnnouncement('')
     requestAnimationFrame(() => setAnnouncement(msg))
   }, [])
-
-  const handleToggleEditor = useCallback(() => {
-    onToggleEditorPanel?.()
-    announce(isEditorPanelOpen ? 'Editor panel closed' : 'Editor panel opened')
-  }, [onToggleEditorPanel, isEditorPanelOpen, announce])
 
   const handleToggleLibrary = useCallback(() => {
     togglePanel()
@@ -131,7 +129,11 @@ export function EditorToolbar({
     [onChapterSelect, onViewModeChange]
   )
 
-  // Build chapter list for breadcrumb
+  const handleToggleSidebar = useCallback(() => {
+    onToggleSidebar?.()
+    announce(isSidebarOpen ? 'Navigation closed' : 'Navigation opened')
+  }, [onToggleSidebar, isSidebarOpen, announce])
+
   const chapters = projectData.chapters.map((ch) => ({
     id: ch.id,
     title: ch.title,
@@ -145,27 +147,26 @@ export function EditorToolbar({
       aria-label="Editor toolbar"
       aria-orientation="horizontal"
     >
-      {/* Far left: Editor panel toggle (icon only) */}
-      <div className="shrink-0">
-        {onToggleEditorPanel && (
-          <PanelToggleButton
-            label="Editor"
-            icon={
-              <svg fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-                />
-              </svg>
-            }
-            isOpen={isEditorPanelOpen}
-            onToggle={handleToggleEditor}
-            zone="editor"
-          />
-        )}
-      </div>
+      {/* Far left: Logomark — opens sidebar */}
+      <button
+        onClick={handleToggleSidebar}
+        className={`min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg transition-colors ${
+          isSidebarOpen
+            ? 'bg-[var(--dc-color-interactive-primary-subtle)]'
+            : 'hover:bg-[var(--dc-color-surface-tertiary)]'
+        }`}
+        aria-label={isSidebarOpen ? 'Close navigation' : 'Open navigation'}
+        aria-pressed={isSidebarOpen}
+      >
+        <svg
+          className="w-6 h-6 text-[var(--dc-color-interactive-primary)]"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-1 14.5v-9l5 4.5-5 4.5z" />
+        </svg>
+      </button>
 
       {/* Center: Breadcrumb navigation */}
       <div className="flex-1 flex items-center min-w-0 px-2">
@@ -188,7 +189,7 @@ export function EditorToolbar({
         />
       </div>
 
-      {/* Right cluster: Save + Export + Settings + Library toggle */}
+      {/* Right cluster: Save + Export + Settings + Library */}
       <div className="flex items-center gap-1 shrink-0">
         {viewMode !== 'book' && <SaveIndicator status={saveStatus} onRetry={onSaveRetry} />}
 
@@ -230,7 +231,7 @@ export function EditorToolbar({
         />
       </div>
 
-      {/* Screen reader announcements (#393) */}
+      {/* Screen reader announcements */}
       <div className="sr-only" aria-live="polite" aria-atomic="true">
         {announcement}
       </div>

--- a/web/src/components/layout/app-header.tsx
+++ b/web/src/components/layout/app-header.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { UserButton } from '@clerk/nextjs'
+import Link from 'next/link'
+
+/**
+ * App header — conditionally rendered based on route.
+ *
+ * Hidden on /editor/* routes where the editor has its own toolbar.
+ * Visible on dashboard, help, setup, and other pages.
+ */
+export function AppHeader() {
+  const pathname = usePathname()
+
+  if (pathname.startsWith('/editor/')) return null
+
+  return (
+    <header className="flex h-14 shrink-0 items-center justify-between border-b border-gray-200 px-4 pt-[env(safe-area-inset-top)]">
+      <Link
+        href="/dashboard"
+        className="flex h-11 items-center font-serif text-xl font-semibold text-[var(--dc-color-text-primary)]"
+      >
+        DraftCrane
+      </Link>
+
+      <div className="flex items-center gap-2">
+        <Link
+          href="/help"
+          className="flex h-11 w-11 items-center justify-center rounded-lg hover:bg-[var(--dc-color-surface-tertiary)] transition-colors"
+          aria-label="Help"
+        >
+          <svg
+            className="h-5 w-5 text-[var(--dc-color-text-muted)]"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </Link>
+        <div className="flex h-11 w-11 items-center justify-center">
+          <UserButton
+            appearance={{
+              elements: {
+                avatarBox: 'h-9 w-9',
+                userButtonTrigger: 'h-11 w-11 flex items-center justify-center',
+              },
+            }}
+          />
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/web/test/components/editor-toolbar.test.tsx
+++ b/web/test/components/editor-toolbar.test.tsx
@@ -5,8 +5,8 @@ import { EditorToolbar } from '@/components/editor/editor-toolbar'
 /**
  * Tests for EditorToolbar — the top toolbar for the writing environment.
  *
- * Contains: BreadcrumbNav (replaces ProjectSwitcher + WorkspaceToggle),
- * SaveIndicator, Editor panel toggle, Library toggle, ExportMenu, SettingsMenu.
+ * Contains: BreadcrumbNav, SaveIndicator, logomark/sidebar toggle,
+ * Library toggle, ExportMenu, SettingsMenu.
  *
  * Mock strategy: We mock all child components to isolate toolbar behavior.
  */
@@ -116,29 +116,27 @@ describe('EditorToolbar', () => {
   })
 
   // ────────────────────────────────────────────
-  // Editor Panel toggle button
+  // Logomark / sidebar toggle
   // ────────────────────────────────────────────
 
-  it('renders Editor panel toggle button when onToggleEditorPanel is provided', () => {
-    render(<EditorToolbar {...makeProps({ onToggleEditorPanel: vi.fn() })} />)
+  it('renders logomark sidebar toggle', () => {
+    render(<EditorToolbar {...makeProps({ onToggleSidebar: vi.fn() })} />)
 
-    expect(screen.getByLabelText('Open editor panel')).toBeInTheDocument()
+    expect(screen.getByLabelText('Open navigation')).toBeInTheDocument()
   })
 
-  it('calls onToggleEditorPanel when Editor button is clicked', () => {
-    const onToggleEditorPanel = vi.fn()
-    render(<EditorToolbar {...makeProps({ onToggleEditorPanel })} />)
+  it('calls onToggleSidebar when logomark is clicked', () => {
+    const onToggleSidebar = vi.fn()
+    render(<EditorToolbar {...makeProps({ onToggleSidebar })} />)
 
-    fireEvent.click(screen.getByLabelText('Open editor panel'))
-    expect(onToggleEditorPanel).toHaveBeenCalledTimes(1)
+    fireEvent.click(screen.getByLabelText('Open navigation'))
+    expect(onToggleSidebar).toHaveBeenCalledTimes(1)
   })
 
-  it('shows active state when editor panel is open', () => {
-    render(
-      <EditorToolbar {...makeProps({ isEditorPanelOpen: true, onToggleEditorPanel: vi.fn() })} />
-    )
+  it('shows active state when sidebar is open', () => {
+    render(<EditorToolbar {...makeProps({ isSidebarOpen: true, onToggleSidebar: vi.fn() })} />)
 
-    expect(screen.getByLabelText('Close editor panel')).toBeInTheDocument()
+    expect(screen.getByLabelText('Close navigation')).toBeInTheDocument()
   })
 
   // ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extract header into `AppHeader` client component that uses `usePathname()` to hide on `/editor/*` routes — avoids the route group split that broke the editor in #471-#473
- Editor page uses `h-dvh` (full viewport height) since no header is present
- Toolbar redesigned per approved Stitch screens: logomark sidebar toggle replaces editor panel toggle, breadcrumb hamburger icon removed

## Context
PR #471 attempted this by splitting `(protected)/` into `(editor)/` and `(with-header)/` route groups. The editor content area went completely blank. Two fix attempts (#472, #473) failed. PR #474 reverted everything. This PR takes a simpler approach — conditional rendering via `usePathname()` — which avoids moving files between directories and the associated Next.js routing issues.

## Test plan
- [x] `npm run verify` passes (typecheck, format, lint, 531 tests)
- [x] `next build` compiles all routes successfully
- [ ] Visual: editor page has no DraftCrane header bar, full viewport height
- [ ] Visual: dashboard/help/setup pages still show the header
- [ ] Visual: logomark button in toolbar opens sidebar overlay
- [ ] Visual: breadcrumb shows book title > chapter without hamburger icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)