### PR TITLE
feat: swap fonts from Geist/Lora to Inter/Newsreader

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -109,8 +109,8 @@
    * ================================================================ */
 
   /* Font stacks */
-  --dc-font-sans: var(--font-geist-sans), ui-sans-serif, system-ui, sans-serif;
-  --dc-font-serif: var(--font-lora), ui-serif, Georgia, serif;
+  --dc-font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+  --dc-font-serif: var(--font-newsreader), ui-serif, Georgia, serif;
   --dc-font-mono: var(--font-geist-mono), ui-monospace, monospace;
 
   /* Text sizes */

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,10 +1,10 @@
 import type { Metadata, Viewport } from 'next'
-import { Geist, Geist_Mono, Lora } from 'next/font/google'
+import { Inter, Newsreader, Geist_Mono } from 'next/font/google'
 import './globals.css'
 import { Providers } from './providers'
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const inter = Inter({
+  variable: '--font-inter',
   subsets: ['latin'],
 })
 
@@ -13,8 +13,8 @@ const geistMono = Geist_Mono({
   subsets: ['latin'],
 })
 
-const lora = Lora({
-  variable: '--font-lora',
+const newsreader = Newsreader({
+  variable: '--font-newsreader',
   subsets: ['latin'],
   weight: ['400', '500', '600', '700'],
 })
@@ -54,7 +54,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} ${lora.variable} antialiased`}>
+      <body
+        className={`${inter.variable} ${geistMono.variable} ${newsreader.variable} antialiased`}
+      >
         <Providers>{children}</Providers>
       </body>
     </html>


### PR DESCRIPTION
## Summary
- Replace Geist Sans → Inter (UI sans-serif)
- Replace Lora → Newsreader (literary serif for headlines and editor body)
- Geist Mono unchanged (code/technical)
- 2 files changed: `layout.tsx` (font imports) and `globals.css` (token references)

## Why
Per the approved Stitch design direction — warm literary aesthetic with Newsreader headlines and Inter body text. This is PR 2 of 5 in the design adoption plan.

## iPad QA Gate
**This PR has a mandatory iPad Safari QA requirement before merge.** Newsreader has different metrics than Lora (x-height, ascender/descender ratios, kerning). In a book-writing app, the manuscript rendering feel is the product.

Please verify on iPad Safari:
- [ ] Editor writing area: Newsreader at 18px reads well for manuscript composition
- [ ] Chapter sidebar: Inter renders cleanly for navigation
- [ ] Toolbar: breadcrumb text doesn't truncate unexpectedly
- [ ] Landing page / dashboard: headings render properly

If Newsreader feels off at 18px, line-height or font-size tuning in `editor.css` may be needed before merge.

## Test plan
- [x] `npm run verify` passes (531 tests, typecheck, lint, format)
- [ ] iPad Safari visual QA (mandatory gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)