### PR TITLE
refactor: polish editor chrome and migrate shorthand classes

### DIFF
--- a/web/src/app/(protected)/dashboard/page.tsx
+++ b/web/src/app/(protected)/dashboard/page.tsx
@@ -134,7 +134,7 @@ export default function DashboardPage() {
   if (isLoadingProjects) {
     return (
       <div className="flex min-h-[60vh] items-center justify-center">
-        <div className="text-muted-foreground">Loading...</div>
+        <div className="text-[var(--dc-color-text-muted)]">Loading...</div>
       </div>
     )
   }
@@ -164,10 +164,10 @@ export default function DashboardPage() {
     return (
       <div className="flex min-h-[60vh] flex-col items-center justify-center p-6">
         <div className="text-center max-w-md">
-          <h1 className="font-serif text-3xl font-semibold text-foreground mb-2">
+          <h1 className="font-serif text-3xl font-semibold text-[var(--dc-color-text-primary)] mb-2">
             Welcome to DraftCrane
           </h1>
-          <p className="text-muted-foreground mb-8">
+          <p className="text-[var(--dc-color-text-muted)] mb-8">
             A quiet place to write and shape your nonfiction book, chapter by chapter.
           </p>
 
@@ -233,7 +233,9 @@ export default function DashboardPage() {
     <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8">
       {/* Header */}
       <div className="flex items-center justify-between mb-8">
-        <h1 className="font-serif text-2xl font-semibold text-foreground">Your Books</h1>
+        <h1 className="font-serif text-2xl font-semibold text-[var(--dc-color-text-primary)]">
+          Your Books
+        </h1>
         <Link
           href="/setup"
           className="inline-flex h-11 items-center justify-center rounded-lg bg-[var(--dc-color-text-primary)] px-5 text-sm font-medium text-[var(--dc-color-text-inverse)] hover:bg-[var(--dc-color-text-secondary)] transition-colors"
@@ -251,10 +253,10 @@ export default function DashboardPage() {
           >
             {/* Clickable card body */}
             <Link href={`/editor/${project.id}`} className="block min-h-[100px]">
-              <h2 className="font-serif text-lg font-semibold text-foreground truncate pr-8">
+              <h2 className="font-serif text-lg font-semibold text-[var(--dc-color-text-primary)] truncate pr-8">
                 {project.title}
               </h2>
-              <div className="mt-2 flex items-center gap-3 text-sm text-muted-foreground">
+              <div className="mt-2 flex items-center gap-3 text-sm text-[var(--dc-color-text-muted)]">
                 <span>
                   {project.chapterCount} {project.chapterCount === 1 ? 'chapter' : 'chapters'}
                 </span>

--- a/web/src/app/(protected)/drive/error/page.tsx
+++ b/web/src/app/(protected)/drive/error/page.tsx
@@ -45,11 +45,11 @@ function DriveErrorContent() {
           </svg>
         </div>
 
-        <h1 className="font-serif text-3xl font-semibold text-foreground mb-2">
+        <h1 className="font-serif text-3xl font-semibold text-[var(--dc-color-text-primary)] mb-2">
           Drive Connection Issue
         </h1>
 
-        <p className="text-muted-foreground">{errorMessage}</p>
+        <p className="text-[var(--dc-color-text-muted)]">{errorMessage}</p>
 
         <div className="mt-6 flex flex-col items-center gap-3">
           <button
@@ -59,7 +59,7 @@ function DriveErrorContent() {
             Back to DraftCrane
           </button>
 
-          <p className="text-sm text-muted-foreground">
+          <p className="text-sm text-[var(--dc-color-text-muted)]">
             You can connect Google Drive anytime from the editor.
           </p>
         </div>
@@ -73,7 +73,7 @@ export default function DriveErrorPage() {
     <Suspense
       fallback={
         <div className="flex min-h-[60vh] items-center justify-center">
-          <div className="text-muted-foreground">Loading...</div>
+          <div className="text-[var(--dc-color-text-muted)]">Loading...</div>
         </div>
       }
     >

--- a/web/src/app/(protected)/drive/success/page.tsx
+++ b/web/src/app/(protected)/drive/success/page.tsx
@@ -171,23 +171,24 @@ export default function DriveSuccessPage() {
           </svg>
         </div>
 
-        <h1 className="font-serif text-3xl font-semibold text-foreground mb-2">
+        <h1 className="font-serif text-3xl font-semibold text-[var(--dc-color-text-primary)] mb-2">
           Google Drive Connected
         </h1>
 
         {isLoadingDrive ? (
-          <p className="text-muted-foreground">Verifying connection...</p>
+          <p className="text-[var(--dc-color-text-muted)]">Verifying connection...</p>
         ) : isConnected ? (
-          <p className="text-muted-foreground">
-            Connected as <span className="font-medium text-foreground">{displayEmail}</span>.
+          <p className="text-[var(--dc-color-text-muted)]">
+            Connected as{' '}
+            <span className="font-medium text-[var(--dc-color-text-primary)]">{displayEmail}</span>.
           </p>
         ) : (
-          <p className="text-muted-foreground">Your Google Drive is now connected.</p>
+          <p className="text-[var(--dc-color-text-muted)]">Your Google Drive is now connected.</p>
         )}
 
         {sourceLinkProjectId && (
           <div className="mt-4">
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-[var(--dc-color-text-muted)]">
               {linkComplete
                 ? 'Source connected. Redirecting to your book...'
                 : 'Connecting source...'}

--- a/web/src/app/(protected)/editor/[projectId]/error.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/error.tsx
@@ -16,7 +16,9 @@ export default function EditorError({
   return (
     <div className="flex h-[calc(100dvh-3.5rem)] items-center justify-center p-4">
       <div className="text-center max-w-md">
-        <h2 className="text-lg font-semibold text-foreground mb-2">Something went wrong</h2>
+        <h2 className="text-lg font-semibold text-[var(--dc-color-text-primary)] mb-2">
+          Something went wrong
+        </h2>
         <p className="text-sm text-[var(--dc-color-status-error)] mb-4 font-mono break-all">
           {error.message}
         </p>

--- a/web/src/app/(protected)/editor/[projectId]/page.tsx
+++ b/web/src/app/(protected)/editor/[projectId]/page.tsx
@@ -290,7 +290,7 @@ function EditorPageInner() {
   if (isLoading) {
     return (
       <div className="flex h-dvh items-center justify-center">
-        <div className="text-muted-foreground">Loading project...</div>
+        <div className="text-[var(--dc-color-text-muted)]">Loading project...</div>
       </div>
     )
   }

--- a/web/src/app/(protected)/layout.tsx
+++ b/web/src/app/(protected)/layout.tsx
@@ -21,7 +21,7 @@ export default async function ProtectedLayout({ children }: ProtectedLayoutProps
   }
 
   return (
-    <div className="flex min-h-dvh flex-col bg-background">
+    <div className="flex min-h-dvh flex-col bg-[var(--dc-color-surface-primary)]">
       <AppHeader />
       <main className="flex-1 pb-[env(safe-area-inset-bottom)]">{children}</main>
     </div>

--- a/web/src/app/(protected)/setup/page.tsx
+++ b/web/src/app/(protected)/setup/page.tsx
@@ -77,13 +77,13 @@ export default function SetupPage() {
   }
 
   return (
-    <div className="min-h-dvh flex items-center justify-center p-4 bg-background">
+    <div className="min-h-dvh flex items-center justify-center p-4 bg-[var(--dc-color-surface-primary)]">
       <div className="w-full max-w-lg">
         <div className="text-center mb-8">
-          <h1 className="font-serif text-3xl font-semibold text-foreground mb-2">
+          <h1 className="font-serif text-3xl font-semibold text-[var(--dc-color-text-primary)] mb-2">
             Create Your Book
           </h1>
-          <p className="text-muted-foreground">
+          <p className="text-[var(--dc-color-text-muted)]">
             Give your book a working title. You can change it anytime.
           </p>
         </div>
@@ -91,7 +91,10 @@ export default function SetupPage() {
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* Title field */}
           <div className="space-y-2">
-            <label htmlFor="title" className="block text-sm font-medium text-foreground">
+            <label
+              htmlFor="title"
+              className="block text-sm font-medium text-[var(--dc-color-text-primary)]"
+            >
               Book Title <span className="text-[var(--dc-color-status-error)]">*</span>
             </label>
             <input
@@ -100,8 +103,8 @@ export default function SetupPage() {
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder="Enter your book title"
-              className="w-full px-4 py-3 rounded-lg border border-border bg-background text-foreground
-                         placeholder:text-muted-foreground
+              className="w-full px-4 py-3 rounded-lg border border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-primary)] text-[var(--dc-color-text-primary)]
+                         placeholder:text-[var(--dc-color-text-placeholder)]
                          focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-border-focus)] focus:border-transparent
                          transition-all"
               maxLength={500}
@@ -109,12 +112,12 @@ export default function SetupPage() {
               aria-describedby="title-help title-count"
             />
             <div className="flex justify-between items-center text-sm">
-              <p id="title-help" className="text-muted-foreground">
+              <p id="title-help" className="text-[var(--dc-color-text-muted)]">
                 This is a working title. You can change it anytime.
               </p>
               <span
                 id="title-count"
-                className={`tabular-nums ${titleLength > 450 ? 'text-[var(--dc-color-status-warning)]' : 'text-muted-foreground'} ${titleLength > 500 ? 'text-[var(--dc-color-status-error)]' : ''}`}
+                className={`tabular-nums ${titleLength > 450 ? 'text-[var(--dc-color-status-warning)]' : 'text-[var(--dc-color-text-muted)]'} ${titleLength > 500 ? 'text-[var(--dc-color-status-error)]' : ''}`}
               >
                 {titleLength}/500
               </span>
@@ -123,8 +126,11 @@ export default function SetupPage() {
 
           {/* Description field */}
           <div className="space-y-2">
-            <label htmlFor="description" className="block text-sm font-medium text-foreground">
-              Description <span className="text-muted-foreground">(optional)</span>
+            <label
+              htmlFor="description"
+              className="block text-sm font-medium text-[var(--dc-color-text-primary)]"
+            >
+              Description <span className="text-[var(--dc-color-text-muted)]">(optional)</span>
             </label>
             <textarea
               id="description"
@@ -132,8 +138,8 @@ export default function SetupPage() {
               onChange={(e) => setDescription(e.target.value)}
               placeholder="A brief description of what your book is about"
               rows={3}
-              className="w-full px-4 py-3 rounded-lg border border-border bg-background text-foreground
-                         placeholder:text-muted-foreground
+              className="w-full px-4 py-3 rounded-lg border border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-primary)] text-[var(--dc-color-text-primary)]
+                         placeholder:text-[var(--dc-color-text-placeholder)]
                          focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-border-focus)] focus:border-transparent
                          transition-all resize-none"
               maxLength={1000}
@@ -142,7 +148,7 @@ export default function SetupPage() {
             <div className="flex justify-end">
               <span
                 id="description-count"
-                className={`text-sm tabular-nums ${descriptionLength > 900 ? 'text-[var(--dc-color-status-warning)]' : 'text-muted-foreground'} ${descriptionLength > 1000 ? 'text-[var(--dc-color-status-error)]' : ''}`}
+                className={`text-sm tabular-nums ${descriptionLength > 900 ? 'text-[var(--dc-color-status-warning)]' : 'text-[var(--dc-color-text-muted)]'} ${descriptionLength > 1000 ? 'text-[var(--dc-color-status-error)]' : ''}`}
               >
                 {descriptionLength}/1000
               </span>
@@ -172,7 +178,7 @@ export default function SetupPage() {
           </button>
         </form>
 
-        <p className="mt-6 text-center text-sm text-muted-foreground">
+        <p className="mt-6 text-center text-sm text-[var(--dc-color-text-muted)]">
           Your first chapter will be waiting for you.
         </p>
       </div>

--- a/web/src/components/editor/editor-panel.tsx
+++ b/web/src/components/editor/editor-panel.tsx
@@ -70,14 +70,14 @@ export function EditorPanel({
 
   return (
     <div
-      className={`hidden lg:flex editor-panel w-[320px] h-full flex-col border-r border-[var(--color-border)] bg-[var(--color-background)] shrink-0
+      className={`hidden lg:flex editor-panel w-[320px] h-full flex-col border-r border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-secondary)] shrink-0
                   ${isClosing ? 'editor-panel-slide-out' : 'editor-panel-slide-in'}`}
       role="complementary"
       aria-label={title}
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 h-12 border-b border-[var(--color-border)] shrink-0">
-        <h2 className="text-sm font-semibold text-[var(--color-foreground)]">{title}</h2>
+      <div className="flex items-center justify-between px-4 h-12 border-b border-[var(--dc-color-border-default)] shrink-0">
+        <h2 className="text-sm font-semibold text-[var(--dc-color-text-primary)]">{title}</h2>
         <button
           type="button"
           onClick={onClose}
@@ -165,14 +165,14 @@ export function EditorPanelOverlay({
       <div
         ref={panelRef}
         className={`editor-panel-overlay fixed inset-y-0 left-0 z-50 w-full max-w-[380px]
-                   bg-[var(--color-background)] shadow-xl flex flex-col lg:hidden
+                   bg-[var(--dc-color-surface-secondary)] shadow-xl flex flex-col lg:hidden
                    ${isClosing ? 'editor-panel-slide-out' : 'editor-panel-slide-in'}`}
         role="complementary"
         aria-label={title}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 h-12 border-b border-[var(--color-border)] shrink-0">
-          <h2 className="text-sm font-semibold text-[var(--color-foreground)]">{title}</h2>
+        <div className="flex items-center justify-between px-4 h-12 border-b border-[var(--dc-color-border-default)] shrink-0">
+          <h2 className="text-sm font-semibold text-[var(--dc-color-text-primary)]">{title}</h2>
           <button
             type="button"
             onClick={onClose}

--- a/web/src/components/editor/editor-writing-area.tsx
+++ b/web/src/components/editor/editor-writing-area.tsx
@@ -74,14 +74,14 @@ export function EditorWritingArea({
               if (e.key === 'Enter') onTitleSave()
               if (e.key === 'Escape') onTitleEditCancel()
             }}
-            className="text-3xl font-semibold text-foreground mb-6 outline-none w-full
+            className="text-3xl font-semibold text-[var(--dc-color-text-primary)] mb-6 outline-none w-full
                        border-b-2 border-[var(--dc-color-interactive-primary)] bg-transparent"
             autoFocus
             maxLength={200}
           />
         ) : (
           <h1
-            className="text-3xl font-semibold text-foreground mb-6 outline-none cursor-text
+            className="text-3xl font-semibold text-[var(--dc-color-text-primary)] mb-6 outline-none cursor-text
                        hover:bg-[var(--dc-color-surface-secondary)] focus:bg-[var(--dc-color-surface-secondary)] focus:ring-2 focus:ring-[var(--dc-color-border-focus)]
                        rounded px-1 -mx-1 transition-colors"
             onClick={onTitleEdit}
@@ -110,7 +110,7 @@ export function EditorWritingArea({
         />
 
         <div className="mt-4 flex items-center justify-end">
-          <span className="text-sm text-muted-foreground tabular-nums">
+          <span className="text-sm text-[var(--dc-color-text-muted)] tabular-nums">
             {selectionWordCount > 0
               ? `${selectionWordCount.toLocaleString()} / ${currentWordCount.toLocaleString()} words`
               : `${currentWordCount.toLocaleString()} words`}

--- a/web/src/components/editor/save-indicator.tsx
+++ b/web/src/components/editor/save-indicator.tsx
@@ -41,14 +41,14 @@ export function SaveIndicator({ status, onRetry }: SaveIndicatorProps) {
 function getStatusDisplay(status: SaveStatus): { text: string; className: string } {
   switch (status.state) {
     case 'idle':
-      return { text: '', className: 'text-muted-foreground' }
+      return { text: '', className: 'text-[var(--dc-color-text-muted)]' }
 
     case 'saving':
       return { text: 'Saving\u2026', className: 'text-[var(--dc-color-interactive-primary)]' }
 
     case 'saved': {
       const timeStr = formatTime(status.at)
-      return { text: `Saved ${timeStr}`, className: 'text-muted-foreground' }
+      return { text: `Saved ${timeStr}`, className: 'text-[var(--dc-color-text-muted)]' }
     }
 
     case 'error':

--- a/web/src/components/editor/workspace-toggle.tsx
+++ b/web/src/components/editor/workspace-toggle.tsx
@@ -110,7 +110,7 @@ function ToggleOption({ label, value, isSelected, onSelect }: ToggleOptionProps)
       className={`relative z-10 flex items-center justify-center px-3 h-10 min-w-[72px]
                  text-sm font-medium rounded-md transition-colors duration-200
                  focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--dc-color-border-focus)] focus-visible:ring-offset-1
-                 ${isSelected ? 'text-foreground' : 'text-[var(--dc-color-text-secondary)] hover:text-foreground'}`}
+                 ${isSelected ? 'text-[var(--dc-color-text-primary)]' : 'text-[var(--dc-color-text-secondary)] hover:text-[var(--dc-color-text-primary)]'}`}
       aria-label={`${label} view${isSelected ? ' (selected)' : ''}`}
       data-view={value}
     >

--- a/web/src/components/layout/app-header.tsx
+++ b/web/src/components/layout/app-header.tsx
@@ -16,7 +16,7 @@ export function AppHeader() {
   if (pathname.startsWith('/editor/')) return null
 
   return (
-    <header className="flex h-14 shrink-0 items-center justify-between border-b border-[var(--dc-color-border-default)] px-4 pt-[env(safe-area-inset-top)]">
+    <header className="flex h-14 shrink-0 items-center justify-between border-b border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-primary)] px-4 pt-[env(safe-area-inset-top)]">
       <Link
         href="/dashboard"
         className="flex h-11 items-center font-serif text-xl font-semibold text-[var(--dc-color-text-primary)]"

--- a/web/src/components/layout/sidebar.tsx
+++ b/web/src/components/layout/sidebar.tsx
@@ -231,13 +231,13 @@ export function Sidebar({
   return (
     <aside
       className="flex flex-col h-full w-[260px] min-w-[240px] max-w-[280px]
-                 bg-[var(--dc-color-surface-secondary)] border-r border-border"
+                 bg-[var(--dc-color-surface-secondary)] border-r border-[var(--dc-color-border-default)]"
       role="navigation"
       aria-label="Chapter navigation"
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
-        <h2 className="text-sm font-semibold text-foreground">Chapters</h2>
+      <div className="flex items-center justify-between px-4 py-3 border-b border-[var(--dc-color-border-default)]">
+        <h2 className="text-sm font-semibold text-[var(--dc-color-text-primary)]">Chapters</h2>
         <button
           onClick={onToggleCollapsed}
           className="p-2 rounded-lg hover:bg-[var(--dc-color-surface-tertiary)]
@@ -255,7 +255,7 @@ export function Sidebar({
             strokeWidth="2"
             strokeLinecap="round"
             strokeLinejoin="round"
-            className="text-muted-foreground"
+            className="text-[var(--dc-color-text-muted)]"
           >
             <polyline points="15 18 9 12 15 6" />
           </svg>
@@ -330,11 +330,11 @@ export function Sidebar({
       </DndContext>
 
       {/* Add chapter button */}
-      <div className="px-4 py-2 border-t border-border">
+      <div className="px-4 py-2 border-t border-[var(--dc-color-border-default)]">
         <button
           onClick={onAddChapter}
           className="w-full py-3 px-4 rounded-lg border border-dashed border-[var(--dc-color-border-strong)]
-                     text-muted-foreground hover:border-[var(--dc-color-interactive-primary)] hover:text-[var(--dc-color-interactive-primary)]
+                     text-[var(--dc-color-text-muted)] hover:border-[var(--dc-color-interactive-primary)] hover:text-[var(--dc-color-interactive-primary)]
                      focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-border-focus)]
                      transition-colors flex items-center justify-center gap-2
                      min-h-[48px]"
@@ -359,10 +359,10 @@ export function Sidebar({
       </div>
 
       {/* Total word count */}
-      <div className="px-4 py-3 border-t border-border bg-[var(--dc-color-surface-tertiary)]">
+      <div className="px-4 py-3 border-t border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-tertiary)]">
         <div className="flex items-center justify-between text-sm">
-          <span className="text-muted-foreground">Total</span>
-          <span className="font-medium text-foreground tabular-nums">
+          <span className="text-[var(--dc-color-text-muted)]">Total</span>
+          <span className="font-medium text-[var(--dc-color-text-primary)] tabular-nums">
             {formatWordCount(effectiveTotalWordCount)} words
           </span>
         </div>
@@ -457,14 +457,14 @@ function ChapterListItem({
   return (
     <div
       className={`group w-full flex items-center min-h-[48px] transition-colors
-                 ${isActive ? 'bg-[var(--dc-color-interactive-primary-subtle)] text-[var(--dc-color-interactive-primary-on-subtle)]' : 'hover:bg-[var(--dc-color-surface-tertiary)] text-foreground'}
+                 ${isActive ? 'bg-[var(--dc-color-interactive-primary-subtle)] text-[var(--dc-color-interactive-primary-on-subtle)]' : 'hover:bg-[var(--dc-color-surface-tertiary)] text-[var(--dc-color-text-primary)]'}
                  ${isDragOverlay ? 'shadow-lg rounded-lg bg-[var(--dc-color-surface-primary)] border border-[var(--dc-color-interactive-primary-border)]' : ''}`}
       role="listitem"
     >
       {/* Drag handle */}
       <button
         className="flex items-center justify-center w-6 shrink-0 ml-1 cursor-grab
-                   text-muted-foreground hover:text-foreground transition-colors
+                   text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-text-primary)] transition-colors
                    touch-none select-none"
         aria-label={`Drag to reorder ${chapter.title || 'Untitled Chapter'}`}
         tabIndex={-1}
@@ -504,7 +504,9 @@ function ChapterListItem({
         </div>
         <span
           className={`ml-2 text-xs tabular-nums ${
-            isActive ? 'text-[var(--dc-color-interactive-primary-hover)]' : 'text-muted-foreground'
+            isActive
+              ? 'text-[var(--dc-color-interactive-primary-hover)]'
+              : 'text-[var(--dc-color-text-muted)]'
           }`}
         >
           {formatWordCount(displayWordCount)}w
@@ -519,7 +521,7 @@ function ChapterListItem({
             onDelete()
           }}
           className="mr-2 p-1.5 rounded opacity-0 group-hover:opacity-100 focus:opacity-100
-                     hover:bg-[var(--dc-color-interactive-destructive-subtle)] text-muted-foreground
+                     hover:bg-[var(--dc-color-interactive-destructive-subtle)] text-[var(--dc-color-text-muted)]
                      hover:text-[var(--dc-color-interactive-destructive)] transition-all
                      focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-interactive-destructive)]
                      min-w-[32px] min-h-[32px] flex items-center justify-center shrink-0"
@@ -598,7 +600,7 @@ function InlineRenameInput({
     <div
       className={`w-full px-4 py-3 flex items-center justify-between
                  min-h-[48px] transition-colors
-                 ${isActive ? 'bg-[var(--dc-color-interactive-primary-subtle)] text-[var(--dc-color-interactive-primary-on-subtle)]' : 'bg-[var(--dc-color-surface-tertiary)] text-foreground'}`}
+                 ${isActive ? 'bg-[var(--dc-color-interactive-primary-subtle)] text-[var(--dc-color-interactive-primary-on-subtle)]' : 'bg-[var(--dc-color-surface-tertiary)] text-[var(--dc-color-text-primary)]'}`}
       role="listitem"
     >
       <input
@@ -616,7 +618,9 @@ function InlineRenameInput({
       />
       <span
         className={`ml-2 text-xs tabular-nums shrink-0 ${
-          isActive ? 'text-[var(--dc-color-interactive-primary-hover)]' : 'text-muted-foreground'
+          isActive
+            ? 'text-[var(--dc-color-interactive-primary-hover)]'
+            : 'text-[var(--dc-color-text-muted)]'
         }`}
       >
         {formatWordCount(displayWordCount)}w

--- a/web/src/components/project/project-switcher.tsx
+++ b/web/src/components/project/project-switcher.tsx
@@ -47,9 +47,11 @@ export function ProjectSwitcher({ currentProject, projects }: ProjectSwitcherPro
         aria-expanded={isOpen}
         aria-haspopup="listbox"
       >
-        <span className="text-sm font-medium text-foreground truncate">{currentProject.title}</span>
+        <span className="text-sm font-medium text-[var(--dc-color-text-primary)] truncate">
+          {currentProject.title}
+        </span>
         <svg
-          className={`w-4 h-4 text-muted-foreground transition-transform ${isOpen ? 'rotate-180' : ''}`}
+          className={`w-4 h-4 text-[var(--dc-color-text-muted)] transition-transform ${isOpen ? 'rotate-180' : ''}`}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -61,7 +63,7 @@ export function ProjectSwitcher({ currentProject, projects }: ProjectSwitcherPro
       {/* Dropdown menu */}
       {isOpen && (
         <div
-          className="absolute top-full left-0 mt-1 w-64 bg-[var(--dc-color-surface-primary)] border border-border rounded-lg shadow-lg z-50 py-1"
+          className="absolute top-full left-0 mt-1 w-64 bg-[var(--dc-color-surface-primary)] border border-[var(--dc-color-border-default)] rounded-lg shadow-lg z-50 py-1"
           role="listbox"
         >
           {/* Project list */}
@@ -76,11 +78,11 @@ export function ProjectSwitcher({ currentProject, projects }: ProjectSwitcherPro
               aria-selected={project.id === currentProject.id}
             >
               <div className="min-w-0 flex-1">
-                <span className="block text-sm font-medium text-foreground truncate">
+                <span className="block text-sm font-medium text-[var(--dc-color-text-primary)] truncate">
                   {project.title}
                 </span>
               </div>
-              <span className="ml-2 text-xs text-muted-foreground tabular-nums shrink-0">
+              <span className="ml-2 text-xs text-[var(--dc-color-text-muted)] tabular-nums shrink-0">
                 {project.wordCount.toLocaleString()}w
               </span>
               {project.id === currentProject.id && (
@@ -102,7 +104,7 @@ export function ProjectSwitcher({ currentProject, projects }: ProjectSwitcherPro
           ))}
 
           {/* Separator */}
-          <div className="border-t border-border my-1" />
+          <div className="border-t border-[var(--dc-color-border-default)] my-1" />
 
           {/* New project link */}
           <Link

--- a/web/src/components/project/settings-menu.tsx
+++ b/web/src/components/project/settings-menu.tsx
@@ -52,7 +52,7 @@ export function SettingsMenu({
         aria-haspopup="true"
       >
         <svg
-          className="w-5 h-5 text-muted-foreground"
+          className="w-5 h-5 text-[var(--dc-color-text-muted)]"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/web/src/components/sources/sources-panel-overlay.tsx
+++ b/web/src/components/sources/sources-panel-overlay.tsx
@@ -42,13 +42,13 @@ export function SourcesPanelOverlay() {
       <div
         ref={panelRef}
         className={`sources-panel-overlay fixed inset-y-0 right-0 z-50 w-full max-w-[380px]
-                   bg-background shadow-xl flex flex-col lg:hidden ${isClosing ? 'sources-panel-slide-out' : 'sources-panel-slide-in'}`}
+                   bg-[var(--dc-color-surface-primary)] shadow-xl flex flex-col lg:hidden ${isClosing ? 'sources-panel-slide-out' : 'sources-panel-slide-in'}`}
         role="dialog"
         aria-modal="true"
         aria-label="Library panel"
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-4 h-12 border-b border-border shrink-0">
+        <div className="flex items-center justify-between px-4 h-12 border-b border-[var(--dc-color-border-default)] shrink-0">
           <div className="flex items-center gap-1">
             {tabs.map((tab) => (
               <button

--- a/web/src/components/sources/sources-panel.tsx
+++ b/web/src/components/sources/sources-panel.tsx
@@ -45,9 +45,9 @@ export function SourcesPanel() {
   if (!isPanelOpen) return null
 
   return (
-    <div className="hidden lg:flex sources-panel w-[320px] h-full flex-col border-l border-border bg-background shrink-0">
+    <div className="hidden lg:flex sources-panel w-[320px] h-full flex-col border-l border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-secondary)] shrink-0">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 h-12 border-b border-border shrink-0">
+      <div className="flex items-center justify-between px-4 h-12 border-b border-[var(--dc-color-border-default)] shrink-0">
         <div className="flex items-center gap-1">
           {tabs.map((tab) => (
             <button


### PR DESCRIPTION
## Summary
- Migrate ~52 legacy Tailwind shorthand classes (`text-foreground`, `text-muted-foreground`, `bg-background`, `border-border`) to explicit `--dc-color-*` tokens across 17 files
- Polish editor chrome: panels get `surface-secondary` background for subtle distinction from writing surface
- App header gets explicit warm background
- All styling now flows exclusively through the `dc-color-*` token system

## Why
After the token swap (PR #480), these legacy Tailwind shorthands were using Tailwind's implicit defaults rather than our explicit design tokens. This completes the token migration — every color in the product now flows through `globals.css` `:root`.

## Test plan
- [x] `npm run verify` passes (531 tests, typecheck, lint, format)
- [x] Zero legacy shorthand color classes remaining
- [ ] Visual check: editor panels have subtle background distinction from writing surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)