### PR TITLE
feat: redesign setup page to match Stitch warm literary design

### DIFF
--- a/.stitch/SCREENS.md
+++ b/.stitch/SCREENS.md
@@ -1,0 +1,66 @@
+# Stitch Screen Registry
+
+Stitch Project: **DraftCrane — Full Product Design** (`6819167765706387197`)
+
+## How This File Works
+
+Every Stitch screen gets an entry here. This is the single source of truth for what each screen is, whether it's aspirational or production-ready, and which version is current.
+
+**Statuses:**
+
+- `exploration` — Directional/aspirational. Useful for mood and vision, not meant to be coded pixel-for-pixel.
+- `draft` — Work-in-progress toward production fidelity. Needs iteration.
+- `review` — High-fidelity candidate ready for Captain review.
+- `approved` — Captain-approved. Code from this screen.
+- `shipped` — Coded and deployed. Keep as reference.
+- `retired` — Superseded or no longer relevant. May delete later.
+
+**Naming convention for new screens:** `{Page} - {Variant} ({Viewport})`
+Examples: `Setup - New Book (Tablet)`, `Dashboard - Empty State (Mobile)`, `Editor - AI Panel Open (Tablet)`
+
+---
+
+## Screen Index
+
+### Dashboard
+
+| Screen ID                          | Title                              | Viewport | Status      | Notes                                                                                                                      |
+| ---------------------------------- | ---------------------------------- | -------- | ----------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `4fb43593955e4ad388282e04abb3530b` | DraftCrane Dashboard (Empty State) | Mobile   | exploration | Empty state with hero, feature cards, bottom tabs. Aspirational — includes social proof and tab bar that won't ship as-is. |
+| `e4b30f2a9fdc4866b51561e6561bae73` | DraftCrane Dashboard (Tablet)      | Desktop  | exploration | Populated dashboard with project cards. Good directional reference for card layout.                                        |
+
+### Setup / New Book
+
+| Screen ID                          | Title                               | Viewport | Status      | Notes                                                                                                            |
+| ---------------------------------- | ----------------------------------- | -------- | ----------- | ---------------------------------------------------------------------------------------------------------------- |
+| `97cb2c7ab4754e669884d367f5eedaa8` | New Book Setup                      | Tablet   | exploration | Original setup screen. Has dark banner and decorative elements that won't ship.                                  |
+| `a63df46009d24a51a549452527be9f03` | New Book Setup Mockup               | Tablet   | retired     | Superseded by v3. Had Cancel button (wrong for new users).                                                       |
+| `8e40cdf0105d4baf8a34d6b4e59fba78` | New Book Setup — Initial Experience | Tablet   | draft       | **CURRENT** — First-time user flow. No Cancel (no dashboard to return to). Logo-only header, form, Drive prompt. |
+
+### Editor
+
+| Screen ID                          | Title                             | Viewport | Status      | Notes                                     |
+| ---------------------------------- | --------------------------------- | -------- | ----------- | ----------------------------------------- |
+| `fddce469903b4561978f9303bdae9731` | Three-Zone Spatial Editor         | Tablet   | exploration | Shows the 3-panel spatial layout concept. |
+| `2f2ed738c1584183a40ec487fbd152d1` | DraftCrane AI Editor (Tablet)     | Desktop  | exploration | Editor with AI panel open.                |
+| `d4eae21887f040ef9588624dc6b1dcb8` | DraftCrane Editor - Library Panel | Desktop  | exploration | Editor with Library panel open.           |
+| `c3e60cbf2fed460089f6788c2ce6c1e9` | DraftCrane Editor (Portrait)      | Mobile   | exploration | Portrait/mobile editor layout.            |
+| `4461403c8d514047a275c6d0b7a73b9b` | DraftCrane Immersive Editor       | Tablet   | exploration | Full immersive writing mode.              |
+
+### Landing Page
+
+| Screen ID                          | Title                            | Viewport | Status  | Notes                                               |
+| ---------------------------------- | -------------------------------- | -------- | ------- | --------------------------------------------------- |
+| `1c4b120fe4ed4b3091bf56e8678ba3a2` | DraftCrane Landing Page (Tablet) | Mobile   | shipped | Used as reference for PR #482 landing page rebuild. |
+
+### Export
+
+| Screen ID                          | Title                           | Viewport | Status      | Notes                |
+| ---------------------------------- | ------------------------------- | -------- | ----------- | -------------------- |
+| `fa4099cf93324d1697bd4f1a8283ecbc` | DraftCrane Export Flow (Tablet) | Tablet   | exploration | Export flow concept. |
+
+### Other
+
+| Screen ID                          | Title                          | Viewport | Status      | Notes                                                                  |
+| ---------------------------------- | ------------------------------ | -------- | ----------- | ---------------------------------------------------------------------- |
+| `b56536746f554f919eda750ba4ed7b40` | DraftCrane AI Writing Platform | Mobile   | exploration | Unclear purpose — possibly an early concept. Candidate for retirement. |

--- a/web/src/app/(protected)/setup/page.tsx
+++ b/web/src/app/(protected)/setup/page.tsx
@@ -1,22 +1,25 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@clerk/nextjs'
+import Link from 'next/link'
+import { useDriveAccounts } from '@/hooks/use-drive-accounts'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || ''
 
 /**
- * Book Setup Screen
+ * Book Setup Screen — "Start Your New Book"
  *
- * Per PRD Section 7 (Step 3) and US-009:
- * - Two fields: book title (required) and optional description (1-2 sentences)
- * - Helper text: "This is a working title. You can change it anytime."
- * - "Create Book" button
- * - Creates default "Chapter 1"
- * - After creation, redirects directly to the editor
+ * Matches Stitch screen "New Book Setup — Initial Experience"
+ * (8e40cdf0105d4baf8a34d6b4e59fba78).
  *
- * Per PRD Section 8:
- * - Title max 500 chars
- * - Description max 1000 chars
+ * Two variants:
+ * - First-time user (0 books): Logo-only header, no Cancel
+ * - Returning user (1+ books): Logo + Cancel → /dashboard
+ *
+ * Below the form, a Google Drive connection prompt appears
+ * if the user hasn't connected Drive yet.
  */
 export default function SetupPage() {
   const router = useRouter()
@@ -26,11 +29,37 @@ export default function SetupPage() {
   const [description, setDescription] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [hasProjects, setHasProjects] = useState(false)
+  const [driveDismissed, setDriveDismissed] = useState(false)
+
+  const {
+    connected: driveConnected,
+    connect: connectDrive,
+    isLoading: driveLoading,
+  } = useDriveAccounts()
 
   const titleLength = title.length
   const descriptionLength = description.length
-
   const isValid = title.trim().length > 0 && titleLength <= 500 && descriptionLength <= 1000
+
+  // Check if user has existing projects (for conditional Cancel)
+  useEffect(() => {
+    async function check() {
+      try {
+        const token = await getToken()
+        const res = await fetch(`${API_URL}/projects`, {
+          headers: { Authorization: `Bearer ${token}` },
+        })
+        if (res.ok) {
+          const data = await res.json()
+          setHasProjects(Array.isArray(data) && data.length > 0)
+        }
+      } catch {
+        // Silently fail — just don't show Cancel
+      }
+    }
+    check()
+  }, [getToken])
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -43,7 +72,7 @@ export default function SetupPage() {
     try {
       const token = await getToken()
 
-      const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/projects`, {
+      const response = await fetch(`${API_URL}/projects`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -66,8 +95,6 @@ export default function SetupPage() {
       }
 
       const project = await response.json()
-
-      // Go straight to the editor
       router.push(`/editor/${project.id}`)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred')
@@ -76,83 +103,113 @@ export default function SetupPage() {
     }
   }
 
+  const showDrivePrompt = !driveLoading && !driveConnected && !driveDismissed
+
   return (
-    <div className="min-h-dvh flex items-center justify-center p-4 bg-[var(--dc-color-surface-primary)]">
-      <div className="w-full max-w-lg">
+    <div className="min-h-dvh bg-[var(--dc-color-surface-primary)]">
+      {/* Header */}
+      <header className="flex h-14 shrink-0 items-center justify-between border-b border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-primary)] px-4 pt-[env(safe-area-inset-top)]">
+        <div className="flex items-center gap-2">
+          <svg
+            className="h-6 w-6 text-[var(--dc-color-interactive-primary)]"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zM21 18.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z" />
+          </svg>
+          <span className="text-xl font-semibold text-[var(--dc-color-interactive-primary)] font-serif tracking-tight">
+            DraftCrane
+          </span>
+        </div>
+        {hasProjects && (
+          <Link
+            href="/dashboard"
+            className="flex h-11 items-center text-sm font-medium text-[var(--dc-color-text-secondary)] hover:text-[var(--dc-color-text-primary)] transition-colors"
+          >
+            Cancel
+          </Link>
+        )}
+      </header>
+
+      {/* Main content */}
+      <div className="mx-auto w-full max-w-lg px-4 pt-12 pb-12">
+        {/* Heading */}
         <div className="text-center mb-8">
-          <h1 className="font-serif text-3xl font-semibold text-[var(--dc-color-text-primary)] mb-2">
-            Create Your Book
+          <h1 className="font-serif text-3xl font-semibold text-[var(--dc-color-text-primary)]">
+            Start Your New Book
           </h1>
-          <p className="text-[var(--dc-color-text-muted)]">
-            Give your book a working title. You can change it anytime.
+          <p className="mt-2 font-serif italic text-[var(--dc-color-text-muted)]">
+            Every great manuscript begins with a single title.
           </p>
         </div>
 
+        {/* Form */}
         <form onSubmit={handleSubmit} className="space-y-6">
           {/* Title field */}
-          <div className="space-y-2">
+          <div>
             <label
               htmlFor="title"
-              className="block text-sm font-medium text-[var(--dc-color-text-primary)]"
+              className="block text-xs font-medium uppercase tracking-widest text-[var(--dc-color-text-secondary)] mb-2"
             >
-              Book Title <span className="text-[var(--dc-color-status-error)]">*</span>
+              Book Title
             </label>
             <input
               id="title"
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
-              placeholder="Enter your book title"
+              placeholder="What's your working title?"
               className="w-full px-4 py-3 rounded-lg border border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-primary)] text-[var(--dc-color-text-primary)]
                          placeholder:text-[var(--dc-color-text-placeholder)]
                          focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-border-focus)] focus:border-transparent
                          transition-all"
               maxLength={500}
               autoFocus
-              aria-describedby="title-help title-count"
+              aria-describedby="title-help"
             />
-            <div className="flex justify-between items-center text-sm">
-              <p id="title-help" className="text-[var(--dc-color-text-muted)]">
+            <div className="flex justify-between items-center mt-1">
+              <p id="title-help" className="text-sm text-[var(--dc-color-text-muted)]">
                 This is a working title. You can change it anytime.
               </p>
-              <span
-                id="title-count"
-                className={`tabular-nums ${titleLength > 450 ? 'text-[var(--dc-color-status-warning)]' : 'text-[var(--dc-color-text-muted)]'} ${titleLength > 500 ? 'text-[var(--dc-color-status-error)]' : ''}`}
-              >
-                {titleLength}/500
-              </span>
+              {titleLength > 400 && (
+                <span
+                  className={`text-sm tabular-nums ${titleLength > 500 ? 'text-[var(--dc-color-status-error)]' : 'text-[var(--dc-color-status-warning)]'}`}
+                >
+                  {titleLength}/500
+                </span>
+              )}
             </div>
           </div>
 
           {/* Description field */}
-          <div className="space-y-2">
+          <div>
             <label
               htmlFor="description"
-              className="block text-sm font-medium text-[var(--dc-color-text-primary)]"
+              className="block text-xs font-medium uppercase tracking-widest text-[var(--dc-color-text-secondary)] mb-2"
             >
-              Description <span className="text-[var(--dc-color-text-muted)]">(optional)</span>
+              Description (optional)
             </label>
             <textarea
               id="description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder="A brief description of what your book is about"
+              placeholder="A sentence or two about your book (optional)."
               rows={3}
               className="w-full px-4 py-3 rounded-lg border border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-primary)] text-[var(--dc-color-text-primary)]
                          placeholder:text-[var(--dc-color-text-placeholder)]
                          focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-border-focus)] focus:border-transparent
                          transition-all resize-none"
               maxLength={1000}
-              aria-describedby="description-count"
             />
-            <div className="flex justify-end">
-              <span
-                id="description-count"
-                className={`text-sm tabular-nums ${descriptionLength > 900 ? 'text-[var(--dc-color-status-warning)]' : 'text-[var(--dc-color-text-muted)]'} ${descriptionLength > 1000 ? 'text-[var(--dc-color-status-error)]' : ''}`}
-              >
-                {descriptionLength}/1000
-              </span>
-            </div>
+            {descriptionLength > 800 && (
+              <div className="flex justify-end mt-1">
+                <span
+                  className={`text-sm tabular-nums ${descriptionLength > 1000 ? 'text-[var(--dc-color-status-error)]' : 'text-[var(--dc-color-status-warning)]'}`}
+                >
+                  {descriptionLength}/1000
+                </span>
+              </div>
+            )}
           </div>
 
           {/* Error message */}
@@ -169,18 +226,73 @@ export default function SetupPage() {
           <button
             type="submit"
             disabled={!isValid || isSubmitting}
-            className="w-full py-3 px-4 rounded-lg bg-[var(--dc-color-text-primary)] text-[var(--dc-color-text-inverse)] font-medium
-                       hover:bg-[var(--dc-color-text-secondary)] focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-border-strong)] focus:ring-offset-2
+            className="w-full h-12 rounded-lg bg-[var(--dc-color-interactive-primary)] text-[var(--dc-color-text-inverse)] font-medium
+                       hover:bg-[var(--dc-color-interactive-primary-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--dc-color-border-focus)] focus:ring-offset-2
                        disabled:opacity-50 disabled:cursor-not-allowed
                        transition-all"
           >
-            {isSubmitting ? 'Creating...' : 'Create Book'}
+            {isSubmitting ? 'Creating...' : 'Create Book \u2192'}
           </button>
         </form>
 
-        <p className="mt-6 text-center text-sm text-[var(--dc-color-text-muted)]">
-          Your first chapter will be waiting for you.
-        </p>
+        {/* Decorative divider */}
+        <div className="relative my-8">
+          <div className="absolute inset-0 flex items-center">
+            <div className="w-full border-t border-[var(--dc-color-border-default)]" />
+          </div>
+          <div className="relative flex justify-center">
+            <span className="bg-[var(--dc-color-surface-primary)] px-3">
+              <svg
+                className="h-5 w-5 text-[var(--dc-color-text-placeholder)]"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zM21 18.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z" />
+              </svg>
+            </span>
+          </div>
+        </div>
+
+        {/* Google Drive connection prompt */}
+        {showDrivePrompt && (
+          <div className="border border-[var(--dc-color-border-default)] rounded-xl p-5">
+            <div className="flex items-start gap-4">
+              <svg
+                className="h-7 w-7 shrink-0 text-[var(--dc-color-interactive-primary)] mt-0.5"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zM12 17c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zM15.1 8H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
+              </svg>
+              <div className="flex-1 min-w-0">
+                <p className="font-medium text-[var(--dc-color-text-primary)]">
+                  Keep your book safe
+                </p>
+                <p className="text-sm text-[var(--dc-color-text-muted)] mt-0.5">
+                  Connect your Google Drive to auto-save every draft and source material in
+                  real-time.
+                </p>
+              </div>
+              <div className="flex flex-col items-end shrink-0">
+                <button
+                  type="button"
+                  onClick={() => connectDrive()}
+                  className="px-5 py-2 rounded-lg border border-[var(--dc-color-border-strong)] text-sm font-medium text-[var(--dc-color-text-secondary)]
+                             hover:bg-[var(--dc-color-surface-tertiary)] transition-colors min-h-[36px]"
+                >
+                  Connect
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setDriveDismissed(true)}
+                  className="text-xs text-[var(--dc-color-text-placeholder)] underline mt-2 hover:text-[var(--dc-color-text-muted)] transition-colors"
+                >
+                  Maybe later
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/web/src/components/layout/app-header.tsx
+++ b/web/src/components/layout/app-header.tsx
@@ -13,7 +13,7 @@ import Link from 'next/link'
 export function AppHeader() {
   const pathname = usePathname()
 
-  if (pathname.startsWith('/editor/')) return null
+  if (pathname.startsWith('/editor/') || pathname === '/setup') return null
 
   return (
     <header className="flex h-14 shrink-0 items-center justify-between border-b border-[var(--dc-color-border-default)] bg-[var(--dc-color-surface-primary)] px-4 pt-[env(safe-area-inset-top)]">


### PR DESCRIPTION
## Summary
- Redesign the "Create Your Book" setup page to match Stitch screen "New Book Setup — Initial Experience"
- Custom header with DraftCrane logo replaces shared AppHeader; Cancel button shown conditionally (only for returning users with existing books)
- Warm brown CTA button, uppercase tracked labels, italic serif subtitle, and Google Drive connection prompt card for users who haven't connected Drive
- Add `.stitch/SCREENS.md` — a screen registry to track all Stitch screens with statuses (exploration, draft, review, approved, shipped, retired)

## Test plan
- [ ] `npm run verify` passes
- [ ] Visit `/setup` as new user (0 books) — no Cancel button, Drive prompt visible
- [ ] Visit `/setup` as returning user (1+ books) — Cancel button links to `/dashboard`
- [ ] Submit form — creates project and redirects to editor (unchanged behavior)
- [ ] "Connect" on Drive card initiates OAuth redirect
- [ ] "Maybe later" dismisses Drive card (session-only)
- [ ] iPad viewport — touch targets >=44px, no layout issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)