### PR TITLE
fix: show Cancel button on setup page for returning users

### DIFF
--- a/web/src/app/(protected)/setup/page.tsx
+++ b/web/src/app/(protected)/setup/page.tsx
@@ -52,7 +52,8 @@ export default function SetupPage() {
         })
         if (res.ok) {
           const data = await res.json()
-          setHasProjects(Array.isArray(data) && data.length > 0)
+          const list = data?.projects ?? data
+          setHasProjects(Array.isArray(list) && list.length > 0)
         }
       } catch {
         // Silently fail — just don't show Cancel


### PR DESCRIPTION
## Summary
- The GET `/projects` endpoint returns `{ projects: [...] }`, not a plain array
- The `hasProjects` check was always `false`, so the Cancel button never appeared for returning users
- Fix: unwrap `data.projects` before checking array length

## Test plan
- [ ] `npm run verify` passes
- [ ] Visit `/setup` as user with existing books — Cancel button now visible in header
- [ ] Click Cancel — navigates to `/dashboard`
- [ ] New user (0 books) — still no Cancel button

🤖 Generated with [Claude Code](https://claude.com/claude-code)