### PR TITLE
chore: align docs/ with documentation standard

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+---
+title: 'DraftCrane Docs'
+sidebar:
+  order: 0
+---
+
+# DraftCrane Documentation
+
+Project documentation for [dc-console](https://github.com/venturecrane/dc-console) — the DraftCrane writing environment.
+
+## Directories
+
+- [adr/](adr/) - Architecture Decision Records: technology selections, design tradeoffs, and spike results
+- [design/](design/) - Design documentation: brief, charter, specifications, and multi-role contributions
+- [handoffs/](handoffs/) - Session handoff records (date-prefixed)
+- [pm/](pm/) - Product requirements documents
+- [process/](process/) - Project instructions and development workflow
+- [reviews/](reviews/) - Automated code reviews and platform audits (date-prefixed)
+- [wireframes/](wireframes/) - Wireframe assets organized by issue number
+
+## Other Files
+
+- [openapi.yaml](openapi.yaml) - OpenAPI specification for the dc-api worker

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,0 +1,24 @@
+---
+title: 'Architecture Decision Records'
+sidebar:
+  order: 0
+---
+
+# Architecture Decision Records
+
+Architectural decisions made during the development of DraftCrane, including technology selections, design tradeoffs, and spike results.
+
+## Contents
+
+- [ADR-001: Editor Library Selection](ADR-001-editor-library.md) - Selection of the rich-text editor library
+- [ADR-003: AI Provider](ADR-003-ai-provider.md) - AI provider selection and integration strategy
+- [ADR-004: PDF/EPUB Generation](ADR-004-pdf-epub-generation.md) - Export format generation approach
+- [ADR-005: Content Storage Architecture](ADR-005-content-storage-architecture.md) - How book content is stored and structured
+- [ADR-006: Multi-Tier AI](ADR-006-multi-tier-ai.md) - Multi-tier AI architecture decision
+- [ADR-006: Quality Gate Results](ADR-006-quality-gate-results.md) - Spike results for quality gate evaluation
+- [ADR-007: Research Query Prompts](ADR-007-research-query-prompts.md) - Prompt engineering for research queries
+- [ADR-008: Document Parsing](ADR-008-document-parsing.md) - Document ingestion and parsing approach
+- [ADR-008: Spike Results](ADR-008-spike-results.md) - Spike results for document parsing
+- [ADR-009: Content Chunking](ADR-009-content-chunking.md) - Strategy for chunking content for AI processing
+- [ADR-009: Spike Results](ADR-009-spike-results.md) - Spike results for content chunking
+- [ADR-010: Snippet Prompt Engineering](ADR-010-snippet-prompt-engineering.md) - Prompt engineering for snippet generation

--- a/docs/design/book-view/index.md
+++ b/docs/design/book-view/index.md
@@ -1,0 +1,14 @@
+---
+title: 'Book View'
+sidebar:
+  order: 0
+---
+
+# Book View
+
+Design specifications for the DraftCrane book reading view.
+
+## Contents
+
+- [Outline Mode](outline-mode.md) - Design spec for outline/structure navigation mode
+- [Read Mode](read-mode.md) - Design spec for full reading mode

--- a/docs/design/contributions-archive/2026-02-24/index.md
+++ b/docs/design/contributions-archive/2026-02-24/index.md
@@ -1,0 +1,13 @@
+---
+title: '2026-02-24 Contributions'
+sidebar:
+  order: 0
+---
+
+# Design Contributions - 2026-02-24
+
+Archived design brief contributions from February 24, 2026.
+
+## Contents
+
+- [Round 1](round-1/) - First round of contributions from this session

--- a/docs/design/contributions-archive/2026-02-24/round-1/index.md
+++ b/docs/design/contributions-archive/2026-02-24/round-1/index.md
@@ -1,0 +1,16 @@
+---
+title: 'Archive Round 1 - 2026-02-24'
+sidebar:
+  order: 0
+---
+
+# Design Contributions Archive - 2026-02-24 Round 1
+
+Archived first-round design brief contributions from February 24, 2026.
+
+## Contents
+
+- [Brand Strategist](brand-strategist.md) - Brand strategy perspective on DraftCrane design
+- [Design Technologist](design-technologist.md) - Technical design constraints and opportunities
+- [Interaction Designer - Help/Support](interaction-designer-help-support.md) - Help and support interaction patterns
+- [Target User](target-user.md) - Target user perspective and needs

--- a/docs/design/contributions-archive/index.md
+++ b/docs/design/contributions-archive/index.md
@@ -1,0 +1,13 @@
+---
+title: 'Contributions Archive'
+sidebar:
+  order: 0
+---
+
+# Design Contributions Archive
+
+Archived design brief contributions from prior sessions, organized by date.
+
+## Contents
+
+- [2026-02-24](2026-02-24/) - Design brief contributions from February 24, 2026

--- a/docs/design/contributions/index.md
+++ b/docs/design/contributions/index.md
@@ -1,0 +1,13 @@
+---
+title: 'Design Contributions'
+sidebar:
+  order: 0
+---
+
+# Design Contributions
+
+Active design brief contributions from the multi-role design process. Each round captures perspectives from multiple design roles (brand strategist, design technologist, interaction designer, target user).
+
+## Contents
+
+- [Round 1](round-1/) - First round of design brief contributions

--- a/docs/design/contributions/round-1/index.md
+++ b/docs/design/contributions/round-1/index.md
@@ -1,0 +1,17 @@
+---
+title: 'Contributions Round 1'
+sidebar:
+  order: 0
+---
+
+# Design Contributions - Round 1
+
+First round of multi-role design brief contributions for DraftCrane.
+
+## Contents
+
+- [Brand Strategist](brand-strategist.md) - Brand strategy perspective on DraftCrane design
+- [Design Technologist](design-technologist.md) - Technical design constraints and opportunities
+- [Interaction Designer](interaction-designer.md) - Core interaction patterns and flows
+- [Interaction Designer - Help/Support](interaction-designer-help-support.md) - Help and support interaction patterns
+- [Target User](target-user.md) - Target user perspective and needs

--- a/docs/design/editor-panel/index.md
+++ b/docs/design/editor-panel/index.md
@@ -1,0 +1,13 @@
+---
+title: 'Editor Panel'
+sidebar:
+  order: 0
+---
+
+# Editor Panel
+
+Design specifications for the DraftCrane editor panel.
+
+## Contents
+
+- [Chapter Mode](chapter-mode.md) - Design spec for chapter editing mode

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -1,0 +1,25 @@
+---
+title: 'Design'
+sidebar:
+  order: 0
+---
+
+# Design
+
+Design documentation for DraftCrane, including the design brief, charter, specifications, and multi-role design contributions.
+
+## Contents
+
+- [Brief](brief.md) - Design brief: the Author/Editor metaphor, synthesized from multi-role design process
+- [Charter](charter.md) - Design charter and principles
+- [Library Desk Spec](library-desk-spec.md) - Library desk component specification
+- [Voice and Tone Help](voice-tone-help.md) - Voice and tone guidelines for help content
+
+## Subdirectories
+
+- [Book View](book-view/) - Design specs for the book reading view
+- [Contributions](contributions/) - Active design brief contributions by role
+- [Contributions Archive](contributions-archive/) - Archived design brief contributions
+- [Editor Panel](editor-panel/) - Design specs for the editor panel
+- [Source Review](source-review/) - Design specs for source review workflow
+- [Workspace Toggle](workspace-toggle/) - Design specs for workspace toggle

--- a/docs/design/source-review/index.md
+++ b/docs/design/source-review/index.md
@@ -1,0 +1,13 @@
+---
+title: 'Source Review'
+sidebar:
+  order: 0
+---
+
+# Source Review
+
+Design specifications for the DraftCrane source review workflow.
+
+## Contents
+
+- [Design Spec](design-spec.md) - Full design specification for the source review panel

--- a/docs/design/workspace-toggle/index.md
+++ b/docs/design/workspace-toggle/index.md
@@ -1,0 +1,13 @@
+---
+title: 'Workspace Toggle'
+sidebar:
+  order: 0
+---
+
+# Workspace Toggle
+
+Design specifications for the DraftCrane workspace toggle component.
+
+## Contents
+
+- [Design Spec](design-spec.md) - Full design specification for the workspace toggle

--- a/docs/handoffs/index.md
+++ b/docs/handoffs/index.md
@@ -1,0 +1,9 @@
+---
+title: 'Handoffs'
+sidebar:
+  order: 0
+---
+
+# Handoffs
+
+Session handoff records for dc-console. Files are date-prefixed (e.g., `2026-04-12-session.md`).

--- a/docs/pm/index.md
+++ b/docs/pm/index.md
@@ -1,0 +1,14 @@
+---
+title: 'Product Management'
+sidebar:
+  order: 0
+---
+
+# Product Management
+
+Product requirements and specifications for DraftCrane.
+
+## Contents
+
+- [PRD](prd.md) - Product Requirements Document (v2.0, synthesized from 3-round team review)
+- [PRD App](prd-app.md) - Product Requirements Document (app-level, sourced from VCMS)

--- a/docs/process/index.md
+++ b/docs/process/index.md
@@ -1,0 +1,13 @@
+---
+title: 'Process'
+sidebar:
+  order: 0
+---
+
+# Process
+
+Project instructions and workflow documentation for DraftCrane development.
+
+## Contents
+
+- [DC Project Instructions](dc-project-instructions.md) - Project identity, development workflow, and coding standards for DraftCrane

--- a/docs/reviews/index.md
+++ b/docs/reviews/index.md
@@ -1,0 +1,15 @@
+---
+title: 'Reviews'
+sidebar:
+  order: 0
+---
+
+# Reviews
+
+Automated code reviews and platform audits for dc-console, recorded by date.
+
+## Contents
+
+- [Code Review 2026-02-17](code-review-2026-02-17.md) - Full codebase review
+- [Code Review 2026-02-23](code-review-2026-02-23.md) - Full codebase review
+- [Code Review 2026-03-23](code-review-2026-03-23.md) - Full codebase review

--- a/docs/wireframes/317/index.md
+++ b/docs/wireframes/317/index.md
@@ -1,0 +1,9 @@
+---
+title: 'Wireframes - Issue 317'
+sidebar:
+  order: 0
+---
+
+# Wireframes - Issue #317
+
+Wireframe assets for GitHub issue #317.

--- a/docs/wireframes/index.md
+++ b/docs/wireframes/index.md
@@ -1,0 +1,13 @@
+---
+title: 'Wireframes'
+sidebar:
+  order: 0
+---
+
+# Wireframes
+
+Wireframe files for DraftCrane, organized by GitHub issue number.
+
+## Contents
+
+- [Issue 317](317/) - Wireframes for issue #317


### PR DESCRIPTION
Adds missing index.md files and README per the docs-standard.md framework in crane-console.

## Changes

- `docs/README.md` - new top-level index of all directories
- `docs/handoffs/` - new required directory with `index.md`
- `docs/adr/index.md` - index for Architecture Decision Records
- `docs/design/index.md` and all subdirectory indexes (`book-view/`, `contributions/`, `contributions/round-1/`, `contributions-archive/`, `contributions-archive/2026-02-24/`, `contributions-archive/2026-02-24/round-1/`, `editor-panel/`, `source-review/`, `workspace-toggle/`)
- `docs/pm/index.md`
- `docs/process/index.md`
- `docs/reviews/index.md`
- `docs/wireframes/index.md` and `docs/wireframes/317/index.md`

All files follow the standard frontmatter format (`title`, `sidebar.order: 0`) and include a contents list with relative markdown links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)