### PR TITLE
feat: landing + waitlist + Clerk allowlist gate

### DIFF
--- a/docs/runbooks/waitlist-launch.md
+++ b/docs/runbooks/waitlist-launch.md
@@ -1,0 +1,91 @@
+# Waitlist + Closed-Allowlist Launch Runbook
+
+Manual setup steps to bring the new landing + waitlist + Clerk allowlist gate live on `draftcrane.app`. Code is in PR; this is the operator checklist.
+
+## 1. Clerk Pro upgrade (required for Allowlist)
+
+Restricted Mode + Allowlist are paid features in production (free in dev). Pro is **$25/mo flat for unlimited apps** — covers DC, KE, DFG, SC.
+
+- https://dashboard.clerk.com → DraftCrane app → Billing → upgrade to Pro
+- Settings → Restrictions → enable **Allowlist mode** (Sign-up restrictions: "Allowlist only")
+- Allowlist → add `smdurgan@venturecrane.com` + any test invitees
+- Settings → Email & SMS → Magic link → enable as primary sign-in method
+- Customize the magic-link email template (sender: `hello@mail.draftcrane.app`, body styled to brand voice)
+
+## 2. Resend domain verification
+
+We send from a `mail.<apex>` subdomain so the apex's MX/SPF/DKIM/DMARC stays untouched.
+
+- https://resend.com/domains → Add domain → `mail.draftcrane.app`
+- Resend issues SPF + DKIM TXT records and a DMARC record. Add them to `draftcrane.app` DNS (Cloudflare).
+- Wait for `Verified` (usually < 5 min).
+- Create an API key scoped to `mail.draftcrane.app` with `send` permission.
+- Save key as `RESEND_API_KEY` in Infisical `/dc`.
+
+## 3. Cloudflare Turnstile
+
+Anti-abuse widget on the waitlist form.
+
+- https://dash.cloudflare.com → Turnstile → Add site
+- Site name: `draftcrane.app waitlist`
+- Domain: `draftcrane.app`
+- Widget mode: **Managed** (default)
+- Save site key (public) and secret key (server-side).
+- Save `TURNSTILE_SECRET_KEY` in Infisical `/dc`.
+
+## 4. Worker secrets
+
+```bash
+cd workers/dc-api
+infisical run --env=prod --path=/dc -- bash -c '
+  echo "$RESEND_API_KEY" | wrangler secret put RESEND_API_KEY
+  echo "$TURNSTILE_SECRET_KEY" | wrangler secret put TURNSTILE_SECRET_KEY
+'
+```
+
+## 5. Vercel env var (Turnstile site key)
+
+The site key is public (it appears in the rendered widget); fine to commit to Vercel.
+
+- Vercel project `dc-console` → Settings → Environment Variables
+- Add `NEXT_PUBLIC_TURNSTILE_SITE_KEY` for Production + Preview
+- Trigger a redeploy
+
+## 6. D1 migration
+
+```bash
+cd workers/dc-api
+npm run db:migrate:remote   # applies 0029_create_waitlist_signups.sql to dc-main
+```
+
+## 7. End-to-end verification
+
+1. Visit https://draftcrane.app — landing renders, six sections present, brand-correct.
+2. Submit waitlist with a test email → success state appears.
+3. Confirmation email arrives in test inbox (check Gmail + iCloud + Workspace if you have them).
+4. Captain notification email arrives at `smdurgan@venturecrane.com`.
+5. Submit the same email again → "you are already on the list" state (no duplicate row, no second email).
+6. Open browser devtools, forge a Turnstile token → form submission rejected (400 TURNSTILE_FAILED).
+7. Visit `/sign-in` with an allowlisted email → magic link arrives → click-through completes sign-in → lands on dashboard.
+8. Visit `/sign-in` with a non-allowlisted email → blocked at Clerk with clear message.
+9. Visit a gated route (e.g. `/dashboard`) signed-out → redirect to `/sign-in`.
+10. Tail the worker:
+    ```bash
+    cd workers/dc-api && wrangler tail
+    ```
+    Submit another signup. Confirm a structured `waitlist_signup` log line appears.
+
+## 8. Reviewing waitlist signups
+
+```bash
+cd workers/dc-api
+wrangler d1 execute dc-main --remote --command \
+  "SELECT id, email, signed_up_at, status, utm_source, ip_country FROM waitlist_signups ORDER BY signed_up_at DESC LIMIT 50"
+```
+
+To promote a signup to allowlist: copy the email, paste into Clerk Allowlist, mark the row as `invited`:
+
+```bash
+wrangler d1 execute dc-main --remote --command \
+  "UPDATE waitlist_signups SET status = 'invited' WHERE email = 'foo@example.com'"
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10023,17 +10023,48 @@
       }
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.1.tgz",
-      "integrity": "sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==",
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
+      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
+        "htmlparser2": "^10.1.0",
         "is-plain-object": "^5.0.0",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/sax": {
@@ -12022,7 +12053,7 @@
         "next": "16.2.3",
         "react": "19.2.4",
         "react-dom": "19.2.4",
-        "sanitize-html": "^2.17.1"
+        "sanitize-html": "^2.17.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",

--- a/web/src/app/api/waitlist/route.ts
+++ b/web/src/app/api/waitlist/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * Public waitlist proxy.
+ *
+ * Forwards POST to dc-api `/waitlist` so the worker side owns persistence,
+ * Resend, and Turnstile verification. Next.js stays out of D1 bindings.
+ *
+ * Mounted at `/api/waitlist`. Public — added to middleware.ts public matcher.
+ */
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? 'https://api.draftcrane.app'
+
+export async function POST(request: Request) {
+  const body = await request.text()
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+  const cfIp = request.headers.get('cf-connecting-ip')
+  if (cfIp) headers['cf-connecting-ip'] = cfIp
+  const cfCountry = request.headers.get('cf-ipcountry')
+  if (cfCountry) headers['cf-ipcountry'] = cfCountry
+  const ua = request.headers.get('user-agent')
+  if (ua) headers['user-agent'] = ua
+
+  try {
+    const upstream = await fetch(`${API_BASE}/waitlist`, {
+      method: 'POST',
+      headers,
+      body,
+    })
+    const text = await upstream.text()
+    return new NextResponse(text, {
+      status: upstream.status,
+      headers: { 'Content-Type': 'application/json' },
+    })
+  } catch (err) {
+    console.error('waitlist proxy failed:', err)
+    return NextResponse.json(
+      { error: 'Service temporarily unavailable. Please try again.', code: 'PROXY_ERROR' },
+      { status: 503 }
+    )
+  }
+}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,298 +1,44 @@
-import Link from 'next/link'
+import type { Metadata } from 'next'
+import { Footer } from '@/components/marketing/Footer'
+import { Hero } from '@/components/marketing/Hero'
+import { HowItWorks } from '@/components/marketing/HowItWorks'
+import { Nav } from '@/components/marketing/Nav'
+import { Problem } from '@/components/marketing/Problem'
+import { WaitlistCTA } from '@/components/marketing/WaitlistCTA'
+import { WhyDifferent } from '@/components/marketing/WhyDifferent'
 
-/**
- * Landing Page for DraftCrane.
- * Built to match Stitch "DraftCrane — Full Product Design" landing screen.
- * Warm literary aesthetic with product showcase and benefit cards.
- */
+export const metadata: Metadata = {
+  title: 'DraftCrane — Write the book you have been putting off',
+  description:
+    'A writing environment for consultants and coaches. Organized chapter by chapter, with an AI partner that reads your draft, in your own Google Drive. In private alpha — request access.',
+  openGraph: {
+    title: 'DraftCrane — Write the book you have been putting off',
+    description:
+      'A writing environment for consultants and coaches. Organized chapter by chapter, with an AI partner that reads your draft, in your own Google Drive.',
+    url: 'https://draftcrane.app',
+    siteName: 'DraftCrane',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'DraftCrane — Write the book you have been putting off',
+    description:
+      'A writing environment for consultants and coaches. In private alpha — request access.',
+  },
+}
+
 export default function LandingPage() {
   return (
     <div className="min-h-dvh bg-[var(--dc-color-surface-primary)]">
-      {/* Navigation Bar */}
-      <nav className="fixed top-0 w-full z-50 flex justify-between items-center px-6 py-4 max-w-7xl mx-auto bg-[var(--dc-color-surface-primary)] border-b border-[var(--dc-color-border-default)]/50">
-        <div className="flex items-center gap-2">
-          <svg
-            className="w-6 h-6 text-[var(--dc-color-interactive-primary)]"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-          >
-            <path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zM21 18.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z" />
-          </svg>
-          <span className="text-xl font-semibold text-[var(--dc-color-interactive-primary)] font-serif tracking-tight">
-            DraftCrane
-          </span>
-        </div>
-        <Link
-          href="/sign-up"
-          className="px-5 py-2 bg-[var(--dc-color-interactive-primary)] text-[var(--dc-color-text-inverse)] rounded-lg font-medium text-sm transition-all hover:opacity-90 active:opacity-80 min-h-[44px] flex items-center"
-        >
-          Get Started
-        </Link>
-      </nav>
-
-      <main className="pt-24 pb-12 px-6 max-w-7xl mx-auto">
-        {/* Hero Section */}
-        <section className="text-center py-16 md:py-24 max-w-4xl mx-auto">
-          <h1 className="font-serif text-5xl md:text-7xl font-medium tracking-tight text-[var(--dc-color-interactive-primary)] leading-[1.1] mb-8">
-            Your book. Your files. Your cloud. With an AI writing partner.
-          </h1>
-          <p className="text-lg md:text-xl text-[var(--dc-color-interactive-primary)]/80 leading-relaxed mb-10 max-w-2xl mx-auto">
-            Craft your expertise into a compelling book with a writing environment that respects
-            your ideas and your privacy. Designed specifically for consultants and coaches who want
-            to write, organize, and publish with ease.
-          </p>
-          <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
-            <Link
-              href="/sign-up"
-              className="w-full sm:w-auto px-10 py-4 bg-[var(--dc-color-interactive-primary)] text-[var(--dc-color-text-inverse)] rounded-xl font-semibold text-lg hover:shadow-lg transition-all active:scale-[0.98] min-h-[44px] flex items-center justify-center"
-            >
-              Get Started
-            </Link>
-            <a
-              href="#product-visual"
-              className="w-full sm:w-auto px-10 py-4 text-[var(--dc-color-interactive-primary)] font-medium hover:underline decoration-[var(--dc-color-interactive-primary)]/30 underline-offset-8 transition-all min-h-[44px] flex items-center justify-center"
-            >
-              Learn More
-            </a>
-          </div>
-        </section>
-
-        {/* Product Visual: The Editor Interface */}
-        <section id="product-visual" className="relative mb-32 group">
-          <div className="absolute -inset-4 bg-[var(--dc-color-interactive-primary)]/5 rounded-[2rem] blur-3xl group-hover:bg-[var(--dc-color-interactive-primary)]/10 transition-colors duration-700" />
-          <div className="relative bg-white rounded-2xl shadow-2xl border border-[var(--dc-color-border-default)] overflow-hidden aspect-[4/3] md:aspect-[16/10] flex flex-col">
-            {/* Editor Toolbar */}
-            <div className="h-14 border-b border-[var(--dc-color-border-subtle)] flex items-center justify-between px-4 bg-white/80 backdrop-blur-sm">
-              <div className="flex items-center gap-3">
-                <svg
-                  className="w-5 h-5 text-[var(--dc-color-text-placeholder)]"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z" />
-                </svg>
-                <div className="h-4 w-px bg-[var(--dc-color-border-default)]" />
-                <span className="text-sm font-medium text-[var(--dc-color-text-muted)]">
-                  The Modern Leader › Chapter 4: Authentic Presence
-                </span>
-              </div>
-              <div className="flex items-center gap-4">
-                <span className="text-xs text-[var(--dc-color-text-placeholder)] italic">
-                  Saved to Google Drive
-                </span>
-                <svg
-                  className="w-5 h-5 text-[var(--dc-color-text-placeholder)]"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
-                  <path d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58a.49.49 0 00.12-.61l-1.92-3.32a.488.488 0 00-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 00-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.07.62-.07.94s.02.64.07.94l-2.03 1.58a.49.49 0 00-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z" />
-                </svg>
-              </div>
-            </div>
-            {/* Three-Zone Spatial Layout */}
-            <div className="flex-1 flex overflow-hidden">
-              {/* Left Panel: Chapters */}
-              <aside className="w-64 border-r border-[var(--dc-color-border-subtle)] bg-[var(--dc-color-surface-secondary)]/50 p-6 hidden md:block">
-                <h3 className="text-[10px] uppercase tracking-widest text-[var(--dc-color-text-placeholder)] font-bold mb-6">
-                  Manuscript
-                </h3>
-                <div className="space-y-5">
-                  <div className="flex items-center gap-3 text-[var(--dc-color-text-placeholder)]">
-                    <span className="text-xs font-serif italic">01</span>
-                    <span className="text-sm">Introduction</span>
-                  </div>
-                  <div className="flex items-center gap-3 text-[var(--dc-color-text-placeholder)]">
-                    <span className="text-xs font-serif italic">02</span>
-                    <span className="text-sm">The Expertise Gap</span>
-                  </div>
-                  <div className="flex items-center gap-3 text-[var(--dc-color-interactive-primary)] font-medium">
-                    <span className="text-xs font-serif italic">04</span>
-                    <span className="text-sm">Authentic Presence</span>
-                    <div className="ml-auto w-1.5 h-1.5 rounded-full bg-[var(--dc-color-interactive-primary)]/40" />
-                  </div>
-                  <div className="flex items-center gap-3 text-[var(--dc-color-text-placeholder)]">
-                    <span className="text-xs font-serif italic">05</span>
-                    <span className="text-sm">Building Trust</span>
-                  </div>
-                </div>
-              </aside>
-              {/* Center Panel: Writing Surface */}
-              <section className="flex-1 bg-white p-8 md:p-16 overflow-y-auto">
-                <div className="max-w-2xl mx-auto space-y-8">
-                  <h2 className="font-serif text-4xl text-[var(--dc-color-interactive-primary)] mb-12">
-                    Authentic Presence
-                  </h2>
-                  <p className="font-serif text-xl leading-relaxed text-[var(--dc-color-text-primary)]">
-                    Leadership is not about being the loudest person in the room. It is about
-                    creating a space where the truth can be spoken without fear. For most
-                    consultants, the transition from expert to author requires a shift in how they
-                    view their own authority.
-                  </p>
-                  <p className="font-serif text-xl leading-relaxed text-[var(--dc-color-text-primary)]">
-                    When we sit down to write, we often feel the need to sound like an
-                    &ldquo;Author.&rdquo; We adopt a formal tone, we use academic structures, and we
-                    inadvertently distance ourselves from the very people we are trying to help.
-                  </p>
-                  <div className="h-2 w-12 bg-[var(--dc-color-surface-tertiary)] rounded-full" />
-                </div>
-              </section>
-              {/* Right Panel: AI Editor Assistance */}
-              <aside className="w-80 border-l border-[var(--dc-color-border-subtle)] bg-[var(--dc-color-surface-secondary)]/30 p-6 hidden lg:block">
-                <div className="space-y-6">
-                  <div className="p-4 bg-white rounded-xl shadow-sm border border-[var(--dc-color-border-subtle)]">
-                    <div className="flex items-center gap-2 mb-3">
-                      <svg
-                        className="w-4 h-4 text-[var(--dc-color-interactive-primary)]"
-                        viewBox="0 0 24 24"
-                        fill="currentColor"
-                      >
-                        <path d="M19 9l1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25L19 9zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12l-5.5-2.5zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25L19 15z" />
-                      </svg>
-                      <span className="text-xs font-semibold text-[var(--dc-color-interactive-primary)] uppercase tracking-tighter">
-                        Editor&apos;s Note
-                      </span>
-                    </div>
-                    <p className="text-xs leading-relaxed text-[var(--dc-color-text-muted)] mb-4">
-                      &ldquo;Your transition here is strong, but you could lean more into the
-                      specific &lsquo;Leadership&rsquo; anecdote from your Google Drive research
-                      folder.&rdquo;
-                    </p>
-                    <button className="text-[10px] font-bold text-[var(--dc-color-interactive-primary)] uppercase tracking-wider border-b border-[var(--dc-color-interactive-primary)]/20 pb-0.5">
-                      Show Research
-                    </button>
-                  </div>
-                  <div className="p-4 bg-[var(--dc-color-interactive-primary)]/5 rounded-xl border border-[var(--dc-color-interactive-primary)]/10">
-                    <p className="text-[10px] text-[var(--dc-color-interactive-primary)]/60 font-medium mb-2 uppercase">
-                      Suggested Refinement
-                    </p>
-                    <p className="text-xs italic text-[var(--dc-color-text-secondary)] leading-relaxed">
-                      &ldquo;Consider simplifying this paragraph to maintain the conversational
-                      warmth of your coaching sessions.&rdquo;
-                    </p>
-                  </div>
-                </div>
-              </aside>
-            </div>
-          </div>
-          <div className="mt-8 flex justify-center items-center gap-8 text-[var(--dc-color-text-placeholder)]">
-            <div className="flex items-center gap-2">
-              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M12.545 10.239v3.821h5.445c-.712 2.315-2.647 3.972-5.445 3.972a6.033 6.033 0 110-12.064c1.498 0 2.866.549 3.921 1.453l2.814-2.814A9.969 9.969 0 0012.545 2C7.021 2 2.543 6.477 2.543 12s4.478 10 10.002 10c8.396 0 10.249-7.85 9.426-11.748l-9.426-.013z" />
-              </svg>
-              <span className="text-xs font-medium">Syncing with Google Drive</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <svg className="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
-                <path d="M18 8h-1V6c0-2.76-2.24-5-5-5S7 3.24 7 6v2H6c-1.1 0-2 .9-2 2v10c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V10c0-1.1-.9-2-2-2zM12 17c-1.1 0-2-.9-2-2s.9-2 2-2 2 .9 2 2-.9 2-2 2zM15.1 8H8.9V6c0-1.71 1.39-3.1 3.1-3.1 1.71 0 3.1 1.39 3.1 3.1v2z" />
-              </svg>
-              <span className="text-xs font-medium">End-to-End Privacy</span>
-            </div>
-          </div>
-        </section>
-
-        {/* Benefit Cards */}
-        <section className="grid grid-cols-1 md:grid-cols-3 gap-8 py-12">
-          <div className="bg-[var(--dc-color-surface-secondary)]/50 p-8 rounded-2xl border border-[var(--dc-color-border-default)]/50 hover:bg-white hover:shadow-xl hover:shadow-[var(--dc-color-interactive-primary)]/5 transition-all duration-500">
-            <div className="w-12 h-12 bg-[var(--dc-color-interactive-primary)]/10 rounded-xl flex items-center justify-center mb-6">
-              <svg
-                className="w-6 h-6 text-[var(--dc-color-interactive-primary)]"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path d="M22 11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3h7zM7 9H4V5h3v4zm10 6h3v4h-3v-4zm0-10h3v4h-3V5z" />
-              </svg>
-            </div>
-            <h3 className="font-serif text-2xl text-[var(--dc-color-interactive-primary)] mb-4">
-              Organized Chapters
-            </h3>
-            <p className="text-[var(--dc-color-text-muted)] leading-relaxed">
-              Build your book structure visually, moving chapters and sections as your ideas grow.
-              Never lose track of where a story belongs.
-            </p>
-          </div>
-          <div className="bg-[var(--dc-color-surface-secondary)]/50 p-8 rounded-2xl border border-[var(--dc-color-border-default)]/50 hover:bg-white hover:shadow-xl hover:shadow-[var(--dc-color-interactive-primary)]/5 transition-all duration-500">
-            <div className="w-12 h-12 bg-[var(--dc-color-interactive-primary)]/10 rounded-xl flex items-center justify-center mb-6">
-              <svg
-                className="w-6 h-6 text-[var(--dc-color-interactive-primary)]"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path d="M19 9l1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25L19 9zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12l-5.5-2.5zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25L19 15z" />
-              </svg>
-            </div>
-            <h3 className="font-serif text-2xl text-[var(--dc-color-interactive-primary)] mb-4">
-              AI Writing Partner
-            </h3>
-            <p className="text-[var(--dc-color-text-muted)] leading-relaxed">
-              An intelligent assistant that helps you brainstorm and refine your draft while always
-              honoring your unique author voice.
-            </p>
-          </div>
-          <div className="bg-[var(--dc-color-surface-secondary)]/50 p-8 rounded-2xl border border-[var(--dc-color-border-default)]/50 hover:bg-white hover:shadow-xl hover:shadow-[var(--dc-color-interactive-primary)]/5 transition-all duration-500">
-            <div className="w-12 h-12 bg-[var(--dc-color-interactive-primary)]/10 rounded-xl flex items-center justify-center mb-6">
-              <svg
-                className="w-6 h-6 text-[var(--dc-color-interactive-primary)]"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
-                <path d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96zM10 17l-3.5-3.5 1.41-1.41L10 14.17l4.59-4.58L16 11l-6 6z" />
-              </svg>
-            </div>
-            <h3 className="font-serif text-2xl text-[var(--dc-color-interactive-primary)] mb-4">
-              Your Files, Your Control
-            </h3>
-            <p className="text-[var(--dc-color-text-muted)] leading-relaxed">
-              DraftCrane connects directly to your Google Drive, so your manuscript always stays in
-              your own cloud. No data silos, no locking in.
-            </p>
-          </div>
-        </section>
-
-        {/* Call to Action Section */}
-        <section className="mt-24 mb-12 bg-[var(--dc-color-interactive-primary)] text-[var(--dc-color-text-inverse)] rounded-[2.5rem] p-12 md:p-20 text-center relative overflow-hidden">
-          <div className="absolute top-0 right-0 w-64 h-64 bg-white/5 rounded-full blur-3xl -mr-32 -mt-32" />
-          <div className="absolute bottom-0 left-0 w-64 h-64 bg-white/5 rounded-full blur-3xl -ml-32 -mb-32" />
-          <h2 className="font-serif text-4xl md:text-5xl mb-6 relative z-10">
-            Start your writing journey today.
-          </h2>
-          <p className="text-white/80 text-lg mb-10 max-w-xl mx-auto relative z-10">
-            Join hundreds of experts who are turning their knowledge into published works with the
-            calmest writing tool ever made.
-          </p>
-          <Link
-            href="/sign-up"
-            className="inline-flex items-center justify-center bg-[var(--dc-color-surface-primary)] text-[var(--dc-color-interactive-primary)] px-12 py-4 rounded-xl font-bold text-lg hover:bg-[var(--dc-color-surface-tertiary)] transition-colors relative z-10 min-h-[44px]"
-          >
-            Create Your Free Manuscript
-          </Link>
-        </section>
+      <Nav />
+      <main>
+        <Hero />
+        <Problem />
+        <HowItWorks />
+        <WhyDifferent />
+        <WaitlistCTA />
       </main>
-
-      {/* Footer */}
-      <footer className="w-full py-12 px-6 flex flex-col md:flex-row justify-between items-center gap-8 bg-[var(--dc-color-surface-primary)] border-t border-[var(--dc-color-border-default)]">
-        <div className="flex flex-col items-center md:items-start gap-2">
-          <span className="text-lg font-bold text-[var(--dc-color-interactive-primary)] font-serif tracking-tight">
-            DraftCrane
-          </span>
-          <p className="text-[var(--dc-color-text-muted)] text-sm tracking-wide uppercase">
-            © 2024 DraftCrane. Built for authors.
-          </p>
-        </div>
-        <div className="flex gap-8">
-          <Link
-            href="/privacy"
-            className="text-sm tracking-wide uppercase text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-interactive-primary)] transition-colors"
-          >
-            Privacy
-          </Link>
-          <Link
-            href="/terms"
-            className="text-sm tracking-wide uppercase text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-interactive-primary)] transition-colors"
-          >
-            Terms
-          </Link>
-        </div>
-      </footer>
+      <Footer />
     </div>
   )
 }

--- a/web/src/components/marketing/Footer.tsx
+++ b/web/src/components/marketing/Footer.tsx
@@ -1,0 +1,45 @@
+import Link from 'next/link'
+
+export function Footer() {
+  const year = new Date().getFullYear()
+  return (
+    <footer className="bg-[var(--dc-color-surface-primary)] border-t border-[var(--dc-color-border-default)] py-12 px-6">
+      <div className="max-w-6xl mx-auto flex flex-col md:flex-row justify-between items-center gap-6">
+        <div className="flex flex-col items-center md:items-start gap-1">
+          <span className="text-lg font-semibold text-[var(--dc-color-interactive-primary)] font-serif tracking-tight">
+            DraftCrane
+          </span>
+          <p className="text-[var(--dc-color-text-muted)] text-xs tracking-wide uppercase">
+            © {year} DraftCrane. Built for authors.
+          </p>
+        </div>
+        <nav aria-label="Footer" className="flex flex-wrap gap-6">
+          <a
+            href="#waitlist"
+            className="text-sm tracking-wide uppercase text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-interactive-primary)] transition-colors"
+          >
+            Join the list
+          </a>
+          <Link
+            href="/sign-in"
+            className="text-sm tracking-wide uppercase text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-interactive-primary)] transition-colors"
+          >
+            Sign in
+          </Link>
+          <Link
+            href="/privacy"
+            className="text-sm tracking-wide uppercase text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-interactive-primary)] transition-colors"
+          >
+            Privacy
+          </Link>
+          <Link
+            href="/terms"
+            className="text-sm tracking-wide uppercase text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-interactive-primary)] transition-colors"
+          >
+            Terms
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  )
+}

--- a/web/src/components/marketing/Hero.tsx
+++ b/web/src/components/marketing/Hero.tsx
@@ -1,0 +1,37 @@
+export function Hero() {
+  return (
+    <section className="relative pt-32 pb-20 px-6 max-w-6xl mx-auto">
+      <div className="max-w-3xl">
+        <p className="font-sans text-sm uppercase tracking-widest text-[var(--dc-color-interactive-primary)]/70 mb-6">
+          Private alpha — invite only
+        </p>
+        <h1 className="font-serif text-5xl md:text-6xl font-medium tracking-tight text-[var(--dc-color-interactive-primary)] leading-[1.05] mb-8">
+          Write the book you have been putting off.
+        </h1>
+        <p className="font-sans text-lg md:text-xl text-[var(--dc-color-text-secondary)] leading-relaxed mb-10 max-w-2xl">
+          DraftCrane is a writing environment for consultants, coaches, and subject-matter experts
+          who want to turn their expertise into a published nonfiction book. Organized chapter by
+          chapter. AI that reads what you have written before it suggests anything. Saved to your
+          own Google Drive.
+        </p>
+        <a
+          href="#waitlist"
+          className="inline-flex items-center gap-2 px-8 py-4 bg-[var(--dc-color-interactive-primary)] text-[var(--dc-color-text-inverse)] rounded-xl font-semibold text-base hover:shadow-lg transition-all active:scale-[0.98] min-h-[44px]"
+        >
+          Request access
+          <svg
+            className="w-4 h-4"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            aria-hidden="true"
+          >
+            <path d="M5 12h14M13 5l7 7-7 7" />
+          </svg>
+        </a>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/marketing/HowItWorks.tsx
+++ b/web/src/components/marketing/HowItWorks.tsx
@@ -1,0 +1,42 @@
+const steps = [
+  {
+    number: '01',
+    title: 'Connect your Google Drive',
+    body: 'Sign in and choose where your book lives. DraftCrane works with the files you already have.',
+  },
+  {
+    number: '02',
+    title: 'Write chapter by chapter with AI',
+    body: 'Structure your book into chapters. When you need help, the AI reads your chapter before suggesting rewrites — so the result sounds like you.',
+  },
+  {
+    number: '03',
+    title: 'Export a real book file',
+    body: 'One click to generate a formatted PDF or EPUB, saved straight to your Google Drive.',
+  },
+]
+
+export function HowItWorks() {
+  return (
+    <section className="py-20 px-6">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="font-serif text-3xl md:text-4xl font-medium text-[var(--dc-color-interactive-primary)] mb-16 text-center">
+          How it works
+        </h2>
+        <div className="grid gap-12 md:grid-cols-3">
+          {steps.map((step) => (
+            <div key={step.number} className="text-left">
+              <div className="font-serif italic text-3xl text-[var(--dc-color-interactive-primary)]/40 mb-4">
+                {step.number}
+              </div>
+              <h3 className="font-serif text-2xl text-[var(--dc-color-interactive-primary)] mb-3">
+                {step.title}
+              </h3>
+              <p className="text-[var(--dc-color-text-secondary)] leading-relaxed">{step.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/marketing/Nav.tsx
+++ b/web/src/components/marketing/Nav.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link'
+
+export function Nav() {
+  return (
+    <nav className="fixed top-0 left-0 right-0 z-50 bg-[var(--dc-color-surface-primary)]/90 backdrop-blur-sm border-b border-[var(--dc-color-border-default)]/50">
+      <div className="max-w-6xl mx-auto px-6 py-4 flex justify-between items-center">
+        <Link href="/" className="flex items-center gap-2 group">
+          <svg
+            className="w-6 h-6 text-[var(--dc-color-interactive-primary)]"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M21 5c-1.11-.35-2.33-.5-3.5-.5-1.95 0-4.05.4-5.5 1.5-1.45-1.1-3.55-1.5-5.5-1.5S2.45 4.9 1 6v14.65c0 .25.25.5.5.5.1 0 .15-.05.25-.05C3.1 20.45 5.05 20 6.5 20c1.95 0 4.05.4 5.5 1.5 1.35-.85 3.8-1.5 5.5-1.5 1.65 0 3.35.3 4.75 1.05.1.05.15.05.25.05.25 0 .5-.25.5-.5V6c-.6-.45-1.25-.75-2-1zM21 18.5c-1.1-.35-2.3-.5-3.5-.5-1.7 0-4.15.65-5.5 1.5V8c1.35-.85 3.8-1.5 5.5-1.5 1.2 0 2.4.15 3.5.5v11.5z" />
+          </svg>
+          <span className="text-xl font-semibold text-[var(--dc-color-interactive-primary)] font-serif tracking-tight">
+            DraftCrane
+          </span>
+        </Link>
+        <div className="flex items-center gap-6">
+          <a
+            href="#waitlist"
+            className="hidden sm:inline text-sm text-[var(--dc-color-text-muted)] hover:text-[var(--dc-color-interactive-primary)] transition-colors"
+          >
+            Join the list
+          </a>
+          <Link
+            href="/sign-in"
+            className="text-sm font-medium text-[var(--dc-color-interactive-primary)] hover:text-[var(--dc-color-interactive-primary-hover)] transition-colors"
+          >
+            Sign in
+          </Link>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/web/src/components/marketing/Problem.tsx
+++ b/web/src/components/marketing/Problem.tsx
@@ -1,0 +1,92 @@
+export function Problem() {
+  return (
+    <section className="bg-[var(--dc-color-surface-secondary)] py-20 px-6">
+      <div className="max-w-4xl mx-auto">
+        <h2 className="font-serif text-3xl md:text-4xl font-medium text-[var(--dc-color-interactive-primary)] mb-12">
+          You have the expertise. You have the material. You do not have a system.
+        </h2>
+        <div className="grid gap-10 sm:grid-cols-2">
+          <div>
+            <h3 className="font-sans text-xs font-semibold uppercase tracking-widest text-[var(--dc-color-text-placeholder)] mb-5">
+              What you are doing now
+            </h3>
+            <ul className="space-y-4 text-[var(--dc-color-text-secondary)]">
+              <li className="flex gap-3">
+                <span
+                  className="shrink-0 mt-1 text-[var(--dc-color-text-placeholder)]"
+                  aria-hidden="true"
+                >
+                  ×
+                </span>
+                <span>
+                  Forty-seven Google Docs with names like &ldquo;Book Draft v3 FINAL (2).&rdquo;
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span
+                  className="shrink-0 mt-1 text-[var(--dc-color-text-placeholder)]"
+                  aria-hidden="true"
+                >
+                  ×
+                </span>
+                <span>
+                  Switching between ChatGPT and your manuscript, copy-pasting back and forth.
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span
+                  className="shrink-0 mt-1 text-[var(--dc-color-text-placeholder)]"
+                  aria-hidden="true"
+                >
+                  ×
+                </span>
+                <span>
+                  Telling people &ldquo;I am working on a book&rdquo; for the third year running.
+                </span>
+              </li>
+            </ul>
+          </div>
+          <div>
+            <h3 className="font-sans text-xs font-semibold uppercase tracking-widest text-[var(--dc-color-interactive-primary)] mb-5">
+              What changes with DraftCrane
+            </h3>
+            <ul className="space-y-4 text-[var(--dc-color-text-primary)]">
+              <li className="flex gap-3">
+                <span
+                  className="shrink-0 mt-1 text-[var(--dc-color-interactive-primary)]"
+                  aria-hidden="true"
+                >
+                  ✓
+                </span>
+                <span>One place for your entire manuscript, organized by chapter.</span>
+              </li>
+              <li className="flex gap-3">
+                <span
+                  className="shrink-0 mt-1 text-[var(--dc-color-interactive-primary)]"
+                  aria-hidden="true"
+                >
+                  ✓
+                </span>
+                <span>
+                  An AI writing partner that reads your chapter before suggesting changes.
+                </span>
+              </li>
+              <li className="flex gap-3">
+                <span
+                  className="shrink-0 mt-1 text-[var(--dc-color-interactive-primary)]"
+                  aria-hidden="true"
+                >
+                  ✓
+                </span>
+                <span>
+                  Everything saved to your own Google Drive. If DraftCrane disappears, your book
+                  does not.
+                </span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/marketing/WaitlistCTA.tsx
+++ b/web/src/components/marketing/WaitlistCTA.tsx
@@ -1,0 +1,188 @@
+'use client'
+
+import Script from 'next/script'
+import { useEffect, useRef, useState } from 'react'
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        container: HTMLElement,
+        opts: {
+          sitekey: string
+          callback?: (token: string) => void
+          'expired-callback'?: () => void
+          'error-callback'?: () => void
+          theme?: 'light' | 'dark' | 'auto'
+        }
+      ) => string
+      reset: (id?: string) => void
+    }
+  }
+}
+
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? '1x00000000000000000000AA' // dev fallback (always-pass)
+
+type State = 'idle' | 'submitting' | 'success' | 'duplicate' | 'error'
+
+export function WaitlistCTA() {
+  const [email, setEmail] = useState('')
+  const [token, setToken] = useState<string | null>(null)
+  const [state, setState] = useState<State>('idle')
+  const [error, setError] = useState<string | null>(null)
+  const turnstileContainer = useRef<HTMLDivElement | null>(null)
+  const turnstileWidgetId = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!turnstileContainer.current || turnstileWidgetId.current) return
+    const tryRender = () => {
+      if (window.turnstile && turnstileContainer.current && !turnstileWidgetId.current) {
+        turnstileWidgetId.current = window.turnstile.render(turnstileContainer.current, {
+          sitekey: TURNSTILE_SITE_KEY,
+          theme: 'light',
+          callback: (t: string) => setToken(t),
+          'expired-callback': () => setToken(null),
+          'error-callback': () => setToken(null),
+        })
+      }
+    }
+    tryRender()
+    const interval = window.setInterval(() => {
+      if (turnstileWidgetId.current) {
+        window.clearInterval(interval)
+      } else {
+        tryRender()
+      }
+    }, 250)
+    return () => window.clearInterval(interval)
+  }, [])
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (state === 'submitting') return
+    setState('submitting')
+    setError(null)
+
+    if (!token) {
+      setState('error')
+      setError('Please complete the verification before submitting.')
+      return
+    }
+
+    try {
+      const params = new URLSearchParams(window.location.search)
+      const res = await fetch('/api/waitlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          email,
+          turnstileToken: token,
+          utm_source: params.get('utm_source') ?? undefined,
+          utm_medium: params.get('utm_medium') ?? undefined,
+          utm_campaign: params.get('utm_campaign') ?? undefined,
+          utm_content: params.get('utm_content') ?? undefined,
+          referrer: document.referrer || undefined,
+          landing_path: window.location.pathname,
+        }),
+      })
+      if (!res.ok) {
+        const data = (await res.json().catch(() => ({}))) as { error?: string; code?: string }
+        setState('error')
+        setError(data.error ?? 'Something went wrong. Please try again.')
+        if (window.turnstile && turnstileWidgetId.current) {
+          window.turnstile.reset(turnstileWidgetId.current)
+        }
+        setToken(null)
+        return
+      }
+      const data = (await res.json()) as { status?: string }
+      setState(data.status === 'already_signed_up' ? 'duplicate' : 'success')
+    } catch {
+      setState('error')
+      setError('Network error. Please try again.')
+    }
+  }
+
+  return (
+    <section
+      id="waitlist"
+      className="py-20 px-6 bg-[var(--dc-color-interactive-primary)] text-[var(--dc-color-text-inverse)] relative overflow-hidden"
+    >
+      <Script
+        src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+        strategy="lazyOnload"
+        async
+        defer
+      />
+      <div
+        className="absolute top-0 right-0 w-96 h-96 bg-white/5 rounded-full blur-3xl -mr-32 -mt-32"
+        aria-hidden
+      />
+      <div
+        className="absolute bottom-0 left-0 w-96 h-96 bg-white/5 rounded-full blur-3xl -ml-32 -mb-32"
+        aria-hidden
+      />
+      <div className="relative max-w-2xl mx-auto text-center">
+        <h2 className="font-serif text-3xl md:text-4xl font-medium mb-5">
+          Join the early-access list.
+        </h2>
+        <p className="text-white/80 text-lg mb-10 max-w-xl mx-auto leading-relaxed">
+          DraftCrane is in private alpha. Drop your email to hold a place. We invite writers in
+          small batches as we build.
+        </p>
+
+        {state === 'success' ? (
+          <div className="bg-white/10 border border-white/20 rounded-2xl p-8 text-left max-w-md mx-auto">
+            <p className="font-serif text-2xl mb-3">You are on the list.</p>
+            <p className="text-white/80 text-base leading-relaxed">
+              Watch your inbox for a confirmation. We will be in touch when your spot opens.
+            </p>
+          </div>
+        ) : state === 'duplicate' ? (
+          <div className="bg-white/10 border border-white/20 rounded-2xl p-8 text-left max-w-md mx-auto">
+            <p className="font-serif text-2xl mb-3">You are already on the list.</p>
+            <p className="text-white/80 text-base leading-relaxed">
+              No need to sign up again — we have you. Watch your inbox.
+            </p>
+          </div>
+        ) : (
+          <form
+            onSubmit={handleSubmit}
+            className="flex flex-col items-center gap-4 max-w-md mx-auto"
+          >
+            <label htmlFor="waitlist-email" className="sr-only">
+              Email address
+            </label>
+            <input
+              id="waitlist-email"
+              type="email"
+              required
+              autoComplete="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              className="w-full px-5 py-4 rounded-xl bg-white text-[var(--dc-color-text-primary)] placeholder:text-[var(--dc-color-text-placeholder)] focus:outline-none focus:ring-2 focus:ring-white/40 min-h-[48px]"
+              disabled={state === 'submitting'}
+            />
+
+            <div ref={turnstileContainer} className="min-h-[65px]" />
+
+            <button
+              type="submit"
+              disabled={state === 'submitting' || !token}
+              className="w-full sm:w-auto px-10 py-4 bg-white text-[var(--dc-color-interactive-primary)] rounded-xl font-bold text-base hover:bg-[var(--dc-color-surface-tertiary)] transition-colors active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed min-h-[48px]"
+            >
+              {state === 'submitting' ? 'Joining...' : 'Request access'}
+            </button>
+
+            {error && (
+              <p className="text-white/90 text-sm bg-white/10 border border-white/20 rounded-lg px-4 py-2">
+                {error}
+              </p>
+            )}
+          </form>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/marketing/WhyDifferent.tsx
+++ b/web/src/components/marketing/WhyDifferent.tsx
@@ -1,0 +1,39 @@
+const differentiators = [
+  {
+    title: 'Your files stay in your Google Drive',
+    body: 'Your manuscript is not locked in another app. Every chapter, every draft lives in your own Drive folder. You own your book.',
+  },
+  {
+    title: 'AI that reads your chapter first',
+    body: 'Other tools give you generic AI. DraftCrane reads the chapter you are working on before suggesting a rewrite. The result sounds like you, not a chatbot.',
+  },
+  {
+    title: 'Built for your iPad',
+    body: 'DraftCrane is a browser app designed for iPad Safari. Write on the couch, at a coffee shop, or between client calls. No desktop required.',
+  },
+]
+
+export function WhyDifferent() {
+  return (
+    <section className="bg-[var(--dc-color-surface-secondary)] py-20 px-6">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="font-serif text-3xl md:text-4xl font-medium text-[var(--dc-color-interactive-primary)] mb-16 text-center">
+          Why it is different
+        </h2>
+        <div className="grid gap-8 md:grid-cols-3">
+          {differentiators.map((item) => (
+            <div
+              key={item.title}
+              className="bg-[var(--dc-color-surface-primary)] p-8 rounded-2xl border border-[var(--dc-color-border-default)]/50"
+            >
+              <h3 className="font-serif text-xl text-[var(--dc-color-interactive-primary)] mb-3">
+                {item.title}
+              </h3>
+              <p className="text-[var(--dc-color-text-secondary)] leading-relaxed">{item.body}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -12,6 +12,7 @@ const isPublicRoute = createRouteMatcher([
   '/privacy',
   '/terms',
   '/spike(.*)',
+  '/api/waitlist',
 ])
 
 /**

--- a/workers/dc-api/migrations/0029_create_waitlist_signups.sql
+++ b/workers/dc-api/migrations/0029_create_waitlist_signups.sql
@@ -1,0 +1,28 @@
+-- Waitlist signups for invite-only alpha access.
+-- Public POST /waitlist endpoint accepts an email + Turnstile token and stores a signup.
+-- Captain reviews pending rows, promotes to Clerk allowlist, sends invite manually.
+
+CREATE TABLE IF NOT EXISTS waitlist_signups (
+  id TEXT PRIMARY KEY,
+  email TEXT NOT NULL,
+  signed_up_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+  confirmed_at TEXT,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'invited', 'closed', 'unsubscribed')),
+  utm_source TEXT,
+  utm_medium TEXT,
+  utm_campaign TEXT,
+  utm_content TEXT,
+  referrer TEXT,
+  landing_path TEXT,
+  ip_country TEXT,
+  user_agent TEXT,
+  unsubscribe_token TEXT NOT NULL,
+  notes TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_waitlist_signups_email
+  ON waitlist_signups(email);
+
+CREATE INDEX IF NOT EXISTS idx_waitlist_signups_status
+  ON waitlist_signups(status, signed_up_at DESC);

--- a/workers/dc-api/src/index.ts
+++ b/workers/dc-api/src/index.ts
@@ -14,6 +14,7 @@ import { sources } from './routes/sources.js'
 import { research } from './routes/research.js'
 import { aiInstructions } from './routes/ai-instructions.js'
 import { feedback } from './routes/feedback.js'
+import { waitlist } from './routes/waitlist.js'
 import type { ErrorCode } from './types/index.js'
 
 const app = new Hono<{ Bindings: Env }>()
@@ -91,9 +92,11 @@ app.use('*', requestLogger)
 // - /health: no auth required
 // - /auth/webhook: Svix signature verification (not JWT)
 // - /drive/callback: OAuth CSRF state token (not JWT)
+// - /waitlist: public POST endpoint, anti-abuse via Cloudflare Turnstile
 app.route('/health', health)
 app.route('/auth', auth)
 app.route('/drive', driveCallback)
+app.route('/waitlist', waitlist)
 
 // --- Global authentication barrier ---
 // All routes below this line require a valid Clerk JWT.

--- a/workers/dc-api/src/routes/waitlist.ts
+++ b/workers/dc-api/src/routes/waitlist.ts
@@ -1,0 +1,236 @@
+import { Hono } from 'hono'
+import { ulid } from 'ulidx'
+import type { Env } from '../types/index.js'
+
+/**
+ * Public waitlist signup endpoint.
+ *
+ * POST /waitlist
+ *   Body: { email, turnstileToken, utm_source?, utm_medium?, utm_campaign?,
+ *           utm_content?, referrer?, landing_path? }
+ *   Returns: 200 { ok: true, status: "pending" | "already_signed_up" }
+ *
+ * Mounted BEFORE the global auth barrier (this is a public endpoint).
+ * Anti-abuse via Cloudflare Turnstile token verification.
+ * Idempotent: dup email returns 200 with status="already_signed_up".
+ *
+ * On signup:
+ *   - Insert row in waitlist_signups (UNIQUE on email)
+ *   - Send Resend confirmation to user (best-effort)
+ *   - Send Resend notification to Captain (best-effort)
+ *   - Emit structured console.log for observability
+ */
+const waitlist = new Hono<{ Bindings: Env }>()
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const VENTURE_CODE = 'dc'
+const VENTURE_NAME = 'DraftCrane'
+const DEFAULT_FROM = 'DraftCrane <hello@mail.draftcrane.app>'
+const DEFAULT_NOTIFY = 'smdurgan@venturecrane.com'
+
+interface SignupBody {
+  email?: string
+  turnstileToken?: string
+  utm_source?: string
+  utm_medium?: string
+  utm_campaign?: string
+  utm_content?: string
+  referrer?: string
+  landing_path?: string
+}
+
+waitlist.post('/', async (c) => {
+  const body = (await c.req.json().catch(() => ({}))) as SignupBody
+
+  const email = body.email?.trim().toLowerCase()
+  if (!email || !EMAIL_RE.test(email) || email.length > 254) {
+    return c.json({ error: 'Invalid email', code: 'INVALID_EMAIL' }, 400)
+  }
+
+  const turnstileToken = body.turnstileToken
+  if (!turnstileToken) {
+    return c.json({ error: 'Missing verification', code: 'MISSING_TURNSTILE' }, 400)
+  }
+
+  const remoteIp = c.req.header('cf-connecting-ip') ?? undefined
+  const turnstileOk = await verifyTurnstile(c.env.TURNSTILE_SECRET_KEY, turnstileToken, remoteIp)
+  if (!turnstileOk) {
+    return c.json({ error: 'Verification failed', code: 'TURNSTILE_FAILED' }, 400)
+  }
+
+  const id = ulid()
+  const unsubscribeToken = crypto.randomUUID()
+  const ipCountry = c.req.header('cf-ipcountry') ?? null
+  const userAgent = c.req.header('user-agent')?.slice(0, 500) ?? null
+
+  const result = await c.env.DB.prepare(
+    `INSERT INTO waitlist_signups
+      (id, email, unsubscribe_token, utm_source, utm_medium, utm_campaign,
+       utm_content, referrer, landing_path, ip_country, user_agent)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(email) DO NOTHING`
+  )
+    .bind(
+      id,
+      email,
+      unsubscribeToken,
+      body.utm_source ?? null,
+      body.utm_medium ?? null,
+      body.utm_campaign ?? null,
+      body.utm_content ?? null,
+      body.referrer ?? null,
+      body.landing_path ?? null,
+      ipCountry,
+      userAgent
+    )
+    .run()
+
+  const isNewSignup = (result.meta?.changes ?? 0) > 0
+
+  console.log(
+    JSON.stringify({
+      level: 'info',
+      event: 'waitlist_signup',
+      venture: VENTURE_CODE,
+      email_hash: await hashEmail(email),
+      status: isNewSignup ? 'new' : 'duplicate',
+      utm_source: body.utm_source ?? null,
+      ip_country: ipCountry,
+      timestamp: new Date().toISOString(),
+    })
+  )
+
+  if (isNewSignup) {
+    const from = c.env.RESEND_FROM_EMAIL ?? DEFAULT_FROM
+    const notify = c.env.WAITLIST_NOTIFY_EMAIL ?? DEFAULT_NOTIFY
+    await Promise.allSettled([
+      sendResend(c.env.RESEND_API_KEY, {
+        from,
+        to: email,
+        subject: 'You are on the DraftCrane list',
+        text: confirmationEmailText(),
+        html: confirmationEmailHtml(),
+      }),
+      sendResend(c.env.RESEND_API_KEY, {
+        from,
+        to: notify,
+        subject: `[${VENTURE_CODE}] new waitlist signup: ${email}`,
+        text: notificationEmailText(email, body, ipCountry),
+      }),
+    ]).then((results) => {
+      results.forEach((r, i) => {
+        if (r.status === 'rejected') {
+          console.error(
+            JSON.stringify({
+              level: 'error',
+              event: 'waitlist_email_failed',
+              venture: VENTURE_CODE,
+              recipient_kind: i === 0 ? 'user' : 'notify',
+              error: String(r.reason),
+            })
+          )
+        }
+      })
+    })
+  }
+
+  return c.json({
+    ok: true,
+    status: isNewSignup ? 'pending' : 'already_signed_up',
+  })
+})
+
+async function verifyTurnstile(secret: string, token: string, remoteIp?: string): Promise<boolean> {
+  if (!secret) return false
+  const form = new FormData()
+  form.append('secret', secret)
+  form.append('response', token)
+  if (remoteIp) form.append('remoteip', remoteIp)
+
+  try {
+    const res = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      body: form,
+    })
+    const data = (await res.json()) as { success?: boolean }
+    return Boolean(data.success)
+  } catch {
+    return false
+  }
+}
+
+interface ResendMessage {
+  from: string
+  to: string
+  subject: string
+  text: string
+  html?: string
+}
+
+async function sendResend(apiKey: string, msg: ResendMessage): Promise<void> {
+  if (!apiKey) throw new Error('RESEND_API_KEY not configured')
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(msg),
+  })
+  if (!res.ok) {
+    const errBody = await res.text().catch(() => '')
+    throw new Error(`Resend ${res.status}: ${errBody.slice(0, 200)}`)
+  }
+}
+
+async function hashEmail(email: string): Promise<string> {
+  const enc = new TextEncoder().encode(email)
+  const buf = await crypto.subtle.digest('SHA-256', enc)
+  return Array.from(new Uint8Array(buf))
+    .slice(0, 8)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+function confirmationEmailText(): string {
+  return `Welcome to ${VENTURE_NAME}.
+
+You are on the early-access list for ${VENTURE_NAME} - a writing environment for consultants, coaches, and subject-matter experts who want to turn their expertise into a published nonfiction book.
+
+We are in private alpha right now, building deliberately, inviting writers in small batches. When your spot opens, you will get an invite to sign in.
+
+In the meantime: keep writing.
+
+The ${VENTURE_NAME} team
+https://draftcrane.app`
+}
+
+function confirmationEmailHtml(): string {
+  return `<!doctype html>
+<html>
+<body style="font-family:Georgia,'Times New Roman',serif;max-width:560px;margin:40px auto;padding:0 20px;color:#111827;line-height:1.6">
+  <h1 style="font-size:24px;font-weight:500;color:#2563eb;margin:0 0 24px">Welcome to ${VENTURE_NAME}.</h1>
+  <p>You are on the early-access list for <strong>${VENTURE_NAME}</strong> - a writing environment for consultants, coaches, and subject-matter experts who want to turn their expertise into a published nonfiction book.</p>
+  <p>We are in private alpha right now, building deliberately, inviting writers in small batches. When your spot opens, you will get an invite to sign in.</p>
+  <p>In the meantime: keep writing.</p>
+  <p style="margin-top:32px;color:#6b7280;font-size:14px;font-family:system-ui,sans-serif">The ${VENTURE_NAME} team<br><a href="https://draftcrane.app" style="color:#2563eb;text-decoration:none">draftcrane.app</a></p>
+</body>
+</html>`
+}
+
+function notificationEmailText(email: string, body: SignupBody, ipCountry: string | null): string {
+  const lines = [
+    `New waitlist signup for ${VENTURE_NAME}.`,
+    ``,
+    `Email: ${email}`,
+    `Country: ${ipCountry ?? 'unknown'}`,
+    `Source: ${body.utm_source ?? body.referrer ?? 'direct'}`,
+    `Landing: ${body.landing_path ?? '/'}`,
+    ``,
+    `Promote to allowlist: https://dashboard.clerk.com (DraftCrane app > Settings > Restrictions > Allowlist)`,
+  ]
+  return lines.join('\n')
+}
+
+export { waitlist }

--- a/workers/dc-api/src/types/env.ts
+++ b/workers/dc-api/src/types/env.ts
@@ -31,4 +31,10 @@ export interface Env {
   API_BASE_URL?: string // Base URL for API (used in export download URLs)
   ENCRYPTION_KEY: string
   ALLOW_TEST_AUTH?: string
+
+  // Waitlist (public POST /waitlist endpoint)
+  RESEND_API_KEY: string // Resend transactional email API key
+  RESEND_FROM_EMAIL?: string // Sender, default: "DraftCrane <hello@mail.draftcrane.app>"
+  WAITLIST_NOTIFY_EMAIL?: string // Where to notify on signup, default: smdurgan@venturecrane.com
+  TURNSTILE_SECRET_KEY: string // Cloudflare Turnstile server-side verification secret
 }

--- a/workers/dc-api/wrangler.toml
+++ b/workers/dc-api/wrangler.toml
@@ -34,6 +34,8 @@ id = "15db632cefe04003a94f1e6e7460c858"
 # AI_API_KEY            - AI rewrite API key (frontier tier)
 # CF_API_TOKEN           - Cloudflare Browser Rendering (PDF export)
 # ENCRYPTION_KEY         - AES-256-GCM token encryption
+# RESEND_API_KEY         - Resend transactional email (waitlist confirmations + Captain notify)
+# TURNSTILE_SECRET_KEY   - Cloudflare Turnstile server-side verification
 
 # Workers AI
 [ai]


### PR DESCRIPTION
## Summary

- Rebuilds the landing page as a six-section private-alpha template (Nav, Hero, Problem, HowItWorks, WhyDifferent, WaitlistCTA, Footer) with brand-correct DC tokens (blue/violet, Lora serif, Geist UI).
- Adds a public POST `/waitlist` endpoint to dc-api: Cloudflare Turnstile verification, D1 dedup via unique email index, Resend confirmation to user + Captain notification, structured signup logs.
- Next.js `/api/waitlist` is a thin proxy — Worker side owns persistence and email.
- Existing Clerk middleware preserved; `/api/waitlist` added to public matcher; `(protected)` route group untouched (flat dashboard URLs intact).
- Operator setup steps in `docs/runbooks/waitlist-launch.md` (Clerk Pro upgrade for Restricted Mode + Allowlist, Resend `mail.draftcrane.app` domain verification, Turnstile widget, secrets, migration).

This is **Phase 1** of a four-venture initiative — DC ships first as the proof of template; KE, DFG, SC follow with the same pattern.

## Files

**Worker (dc-api)**
- `workers/dc-api/migrations/0029_create_waitlist_signups.sql` — table + unique email index + status index
- `workers/dc-api/src/routes/waitlist.ts` — Hono route, inline Turnstile + Resend helpers
- `workers/dc-api/src/index.ts` — mount `/waitlist` before global auth barrier
- `workers/dc-api/src/types/env.ts` — `RESEND_API_KEY`, `TURNSTILE_SECRET_KEY`, optional `RESEND_FROM_EMAIL`, `WAITLIST_NOTIFY_EMAIL`
- `workers/dc-api/wrangler.toml` — secret comments updated

**Web**
- `web/src/components/marketing/{Nav,Hero,Problem,HowItWorks,WhyDifferent,WaitlistCTA,Footer}.tsx`
- `web/src/app/page.tsx` — composes the new template, OG/Twitter metadata
- `web/src/app/api/waitlist/route.ts` — proxy to `api.draftcrane.app/waitlist`
- `web/src/middleware.ts` — `/api/waitlist` added to public matcher

**Docs**
- `docs/runbooks/waitlist-launch.md` — Captain manual setup checklist

## Test plan

Pre-merge (already green locally):
- [x] `npm run verify` — typecheck + format + lint + 535 tests pass

Post-merge (Captain runs):
- [ ] Apply D1 migration: `cd workers/dc-api && npm run db:migrate:remote`
- [ ] Set `RESEND_API_KEY`, `TURNSTILE_SECRET_KEY` worker secrets
- [ ] Add `NEXT_PUBLIC_TURNSTILE_SITE_KEY` Vercel env
- [ ] Resend domain verify `mail.draftcrane.app` (SPF/DKIM/DMARC)
- [ ] Clerk Pro upgrade + Restricted Mode + allowlist seed
- [ ] Submit waitlist with test email → row in D1, confirmation email lands, Captain notification arrives
- [ ] Sign in with allowlisted email → magic link → dashboard
- [ ] Sign in with non-allowlisted email → blocked
- [ ] Lighthouse mobile perf > 80, OG tags render in Slack/iMessage preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)