### PR TITLE
fix(sync-docs): correct repo glob (draftcrane → venturecrane)

### DIFF
--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -113,12 +113,12 @@ else
         *smd-ventures/smd-console*)
           SCOPE="smd"
           ;;
-        *draftcrane/dc-console*)
+        *venturecrane/dc-console*)
           SCOPE="dc"
           ;;
         *)
           echo -e "${RED}Error: Cannot determine venture from repo: $GITHUB_REPOSITORY${NC}"
-          echo "Supported repos: venturecrane/crane-console, siliconcrane/sc-console, durganfieldguide/dfg-console, smdurgan/smd-console"
+          echo "Supported repos: venturecrane/crane-console, siliconcrane/sc-console, durganfieldguide/dfg-console, smd-ventures/smd-console, venturecrane/dc-console"
           exit 1
           ;;
       esac


### PR DESCRIPTION
## Summary

- The `Sync Docs to Context Worker` workflow has been failing on every push to `docs/process/*` for **15 days**.
- Root cause: `scripts/upload-doc-to-context-worker.sh` checks `*draftcrane/dc-console*` in the repo→venture case, but the repo lives at `venturecrane/dc-console`.
- Every doc sync therefore hit the default `*)` branch and exited 1.

## Fix

- Replace `*draftcrane/dc-console*` → `*venturecrane/dc-console*` in the case statement.
- Correct the supported-repos error message (was missing dc-console entirely; also said `smdurgan/smd-console` while the case glob is `smd-ventures/smd-console`).

## Verification

Last failed run: [#24314008554](https://github.com/venturecrane/dc-console/actions/runs/24314008554) — error message verbatim:
> `Error: Cannot determine venture from repo: venturecrane/dc-console`

After this PR, the next push touching `docs/process/*.md` will exercise the workflow on the correct branch.

## Test plan

- [ ] Sync Docs to Context Worker workflow passes on the next push to main with a `docs/process/*.md` change
- [ ] Manual `workflow_dispatch` trigger from main succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)