### PR TITLE
chore(dependabot): add NPM ecosystems with grouping for /web and /workers/dc-api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,39 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+
+  # Frontend (Next.js, Tiptap, Clerk)
+  - package-ecosystem: 'npm'
+    directory: '/web'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      web-patch:
+        update-types:
+          - 'patch'
+      web-minor-dev:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+    ignore:
+      # postcss is pinned transitively by next.js. Until next bumps its
+      # bundled postcss past 8.4.31, security_update_not_possible fires
+      # on every retry. Re-evaluate when next.js ships a postcss bump.
+      - dependency-name: 'postcss'
+        versions: ['8.4.x']
+
+  # API worker (Hono, Cloudflare Workers)
+  - package-ecosystem: 'npm'
+    directory: '/workers/dc-api'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    groups:
+      api-patch:
+        update-types:
+          - 'patch'
+      api-minor-dev:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'


### PR DESCRIPTION
## Summary

- The repo had Dependabot configured for `docker` and `github-actions` only — no NPM ecosystems.
- Adds explicit `npm` ecosystems for `/web` and `/workers/dc-api` with **patch-level grouping** to collapse the 6–8 PR fanout per release window into one grouped PR per workspace.
- Adds an `ignore` rule for `postcss 8.4.x` in `/web` — `next.js` pins `postcss@8.4.31` transitively, so `security_update_not_possible` fires on every Dependabot retry. The rule silences this noise; remove once Next.js ships a postcss bump.

## Why now

Triage of 768 unresolved CI/CD notifications surfaced two patterns: the postcss recurring-update failures (security_update_not_possible) and the lack of grouping causing 6–8 separate PRs per release. This addresses both.

## Config details

- \`open-pull-requests-limit: 5\` per workspace bounds the queue.
- Two groups per workspace: \`*-patch\` (all patch bumps) and \`*-minor-dev\` (dev-dep minors only — tooling can't reach prod).
- Runtime-dep minor and major bumps still produce individual PRs (require explicit review).

## Test plan

- [x] \`js-yaml\` parse passes (no syntax errors)
- [ ] After merge, next Dependabot run produces a grouped patch PR per workspace instead of N individual PRs
- [ ] postcss 8.4.x security_update_not_possible failures stop appearing in the Dependabot Updater workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)