### PR TITLE
fix(sync-docs): match current venturecrane org in upload-doc script

### DIFF
--- a/scripts/upload-doc-to-context-worker.sh
+++ b/scripts/upload-doc-to-context-worker.sh
@@ -101,24 +101,30 @@ else
     # Venture-specific: determine from repo
     if [ -n "$GITHUB_REPOSITORY" ]; then
       case "$GITHUB_REPOSITORY" in
-        *venturecrane/crane-console*)
+        *venturecrane/crane-console*|*crane-console*)
           SCOPE="vc"
           ;;
-        *siliconcrane/sc-console*)
+        *venturecrane/sc-console*|*sc-console*)
           SCOPE="sc"
           ;;
-        *durganfieldguide/dfg-console*)
+        *venturecrane/dfg-console*|*dfg-console*)
           SCOPE="dfg"
           ;;
-        *smd-ventures/smd-console*)
+        *venturecrane/ke-console*|*ke-console*)
+          SCOPE="ke"
+          ;;
+        *venturecrane/smd-console*|*smd-console*)
           SCOPE="smd"
           ;;
-        *draftcrane/dc-console*)
+        *venturecrane/dc-console*|*dc-console*)
           SCOPE="dc"
+          ;;
+        *venturecrane/ss-console*|*ss-console*)
+          SCOPE="ss"
           ;;
         *)
           echo -e "${RED}Error: Cannot determine venture from repo: $GITHUB_REPOSITORY${NC}"
-          echo "Supported repos: venturecrane/crane-console, siliconcrane/sc-console, durganfieldguide/dfg-console, smdurgan/smd-console"
+          echo "Supported repos: venturecrane/{crane,sc,dfg,ke,smd,dc,ss}-console"
           exit 1
           ;;
       esac


### PR DESCRIPTION
Fixes the 15-day-old `Sync Docs to Context Worker` failure on main. Same root cause as venturecrane/dfg-console#325 and venturecrane/ke-console#235 — stale org prefixes in the case statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)