### PR TITLE
fix(ci): sparse-checkout ui-drift-audit script (mirror ss-console fix)

### DIFF
--- a/.github/workflows/ui-drift-audit.yml
+++ b/.github/workflows/ui-drift-audit.yml
@@ -59,6 +59,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Sync canonical skills from crane-console
+        # The audit script lives in crane-console/.agents/skills/ui-drift-audit/.
+        # Locally, the launcher (crane-console/packages/crane-mcp/src/cli/launch-lib.ts:1185
+        # syncVentureSkills) mirrors it on every `crane <venture>` launch. CI has no
+        # launcher, so we sparse-clone canon and stage the script into the expected path.
+        uses: actions/checkout@v4
+        with:
+          repository: venturecrane/crane-console
+          sparse-checkout: |
+            .agents/skills/ui-drift-audit
+          sparse-checkout-cone-mode: false
+          path: .crane-canon
+
+      - name: Stage ui-drift-audit script
+        run: |
+          mkdir -p .agents/skills
+          cp -R .crane-canon/.agents/skills/ui-drift-audit .agents/skills/ui-drift-audit
+          rm -rf .crane-canon
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary

- The ui-drift-audit workflow has been failing on every PR since the `.agents/skills/` gitignore in PR #540 (2026-05-06).
- Root cause: `python3 .agents/skills/ui-drift-audit/audit.py` runs against a CI checkout that no longer contains the script (gitignored launcher-mirrored copy). `audit.json` is never generated; the "Build PR comment body" step then fails opening it.
- Fix is the same pattern ss-console already uses: sparse-checkout the canon `ui-drift-audit/` directory from crane-console at workflow time and stage it into `.agents/skills/`.

## Linked issue

None — surfaced during a cross-repo audit reconciliation; not tracked as an issue.

## Changes

- `.github/workflows/ui-drift-audit.yml`: insert two steps (`Sync canonical skills from crane-console` + `Stage ui-drift-audit script`) between the existing `Checkout` and `Set up Python` steps. Lifted verbatim from `venturecrane/ss-console/.github/workflows/ui-drift-audit.yml` where this fix has been live and green.

## Test Plan

- [x] Workflow YAML structure validated (sed/diff against ss-console's working version)
- [x] Diff is purely additive: only step names `Sync canonical skills from crane-console` and `Stage ui-drift-audit script` introduced
- [ ] CI green on this PR (will confirm after push)

## Feature Impact

**Feature impact:** None. CI infrastructure fix.

## Deployment Notes

None. Workflow change takes effect on next PR after merge.

## Reference

ss-console workflow at the same path, which already has this pattern: `https://github.com/venturecrane/ss-console/blob/main/.github/workflows/ui-drift-audit.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)