### PR TITLE
docs(agents): add AGENTS.md + surface coding-standards.md in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md
+
+Instructions for AI agents (Codex CLI) working in this repository.
+
+## Repository
+
+venturecrane/dc-console - DurganCo operator console.
+
+## Automatic Session Start
+
+When you begin a session, immediately do these in order before any work:
+
+1. Call `crane_preflight` (no arguments) - validates environment.
+2. Call `crane_sos` with `venture: "dc"` - initializes session, shows P0 issues, cadence briefing, active sessions.
+3. Read `CLAUDE.md` at the repo root - canonical Instruction Modules table (coding standards, guardrails, secrets, tooling, PR workflow, etc.).
+4. Fetch `crane_doc('global', 'coding-standards.md')` before editing any TypeScript or JavaScript.
+
+Do not start any work until preflight + sos succeed and CLAUDE.md is loaded. If preflight fails, show the error and stop.
+
+## Coding Standards
+
+All code edits MUST follow the Venture Crane portfolio coding standard, fetched via `crane_doc('global', 'coding-standards.md')`. Key directives that apply on every change:
+
+- Parse external inputs with Zod; never `as` cast at trust boundaries.
+- No floating Promises; explicitly `await` or attach a `.catch`.
+- No module-level state in Cloudflare Workers (per-isolate state leaks across requests).
+- File/function ceilings: 500 lines/file, 75 lines/function, complexity 15, depth 4, params 5.
+- No default exports outside framework-required positions (Astro pages, Next.js App Router files, Workers entry).
+- Fetch the global doc for the full 12 directives with good/bad examples and per-stack notes.
+
+Mechanical enforcement status: dc-console's `eslint.config.js` does NOT yet enforce the portfolio rule set; lint catches only the basic recommended rules. Self-discipline is required until the per-venture eslint adoption initiative reaches dc-console (audit doc: `docs/research/venture-eslint-adoption-audit-2026-05-06.md` in venturecrane/crane-console). The portfolio rules are nonetheless mandatory; treat the global doc as the source of truth.
+
+## Enterprise Rules
+
+- All changes go through PRs. Never push directly to main.
+- Work only on issues assigned to the current venture context (dc).
+- If you detect scope drift (working on a different repo than session context), stop and verify with the user.
+- All GitHub issues created this session must target `venturecrane/dc-console`.
+- When encountering errors, fix root causes - not symptoms.
+
+## Codex Environment
+
+Codex strips `KEY`/`SECRET`/`TOKEN` vars from all subprocess environments (shell commands and MCP servers). The `crane` launcher configures `shell_environment_policy.ignore_default_excludes` and MCP `env_vars` to whitelist the vars agents need.
+
+## Reference
+
+CLAUDE.md (loaded at session start per step 3 above) contains the full Instruction Modules table covering environment variables, QA grades, secrets management, git authority, and per-domain runbooks. Fetch any module on demand via `crane_doc('global', '<module>')`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -154,13 +154,14 @@ Session start uses MCP tools (see Session Start above). Additional workflow comm
 Detailed domain instructions stored as on-demand documents.
 Fetch the relevant module when working in that domain.
 
-| Module              | Key Rule (always applies)                                                | Fetch for details                          |
-| ------------------- | ------------------------------------------------------------------------ | ------------------------------------------ |
-| `secrets.md`        | Verify secret VALUES, not just key existence                             | Infisical, vault, API keys, GitHub App     |
-| `content-policy.md` | Never auto-save to VCMS; agents ARE the voice                            | VCMS tags, storage rules, editorial, style |
-| `team-workflow.md`  | All changes through PRs; never push to main                              | Full workflow, escalation triggers         |
-| `fleet-ops.md`      | Bootstrap phases IN ORDER: Tailscale > CLI > bootstrap > optimize > mesh | SSH, machines, Tailscale, macOS            |
-| `pr-workflow.md`    | Push branch, `gh pr create` - never skip the PR                          | Branch naming, commit format, PR template  |
+| Module                | Key Rule (always applies)                                                                                                               | Fetch for details                                                         |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `coding-standards.md` | Parse external inputs (never cast); no floating Promises; no module-level state in Workers; 500/75/15 file/function/complexity ceilings | Portable TypeScript directives, agent-context arithmetic, per-stack notes |
+| `secrets.md`          | Verify secret VALUES, not just key existence                                                                                            | Infisical, vault, API keys, GitHub App                                    |
+| `content-policy.md`   | Never auto-save to VCMS; agents ARE the voice                                                                                           | VCMS tags, storage rules, editorial, style                                |
+| `team-workflow.md`    | All changes through PRs; never push to main                                                                                             | Full workflow, escalation triggers                                        |
+| `fleet-ops.md`        | Bootstrap phases IN ORDER: Tailscale > CLI > bootstrap > optimize > mesh                                                                | SSH, machines, Tailscale, macOS                                           |
+| `pr-workflow.md`      | Push branch, `gh pr create` - never skip the PR                                                                                         | Branch naming, commit format, PR template                                 |
 
 Fetch with: `crane_doc('global', '<module>')`
 


### PR DESCRIPTION
## Summary

Closes the documentation gap around the Venture Crane portfolio coding standard. dc-console's `eslint.config.js` does not yet enforce the standard, so agent self-discipline (via doc references) is the current enforcement path. This PR adds AGENTS.md and surfaces `coding-standards.md` in CLAUDE.md.

Companion to venturecrane/crane-console#884.

## Changes

- **New AGENTS.md** — Codex CLI's instruction file.
- **CLAUDE.md Instruction Modules row** — adds `coding-standards.md`.

## Linked issue

None — initiative-level rollout.

## Test plan

- [x] `npx prettier --check AGENTS.md CLAUDE.md` passes
- [x] `npm run lint` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)